### PR TITLE
feat: add KXBTC15M MarketSpec registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Start the Streamlit target-platform dashboard:
 docker compose --profile dashboard up streamlit
 ```
 
+Inspect registered market specifications:
+
+```bash
+alphadb-markets list
+alphadb-markets inspect KXBTC15M --json
+```
+
 By default, local Postgres is published on `localhost:55433` and Streamlit on
 `localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
 `ALPHADB_STREAMLIT_PORT` when needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.scripts]
 alphadb-health = "alphadb.health:main"
+alphadb-markets = "alphadb.markets.cli:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -6,6 +6,8 @@ import streamlit as st
 
 from alphadb.config import settings_from_env
 from alphadb.health import collect_health
+from alphadb.markets.cli import spec_summary_row
+from alphadb.markets.registry import default_market_registry
 
 
 def render() -> None:
@@ -25,6 +27,15 @@ def render() -> None:
 
     st.subheader("Health")
     st.dataframe(report.as_rows(), hide_index=True, use_container_width=True)
+
+    st.subheader("Market Specs")
+    registry = default_market_registry()
+    st.dataframe(
+        [spec_summary_row(spec) for spec in registry.list()],
+        hide_index=True,
+        use_container_width=True,
+    )
+
     st.caption(f"Generated {report.generated_at_utc.isoformat()}")
 
 

--- a/src/alphadb/markets/__init__.py
+++ b/src/alphadb/markets/__init__.py
@@ -1,0 +1,6 @@
+"""Market specifications for the AlphaDB target platform."""
+
+from alphadb.markets.registry import default_market_registry
+from alphadb.markets.spec import MarketSpec
+
+__all__ = ["MarketSpec", "default_market_registry"]

--- a/src/alphadb/markets/cli.py
+++ b/src/alphadb/markets/cli.py
@@ -1,0 +1,72 @@
+"""Command-line inspection for registered market specs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+from alphadb.markets.registry import default_market_registry
+from alphadb.markets.spec import MarketSpec
+
+
+def spec_summary_row(spec: MarketSpec) -> dict[str, str | int]:
+    return {
+        "series": spec.series,
+        "underlying": spec.underlying,
+        "horizon_minutes": spec.horizon_minutes,
+        "external_symbol": spec.feature_config.external_symbol,
+        "execution": spec.trading_cutoffs.time_in_force,
+    }
+
+
+def render_market_list(specs: Sequence[MarketSpec]) -> str:
+    rows = [spec_summary_row(spec) for spec in specs]
+    if not rows:
+        return "No market specs registered."
+
+    header = "series underlying horizon_minutes external_symbol execution"
+    body = [
+        (
+            f"{row['series']} {row['underlying']} {row['horizon_minutes']} "
+            f"{row['external_symbol']} {row['execution']}"
+        )
+        for row in rows
+    ]
+    return "\n".join([header, *body])
+
+
+def render_market_json(spec: MarketSpec) -> str:
+    return json.dumps(spec.model_dump(mode="json"), indent=2, sort_keys=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-markets")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="List registered market specs")
+
+    inspect_parser = subparsers.add_parser("inspect", help="Inspect one market spec")
+    inspect_parser.add_argument("series", help="Series ticker, e.g. KXBTC15M")
+    inspect_parser.add_argument("--json", action="store_true", help="Render the full spec as JSON")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    registry = default_market_registry()
+
+    if args.command == "list":
+        print(render_market_list(registry.list()))
+        return 0
+
+    if args.command == "inspect":
+        spec = registry.get(args.series)
+        if args.json:
+            print(render_market_json(spec))
+        else:
+            print(render_market_list([spec]))
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/markets/registry.py
+++ b/src/alphadb/markets/registry.py
@@ -1,0 +1,32 @@
+"""Registry for tradable market-family specifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from alphadb.markets.spec import MarketSpec, kxbtc15m_spec
+
+
+@dataclass
+class MarketRegistry:
+    _specs: dict[str, MarketSpec] = field(default_factory=dict)
+
+    def register(self, spec: MarketSpec) -> None:
+        if spec.series in self._specs:
+            raise ValueError(f"market spec already registered: {spec.series}")
+        self._specs[spec.series] = spec
+
+    def get(self, series: str) -> MarketSpec:
+        try:
+            return self._specs[series]
+        except KeyError as exc:
+            raise KeyError(f"unknown market spec: {series}") from exc
+
+    def list(self) -> list[MarketSpec]:
+        return [self._specs[key] for key in sorted(self._specs)]
+
+
+def default_market_registry() -> MarketRegistry:
+    registry = MarketRegistry()
+    registry.register(kxbtc15m_spec())
+    return registry

--- a/src/alphadb/markets/spec.py
+++ b/src/alphadb/markets/spec.py
@@ -1,0 +1,126 @@
+"""Validated target-platform market specification contracts."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, PositiveInt, model_validator
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class DiscoveryRules(StrictModel):
+    series_ticker: str = Field(min_length=1)
+    recurrence_minutes: PositiveInt
+    market_ticker_prefix: str = Field(min_length=1)
+    handle_every_instance: bool
+
+
+class FeatureConfig(StrictModel):
+    source: str = Field(min_length=1)
+    external_symbol: str = Field(min_length=1)
+    granularity_seconds: PositiveInt
+    external_data_role: Literal["feature_only"]
+
+
+class LabelFunction(StrictModel):
+    name: str = Field(min_length=1)
+    outcome_source: str = Field(min_length=1)
+    no_external_feature_truth: bool
+
+
+class FeeAssumptions(StrictModel):
+    role: Literal["taker", "maker"]
+    taker_fee_multiplier: PositiveFloat
+    maker_fee_multiplier: PositiveFloat
+
+
+class RiskConfig(StrictModel):
+    bankroll_dollars: PositiveFloat
+    live_stake_cap_dollars: PositiveFloat
+    max_daily_loss_dollars: PositiveFloat
+
+
+class TradingCutoffs(StrictModel):
+    decision_minute_offset: PositiveInt
+    interval_seconds: PositiveInt
+    settlement_buffer_seconds: PositiveInt
+    min_ev: float
+    post_only: bool
+    time_in_force: Literal["immediate_or_cancel", "good_till_canceled"]
+    self_trade_prevention_type: str = Field(min_length=1)
+
+
+class MarketSpec(StrictModel):
+    spec_version: str = Field(min_length=1)
+    series: str = Field(min_length=1)
+    underlying: str = Field(min_length=1)
+    horizon_minutes: PositiveInt
+    settlement_source: str = Field(min_length=1)
+    settlement_reference: str = Field(min_length=1)
+    discovery_rules: DiscoveryRules
+    feature_config: FeatureConfig
+    label_function: LabelFunction
+    fee_assumptions: FeeAssumptions
+    risk_config: RiskConfig
+    trading_cutoffs: TradingCutoffs
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> MarketSpec:
+        if self.discovery_rules.series_ticker != self.series:
+            raise ValueError("discovery series_ticker must match series")
+        if self.trading_cutoffs.decision_minute_offset >= self.horizon_minutes:
+            raise ValueError("decision_minute_offset must be before market horizon")
+        return self
+
+
+def kxbtc15m_spec() -> MarketSpec:
+    return MarketSpec(
+        spec_version="v1",
+        series="KXBTC15M",
+        underlying="BTC",
+        horizon_minutes=15,
+        settlement_source="CF Benchmarks RTI",
+        settlement_reference=(
+            "Kalshi crypto contracts settle from CF Benchmarks RTI; "
+            "external BTC feeds are features only."
+        ),
+        discovery_rules=DiscoveryRules(
+            series_ticker="KXBTC15M",
+            recurrence_minutes=15,
+            market_ticker_prefix="KXBTC15M",
+            handle_every_instance=True,
+        ),
+        feature_config=FeatureConfig(
+            source="coinbase_exchange",
+            external_symbol="BTC-USD",
+            granularity_seconds=60,
+            external_data_role="feature_only",
+        ),
+        label_function=LabelFunction(
+            name="kalshi_market_result",
+            outcome_source="kalshi_settlement",
+            no_external_feature_truth=True,
+        ),
+        fee_assumptions=FeeAssumptions(
+            role="taker",
+            taker_fee_multiplier=0.07,
+            maker_fee_multiplier=0.0175,
+        ),
+        risk_config=RiskConfig(
+            bankroll_dollars=1000.0,
+            live_stake_cap_dollars=1.0,
+            max_daily_loss_dollars=10.0,
+        ),
+        trading_cutoffs=TradingCutoffs(
+            decision_minute_offset=12,
+            interval_seconds=60,
+            settlement_buffer_seconds=60,
+            min_ev=0.0,
+            post_only=False,
+            time_in_force="immediate_or_cancel",
+            self_trade_prevention_type="taker_at_cross",
+        ),
+    )

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -1,0 +1,97 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from alphadb.markets.cli import main, render_market_json, render_market_list
+from alphadb.markets.registry import MarketRegistry, default_market_registry
+from alphadb.markets.spec import MarketSpec, kxbtc15m_spec
+
+
+def test_default_registry_contains_kxbtc15m() -> None:
+    spec = default_market_registry().get("KXBTC15M")
+
+    assert spec.series == "KXBTC15M"
+    assert spec.underlying == "BTC"
+    assert spec.horizon_minutes == 15
+    assert spec.settlement_source == "CF Benchmarks RTI"
+    assert spec.discovery_rules.handle_every_instance is True
+    assert spec.feature_config.source == "coinbase_exchange"
+    assert spec.feature_config.external_symbol == "BTC-USD"
+    assert spec.feature_config.granularity_seconds == 60
+    assert spec.feature_config.external_data_role == "feature_only"
+    assert spec.label_function.outcome_source == "kalshi_settlement"
+    assert spec.label_function.no_external_feature_truth is True
+    assert spec.fee_assumptions.role == "taker"
+    assert spec.fee_assumptions.taker_fee_multiplier == 0.07
+    assert spec.fee_assumptions.maker_fee_multiplier == 0.0175
+    assert spec.risk_config.bankroll_dollars == 1000.0
+    assert spec.risk_config.live_stake_cap_dollars == 1.0
+    assert spec.risk_config.max_daily_loss_dollars == 10.0
+    assert spec.trading_cutoffs.decision_minute_offset == 12
+    assert spec.trading_cutoffs.interval_seconds == 60
+    assert spec.trading_cutoffs.settlement_buffer_seconds == 60
+    assert spec.trading_cutoffs.time_in_force == "immediate_or_cancel"
+    assert spec.trading_cutoffs.post_only is False
+
+
+def test_market_spec_requires_core_fields() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload.pop("series")
+
+    with pytest.raises(ValidationError):
+        MarketSpec(**payload)
+
+
+def test_market_spec_rejects_unknown_fields() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload["unexpected"] = True
+
+    with pytest.raises(ValidationError):
+        MarketSpec(**payload)
+
+
+def test_market_spec_rejects_inconsistent_discovery_series() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload["discovery_rules"]["series_ticker"] = "KXETH15M"
+
+    with pytest.raises(ValidationError, match="series_ticker"):
+        MarketSpec(**payload)
+
+
+def test_market_spec_requires_decision_before_horizon() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload["trading_cutoffs"]["decision_minute_offset"] = 15
+
+    with pytest.raises(ValidationError, match="decision_minute_offset"):
+        MarketSpec(**payload)
+
+
+def test_registry_rejects_duplicate_specs_and_unknown_series() -> None:
+    registry = MarketRegistry()
+    spec = kxbtc15m_spec()
+    registry.register(spec)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(spec)
+
+    with pytest.raises(KeyError, match="unknown market spec"):
+        registry.get("KXETH15M")
+
+
+def test_market_cli_renderers_expose_registered_spec() -> None:
+    spec = kxbtc15m_spec()
+
+    rendered_list = render_market_list([spec])
+    assert "KXBTC15M BTC 15 BTC-USD immediate_or_cancel" in rendered_list
+
+    rendered_json = json.loads(render_market_json(spec))
+    assert rendered_json["series"] == "KXBTC15M"
+    assert rendered_json["feature_config"]["external_symbol"] == "BTC-USD"
+
+
+def test_market_cli_lists_specs(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["list"]) == 0
+
+    output = capsys.readouterr().out
+    assert "KXBTC15M BTC 15 BTC-USD immediate_or_cancel" in output


### PR DESCRIPTION
## Summary
- add validated MarketSpec contracts and a default registry
- register KXBTC15M using current MVP assumptions for BTC-USD features, 15-minute horizon, CF Benchmarks settlement reference, taker fees, IOC execution, and live risk defaults
- expose specs through alphadb-markets and the Streamlit status page

## Verification
- docker compose run --rm app bash -lc "python -m pip install -e '.[dev,dashboard]' && pytest -q && ruff check . && alphadb-health && alphadb-markets list && alphadb-markets inspect KXBTC15M --json >/tmp/kxbtc15m.json && python -m json.tool /tmp/kxbtc15m.json >/dev/null"
- curl -fsS http://localhost:8501/_stcore/health

Stacked on PR #1 / ALP-2.
Linear: ALP-3