### PR TITLE
feat: add AlphaDB platform health path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 POSTGRES_USER=alphadb
 POSTGRES_PASSWORD=alphadb
 POSTGRES_DB=alphadb
-DATABASE_URL=postgresql://alphadb:alphadb@postgres:5432/alphadb
+DATABASE_URL=postgresql://alphadb:alphadb@localhost:55433/alphadb
+ALPHADB_POSTGRES_HOST=localhost
 ALPHADB_POSTGRES_PORT=55433
 ALPHADB_STREAMLIT_PORT=8501

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository has been reset intentionally. Prior AlphaDB history is not part 
 Open the repository in a Dev Container, or run locally with Python 3.12+:
 
 ```bash
-python -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install -e ".[dev]"
 pytest
@@ -29,6 +29,22 @@ Docker Compose provides Postgres for target-platform development:
 ```bash
 docker compose up -d postgres
 ```
+
+Run the same install/test path inside the Compose app container:
+
+```bash
+docker compose run --rm app bash -lc "python -m pip install -e '.[dev,dashboard]' && pytest -q && alphadb-health"
+```
+
+Start the Streamlit target-platform dashboard:
+
+```bash
+docker compose --profile dashboard up streamlit
+```
+
+By default, local Postgres is published on `localhost:55433` and Streamlit on
+`localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
+`ALPHADB_STREAMLIT_PORT` when needed.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "${ALPHADB_STREAMLIT_PORT:-8501}:8501"
     depends_on:
       - postgres
-    command: bash -lc "python -m pip install -e '.[dashboard]' && streamlit hello --server.address=0.0.0.0"
+    command: bash -lc "python -m pip install -e '.[dashboard]' && streamlit run src/alphadb/dashboard/app.py --server.address=0.0.0.0"
 
 volumes:
   postgres-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
   "pyyaml>=6.0",
 ]
 
+[project.scripts]
+alphadb-health = "alphadb.health:main"
+
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]
 dev = [

--- a/src/alphadb/config.py
+++ b/src/alphadb/config.py
@@ -1,0 +1,36 @@
+"""Runtime configuration for local AlphaDB services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import environ
+from typing import Mapping
+
+
+DEFAULT_DATABASE_NAME = "alphadb"
+DEFAULT_DATABASE_USER = "alphadb"
+DEFAULT_DATABASE_PASSWORD = "alphadb"
+DEFAULT_DATABASE_HOST = "localhost"
+DEFAULT_DATABASE_PORT = "55433"
+
+
+@dataclass(frozen=True)
+class Settings:
+    environment: str
+    database_url: str
+    streamlit_port: str
+
+
+def settings_from_env(env: Mapping[str, str] | None = None) -> Settings:
+    values = environ if env is None else env
+    database_host = values.get("ALPHADB_POSTGRES_HOST", DEFAULT_DATABASE_HOST)
+    database_port = values.get("ALPHADB_POSTGRES_PORT", DEFAULT_DATABASE_PORT)
+    default_database_url = (
+        f"postgresql://{DEFAULT_DATABASE_USER}:{DEFAULT_DATABASE_PASSWORD}"
+        f"@{database_host}:{database_port}/{DEFAULT_DATABASE_NAME}"
+    )
+    return Settings(
+        environment=values.get("ALPHADB_ENV", "local"),
+        database_url=values.get("DATABASE_URL", default_database_url),
+        streamlit_port=values.get("ALPHADB_STREAMLIT_PORT", "8501"),
+    )

--- a/src/alphadb/dashboard/__init__.py
+++ b/src/alphadb/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Streamlit dashboard package for AlphaDB."""

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -1,0 +1,31 @@
+"""Streamlit entrypoint for the AlphaDB target-platform dashboard."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from alphadb.config import settings_from_env
+from alphadb.health import collect_health
+
+
+def render() -> None:
+    settings = settings_from_env()
+    report = collect_health(settings=settings)
+
+    st.set_page_config(page_title="AlphaDB", layout="wide")
+    st.title("AlphaDB")
+
+    status_label = "OK" if report.ok else "ERROR"
+    status_delta = None if report.ok else "attention required"
+
+    left, middle, right = st.columns(3)
+    left.metric("Platform", status_label, delta=status_delta)
+    middle.metric("Environment", report.environment)
+    right.metric("Postgres", "configured", settings.database_url.rsplit("@", maxsplit=1)[-1])
+
+    st.subheader("Health")
+    st.dataframe(report.as_rows(), hide_index=True, use_container_width=True)
+    st.caption(f"Generated {report.generated_at_utc.isoformat()}")
+
+
+render()

--- a/src/alphadb/health.py
+++ b/src/alphadb/health.py
@@ -1,0 +1,132 @@
+"""Health checks for the AlphaDB target-platform dev environment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from importlib.metadata import PackageNotFoundError, version
+from typing import Callable, Sequence
+
+import psycopg
+
+from alphadb.config import Settings, settings_from_env
+
+
+class HealthStatus(StrEnum):
+    OK = "ok"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class ComponentHealth:
+    name: str
+    status: HealthStatus
+    detail: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status == HealthStatus.OK
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    service: str
+    environment: str
+    generated_at_utc: datetime
+    components: tuple[ComponentHealth, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(component.ok for component in self.components)
+
+    def as_rows(self) -> list[dict[str, str]]:
+        return [
+            {
+                "component": component.name,
+                "status": component.status.value,
+                "detail": component.detail,
+            }
+            for component in self.components
+        ]
+
+
+DatabaseCheck = Callable[[str], ComponentHealth]
+PackageCheck = Callable[[], ComponentHealth]
+
+
+def check_package() -> ComponentHealth:
+    try:
+        package_version = version("alphadb")
+    except PackageNotFoundError:
+        return ComponentHealth(
+            name="package",
+            status=HealthStatus.ERROR,
+            detail="alphadb package is not installed",
+        )
+    return ComponentHealth(
+        name="package",
+        status=HealthStatus.OK,
+        detail=f"alphadb {package_version}",
+    )
+
+
+def check_database(database_url: str) -> ComponentHealth:
+    try:
+        with psycopg.connect(database_url, connect_timeout=2) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except Exception as exc:  # pragma: no cover - concrete exception varies by driver/platform.
+        return ComponentHealth(
+            name="postgres",
+            status=HealthStatus.ERROR,
+            detail=f"connection failed: {exc}",
+        )
+    return ComponentHealth(
+        name="postgres",
+        status=HealthStatus.OK,
+        detail="connection ok",
+    )
+
+
+def collect_health(
+    settings: Settings | None = None,
+    database_check: DatabaseCheck = check_database,
+    package_check: PackageCheck = check_package,
+    extra_components: Sequence[ComponentHealth] = (),
+) -> HealthReport:
+    resolved_settings = settings or settings_from_env()
+    components = (
+        package_check(),
+        database_check(resolved_settings.database_url),
+        *extra_components,
+    )
+    return HealthReport(
+        service="alphadb",
+        environment=resolved_settings.environment,
+        generated_at_utc=datetime.now(UTC),
+        components=components,
+    )
+
+
+def render_text(report: HealthReport) -> str:
+    lines = [
+        f"service: {report.service}",
+        f"environment: {report.environment}",
+        f"status: {'ok' if report.ok else 'error'}",
+        f"generated_at_utc: {report.generated_at_utc.isoformat()}",
+    ]
+    for component in report.components:
+        lines.append(f"{component.name}: {component.status.value} - {component.detail}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    report = collect_health()
+    print(render_text(report))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+from alphadb.config import settings_from_env
+
+
+def test_settings_default_database_url_uses_configurable_local_port() -> None:
+    settings = settings_from_env({})
+
+    assert settings.database_url == "postgresql://alphadb:alphadb@localhost:55433/alphadb"
+    assert settings.streamlit_port == "8501"
+
+
+def test_settings_database_url_can_be_overridden() -> None:
+    settings = settings_from_env(
+        {
+            "DATABASE_URL": "postgresql://user:pass@postgres:5432/custom",
+            "ALPHADB_ENV": "test",
+            "ALPHADB_STREAMLIT_PORT": "18501",
+        }
+    )
+
+    assert settings.database_url == "postgresql://user:pass@postgres:5432/custom"
+    assert settings.environment == "test"
+    assert settings.streamlit_port == "18501"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,57 @@
+from datetime import UTC
+
+from alphadb.config import Settings
+from alphadb.health import ComponentHealth, HealthStatus, collect_health, render_text
+
+
+def ok_package() -> ComponentHealth:
+    return ComponentHealth(
+        name="package",
+        status=HealthStatus.OK,
+        detail="alphadb test",
+    )
+
+
+def test_collect_health_reports_ok_when_components_are_ok() -> None:
+    settings = Settings(
+        environment="test",
+        database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
+        streamlit_port="8501",
+    )
+
+    report = collect_health(
+        settings=settings,
+        database_check=lambda _: ComponentHealth(
+            name="postgres",
+            status=HealthStatus.OK,
+            detail="connection ok",
+        ),
+        package_check=ok_package,
+    )
+
+    assert report.ok is True
+    assert report.service == "alphadb"
+    assert report.environment == "test"
+    assert report.generated_at_utc.tzinfo == UTC
+    assert {component.name for component in report.components} == {"package", "postgres"}
+
+
+def test_collect_health_reports_error_when_database_is_unavailable() -> None:
+    settings = Settings(
+        environment="test",
+        database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
+        streamlit_port="8501",
+    )
+
+    report = collect_health(
+        settings=settings,
+        database_check=lambda _: ComponentHealth(
+            name="postgres",
+            status=HealthStatus.ERROR,
+            detail="connection failed",
+        ),
+        package_check=ok_package,
+    )
+
+    assert report.ok is False
+    assert "postgres: error - connection failed" in render_text(report)


### PR DESCRIPTION
## Summary
- add AlphaDB settings and health-check modules with an alphadb-health CLI
- replace the Streamlit hello profile with a minimal AlphaDB health/status dashboard
- document the Compose install/test/dashboard path and configurable local ports

## Verification
- docker compose run --rm app bash -lc "python -m pip install -e '.[dev,dashboard]' && pytest -q && ruff check . && alphadb-health"
- docker compose --profile dashboard config
- curl -fsS http://localhost:8501/_stcore/health

Linear: ALP-2