### PR TITLE
feat: add operational state tracer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 POSTGRES_USER=alphadb
 POSTGRES_PASSWORD=alphadb
 POSTGRES_DB=alphadb
-DATABASE_URL=postgresql://alphadb:alphadb@postgres:5432/alphadb
+DATABASE_URL=postgresql://alphadb:alphadb@localhost:55433/alphadb
+ALPHADB_POSTGRES_HOST=localhost
 ALPHADB_POSTGRES_PORT=55433
 ALPHADB_STREAMLIT_PORT=8501

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Start the Streamlit target-platform dashboard:
 docker compose --profile dashboard up streamlit
 ```
 
+Inspect registered market specifications:
+
+```bash
+alphadb-markets list
+alphadb-markets inspect KXBTC15M --json
+```
+
 By default, local Postgres is published on `localhost:55433` and Streamlit on
 `localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
 `ALPHADB_STREAMLIT_PORT` when needed.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository has been reset intentionally. Prior AlphaDB history is not part 
 Open the repository in a Dev Container, or run locally with Python 3.12+:
 
 ```bash
-python -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install -e ".[dev]"
 pytest
@@ -29,6 +29,22 @@ Docker Compose provides Postgres for target-platform development:
 ```bash
 docker compose up -d postgres
 ```
+
+Run the same install/test path inside the Compose app container:
+
+```bash
+docker compose run --rm app bash -lc "python -m pip install -e '.[dev,dashboard]' && pytest -q && alphadb-health"
+```
+
+Start the Streamlit target-platform dashboard:
+
+```bash
+docker compose --profile dashboard up streamlit
+```
+
+By default, local Postgres is published on `localhost:55433` and Streamlit on
+`localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
+`ALPHADB_STREAMLIT_PORT` when needed.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "${ALPHADB_STREAMLIT_PORT:-8501}:8501"
     depends_on:
       - postgres
-    command: bash -lc "python -m pip install -e '.[dashboard]' && streamlit hello --server.address=0.0.0.0"
+    command: bash -lc "python -m pip install -e '.[dashboard]' && streamlit run src/alphadb/dashboard/app.py --server.address=0.0.0.0"
 
 volumes:
   postgres-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.scripts]
 alphadb-health = "alphadb.health:main"
+alphadb-markets = "alphadb.markets.cli:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 [project.scripts]
 alphadb-health = "alphadb.health:main"
 alphadb-markets = "alphadb.markets.cli:main"
+alphadb-state = "alphadb.state.cli:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
   "pyyaml>=6.0",
 ]
 
+[project.scripts]
+alphadb-health = "alphadb.health:main"
+
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]
 dev = [

--- a/src/alphadb/config.py
+++ b/src/alphadb/config.py
@@ -1,0 +1,36 @@
+"""Runtime configuration for local AlphaDB services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import environ
+from typing import Mapping
+
+
+DEFAULT_DATABASE_NAME = "alphadb"
+DEFAULT_DATABASE_USER = "alphadb"
+DEFAULT_DATABASE_PASSWORD = "alphadb"
+DEFAULT_DATABASE_HOST = "localhost"
+DEFAULT_DATABASE_PORT = "55433"
+
+
+@dataclass(frozen=True)
+class Settings:
+    environment: str
+    database_url: str
+    streamlit_port: str
+
+
+def settings_from_env(env: Mapping[str, str] | None = None) -> Settings:
+    values = environ if env is None else env
+    database_host = values.get("ALPHADB_POSTGRES_HOST", DEFAULT_DATABASE_HOST)
+    database_port = values.get("ALPHADB_POSTGRES_PORT", DEFAULT_DATABASE_PORT)
+    default_database_url = (
+        f"postgresql://{DEFAULT_DATABASE_USER}:{DEFAULT_DATABASE_PASSWORD}"
+        f"@{database_host}:{database_port}/{DEFAULT_DATABASE_NAME}"
+    )
+    return Settings(
+        environment=values.get("ALPHADB_ENV", "local"),
+        database_url=values.get("DATABASE_URL", default_database_url),
+        streamlit_port=values.get("ALPHADB_STREAMLIT_PORT", "8501"),
+    )

--- a/src/alphadb/dashboard/__init__.py
+++ b/src/alphadb/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Streamlit dashboard package for AlphaDB."""

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -1,0 +1,31 @@
+"""Streamlit entrypoint for the AlphaDB target-platform dashboard."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from alphadb.config import settings_from_env
+from alphadb.health import collect_health
+
+
+def render() -> None:
+    settings = settings_from_env()
+    report = collect_health(settings=settings)
+
+    st.set_page_config(page_title="AlphaDB", layout="wide")
+    st.title("AlphaDB")
+
+    status_label = "OK" if report.ok else "ERROR"
+    status_delta = None if report.ok else "attention required"
+
+    left, middle, right = st.columns(3)
+    left.metric("Platform", status_label, delta=status_delta)
+    middle.metric("Environment", report.environment)
+    right.metric("Postgres", "configured", settings.database_url.rsplit("@", maxsplit=1)[-1])
+
+    st.subheader("Health")
+    st.dataframe(report.as_rows(), hide_index=True, use_container_width=True)
+    st.caption(f"Generated {report.generated_at_utc.isoformat()}")
+
+
+render()

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -6,6 +6,8 @@ import streamlit as st
 
 from alphadb.config import settings_from_env
 from alphadb.health import collect_health
+from alphadb.markets.cli import spec_summary_row
+from alphadb.markets.registry import default_market_registry
 
 
 def render() -> None:
@@ -25,6 +27,15 @@ def render() -> None:
 
     st.subheader("Health")
     st.dataframe(report.as_rows(), hide_index=True, use_container_width=True)
+
+    st.subheader("Market Specs")
+    registry = default_market_registry()
+    st.dataframe(
+        [spec_summary_row(spec) for spec in registry.list()],
+        hide_index=True,
+        use_container_width=True,
+    )
+
     st.caption(f"Generated {report.generated_at_utc.isoformat()}")
 
 

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -8,6 +8,18 @@ from alphadb.config import settings_from_env
 from alphadb.health import collect_health
 from alphadb.markets.cli import spec_summary_row
 from alphadb.markets.registry import default_market_registry
+from alphadb.state.repository import OperationalStateRepository
+
+
+def operational_state_rows(database_url: str) -> list[dict[str, str | int]]:
+    try:
+        counts = OperationalStateRepository(database_url).counts().as_dict()
+    except Exception as exc:
+        return [{"metric": "operational_state", "value": "unavailable", "detail": str(exc)}]
+    return [
+        {"metric": metric, "value": value, "detail": "postgres"}
+        for metric, value in counts.items()
+    ]
 
 
 def render() -> None:
@@ -32,6 +44,13 @@ def render() -> None:
     registry = default_market_registry()
     st.dataframe(
         [spec_summary_row(spec) for spec in registry.list()],
+        hide_index=True,
+        use_container_width=True,
+    )
+
+    st.subheader("Operational State")
+    st.dataframe(
+        operational_state_rows(settings.database_url),
         hide_index=True,
         use_container_width=True,
     )

--- a/src/alphadb/health.py
+++ b/src/alphadb/health.py
@@ -1,0 +1,132 @@
+"""Health checks for the AlphaDB target-platform dev environment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from importlib.metadata import PackageNotFoundError, version
+from typing import Callable, Sequence
+
+import psycopg
+
+from alphadb.config import Settings, settings_from_env
+
+
+class HealthStatus(StrEnum):
+    OK = "ok"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class ComponentHealth:
+    name: str
+    status: HealthStatus
+    detail: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status == HealthStatus.OK
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    service: str
+    environment: str
+    generated_at_utc: datetime
+    components: tuple[ComponentHealth, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(component.ok for component in self.components)
+
+    def as_rows(self) -> list[dict[str, str]]:
+        return [
+            {
+                "component": component.name,
+                "status": component.status.value,
+                "detail": component.detail,
+            }
+            for component in self.components
+        ]
+
+
+DatabaseCheck = Callable[[str], ComponentHealth]
+PackageCheck = Callable[[], ComponentHealth]
+
+
+def check_package() -> ComponentHealth:
+    try:
+        package_version = version("alphadb")
+    except PackageNotFoundError:
+        return ComponentHealth(
+            name="package",
+            status=HealthStatus.ERROR,
+            detail="alphadb package is not installed",
+        )
+    return ComponentHealth(
+        name="package",
+        status=HealthStatus.OK,
+        detail=f"alphadb {package_version}",
+    )
+
+
+def check_database(database_url: str) -> ComponentHealth:
+    try:
+        with psycopg.connect(database_url, connect_timeout=2) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except Exception as exc:  # pragma: no cover - concrete exception varies by driver/platform.
+        return ComponentHealth(
+            name="postgres",
+            status=HealthStatus.ERROR,
+            detail=f"connection failed: {exc}",
+        )
+    return ComponentHealth(
+        name="postgres",
+        status=HealthStatus.OK,
+        detail="connection ok",
+    )
+
+
+def collect_health(
+    settings: Settings | None = None,
+    database_check: DatabaseCheck = check_database,
+    package_check: PackageCheck = check_package,
+    extra_components: Sequence[ComponentHealth] = (),
+) -> HealthReport:
+    resolved_settings = settings or settings_from_env()
+    components = (
+        package_check(),
+        database_check(resolved_settings.database_url),
+        *extra_components,
+    )
+    return HealthReport(
+        service="alphadb",
+        environment=resolved_settings.environment,
+        generated_at_utc=datetime.now(UTC),
+        components=components,
+    )
+
+
+def render_text(report: HealthReport) -> str:
+    lines = [
+        f"service: {report.service}",
+        f"environment: {report.environment}",
+        f"status: {'ok' if report.ok else 'error'}",
+        f"generated_at_utc: {report.generated_at_utc.isoformat()}",
+    ]
+    for component in report.components:
+        lines.append(f"{component.name}: {component.status.value} - {component.detail}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    report = collect_health()
+    print(render_text(report))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/alphadb/markets/__init__.py
+++ b/src/alphadb/markets/__init__.py
@@ -1,0 +1,6 @@
+"""Market specifications for the AlphaDB target platform."""
+
+from alphadb.markets.registry import default_market_registry
+from alphadb.markets.spec import MarketSpec
+
+__all__ = ["MarketSpec", "default_market_registry"]

--- a/src/alphadb/markets/cli.py
+++ b/src/alphadb/markets/cli.py
@@ -1,0 +1,72 @@
+"""Command-line inspection for registered market specs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+from alphadb.markets.registry import default_market_registry
+from alphadb.markets.spec import MarketSpec
+
+
+def spec_summary_row(spec: MarketSpec) -> dict[str, str | int]:
+    return {
+        "series": spec.series,
+        "underlying": spec.underlying,
+        "horizon_minutes": spec.horizon_minutes,
+        "external_symbol": spec.feature_config.external_symbol,
+        "execution": spec.trading_cutoffs.time_in_force,
+    }
+
+
+def render_market_list(specs: Sequence[MarketSpec]) -> str:
+    rows = [spec_summary_row(spec) for spec in specs]
+    if not rows:
+        return "No market specs registered."
+
+    header = "series underlying horizon_minutes external_symbol execution"
+    body = [
+        (
+            f"{row['series']} {row['underlying']} {row['horizon_minutes']} "
+            f"{row['external_symbol']} {row['execution']}"
+        )
+        for row in rows
+    ]
+    return "\n".join([header, *body])
+
+
+def render_market_json(spec: MarketSpec) -> str:
+    return json.dumps(spec.model_dump(mode="json"), indent=2, sort_keys=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-markets")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="List registered market specs")
+
+    inspect_parser = subparsers.add_parser("inspect", help="Inspect one market spec")
+    inspect_parser.add_argument("series", help="Series ticker, e.g. KXBTC15M")
+    inspect_parser.add_argument("--json", action="store_true", help="Render the full spec as JSON")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    registry = default_market_registry()
+
+    if args.command == "list":
+        print(render_market_list(registry.list()))
+        return 0
+
+    if args.command == "inspect":
+        spec = registry.get(args.series)
+        if args.json:
+            print(render_market_json(spec))
+        else:
+            print(render_market_list([spec]))
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/markets/registry.py
+++ b/src/alphadb/markets/registry.py
@@ -1,0 +1,32 @@
+"""Registry for tradable market-family specifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from alphadb.markets.spec import MarketSpec, kxbtc15m_spec
+
+
+@dataclass
+class MarketRegistry:
+    _specs: dict[str, MarketSpec] = field(default_factory=dict)
+
+    def register(self, spec: MarketSpec) -> None:
+        if spec.series in self._specs:
+            raise ValueError(f"market spec already registered: {spec.series}")
+        self._specs[spec.series] = spec
+
+    def get(self, series: str) -> MarketSpec:
+        try:
+            return self._specs[series]
+        except KeyError as exc:
+            raise KeyError(f"unknown market spec: {series}") from exc
+
+    def list(self) -> list[MarketSpec]:
+        return [self._specs[key] for key in sorted(self._specs)]
+
+
+def default_market_registry() -> MarketRegistry:
+    registry = MarketRegistry()
+    registry.register(kxbtc15m_spec())
+    return registry

--- a/src/alphadb/markets/spec.py
+++ b/src/alphadb/markets/spec.py
@@ -1,0 +1,126 @@
+"""Validated target-platform market specification contracts."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, PositiveInt, model_validator
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class DiscoveryRules(StrictModel):
+    series_ticker: str = Field(min_length=1)
+    recurrence_minutes: PositiveInt
+    market_ticker_prefix: str = Field(min_length=1)
+    handle_every_instance: bool
+
+
+class FeatureConfig(StrictModel):
+    source: str = Field(min_length=1)
+    external_symbol: str = Field(min_length=1)
+    granularity_seconds: PositiveInt
+    external_data_role: Literal["feature_only"]
+
+
+class LabelFunction(StrictModel):
+    name: str = Field(min_length=1)
+    outcome_source: str = Field(min_length=1)
+    no_external_feature_truth: bool
+
+
+class FeeAssumptions(StrictModel):
+    role: Literal["taker", "maker"]
+    taker_fee_multiplier: PositiveFloat
+    maker_fee_multiplier: PositiveFloat
+
+
+class RiskConfig(StrictModel):
+    bankroll_dollars: PositiveFloat
+    live_stake_cap_dollars: PositiveFloat
+    max_daily_loss_dollars: PositiveFloat
+
+
+class TradingCutoffs(StrictModel):
+    decision_minute_offset: PositiveInt
+    interval_seconds: PositiveInt
+    settlement_buffer_seconds: PositiveInt
+    min_ev: float
+    post_only: bool
+    time_in_force: Literal["immediate_or_cancel", "good_till_canceled"]
+    self_trade_prevention_type: str = Field(min_length=1)
+
+
+class MarketSpec(StrictModel):
+    spec_version: str = Field(min_length=1)
+    series: str = Field(min_length=1)
+    underlying: str = Field(min_length=1)
+    horizon_minutes: PositiveInt
+    settlement_source: str = Field(min_length=1)
+    settlement_reference: str = Field(min_length=1)
+    discovery_rules: DiscoveryRules
+    feature_config: FeatureConfig
+    label_function: LabelFunction
+    fee_assumptions: FeeAssumptions
+    risk_config: RiskConfig
+    trading_cutoffs: TradingCutoffs
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> MarketSpec:
+        if self.discovery_rules.series_ticker != self.series:
+            raise ValueError("discovery series_ticker must match series")
+        if self.trading_cutoffs.decision_minute_offset >= self.horizon_minutes:
+            raise ValueError("decision_minute_offset must be before market horizon")
+        return self
+
+
+def kxbtc15m_spec() -> MarketSpec:
+    return MarketSpec(
+        spec_version="v1",
+        series="KXBTC15M",
+        underlying="BTC",
+        horizon_minutes=15,
+        settlement_source="CF Benchmarks RTI",
+        settlement_reference=(
+            "Kalshi crypto contracts settle from CF Benchmarks RTI; "
+            "external BTC feeds are features only."
+        ),
+        discovery_rules=DiscoveryRules(
+            series_ticker="KXBTC15M",
+            recurrence_minutes=15,
+            market_ticker_prefix="KXBTC15M",
+            handle_every_instance=True,
+        ),
+        feature_config=FeatureConfig(
+            source="coinbase_exchange",
+            external_symbol="BTC-USD",
+            granularity_seconds=60,
+            external_data_role="feature_only",
+        ),
+        label_function=LabelFunction(
+            name="kalshi_market_result",
+            outcome_source="kalshi_settlement",
+            no_external_feature_truth=True,
+        ),
+        fee_assumptions=FeeAssumptions(
+            role="taker",
+            taker_fee_multiplier=0.07,
+            maker_fee_multiplier=0.0175,
+        ),
+        risk_config=RiskConfig(
+            bankroll_dollars=1000.0,
+            live_stake_cap_dollars=1.0,
+            max_daily_loss_dollars=10.0,
+        ),
+        trading_cutoffs=TradingCutoffs(
+            decision_minute_offset=12,
+            interval_seconds=60,
+            settlement_buffer_seconds=60,
+            min_ev=0.0,
+            post_only=False,
+            time_in_force="immediate_or_cancel",
+            self_trade_prevention_type="taker_at_cross",
+        ),
+    )

--- a/src/alphadb/state/__init__.py
+++ b/src/alphadb/state/__init__.py
@@ -1,0 +1,5 @@
+"""Postgres-backed target-platform operational state."""
+
+from alphadb.state.repository import OperationalStateRepository
+
+__all__ = ["OperationalStateRepository"]

--- a/src/alphadb/state/cli.py
+++ b/src/alphadb/state/cli.py
@@ -1,0 +1,54 @@
+"""Command-line tools for target-platform operational state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+from alphadb.config import settings_from_env
+from alphadb.markets.registry import default_market_registry
+from alphadb.state.repository import OperationalStateRepository
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-state")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("migrate", help="Apply operational state migrations")
+    subparsers.add_parser("counts", help="Show operational state record counts")
+
+    tracer_parser = subparsers.add_parser("create-tracer", help="Create a complete tracer run")
+    tracer_parser.add_argument("--series", default="KXBTC15M")
+
+    show_parser = subparsers.add_parser("show-run", help="Show one run summary")
+    show_parser.add_argument("run_id")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = settings_from_env()
+    repository = OperationalStateRepository(settings.database_url)
+
+    if args.command == "migrate":
+        applied = repository.apply_migrations()
+        print(json.dumps({"applied_migrations": applied}, indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "counts":
+        print(json.dumps(repository.counts().as_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "create-tracer":
+        spec = default_market_registry().get(args.series)
+        repository.apply_migrations()
+        print(json.dumps(repository.create_tracer_run(spec).as_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "show-run":
+        print(json.dumps(repository.get_run_summary(args.run_id), indent=2, sort_keys=True))
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/state/migrations.py
+++ b/src/alphadb/state/migrations.py
@@ -1,0 +1,88 @@
+"""Small SQL migration runner for early target-platform state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: str
+    statements: tuple[str, ...]
+
+
+INITIAL_OPERATIONAL_STATE = Migration(
+    version="0001_operational_state",
+    statements=(
+        """
+        create table if not exists schema_migrations (
+            version text primary key,
+            applied_at timestamptz not null default now()
+        )
+        """,
+        """
+        create table if not exists platform_runs (
+            run_id text primary key,
+            mode text not null,
+            market_series text not null,
+            status text not null,
+            started_at timestamptz not null,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create table if not exists market_instances (
+            market_ticker text primary key,
+            series text not null,
+            open_time timestamptz not null,
+            close_time timestamptz not null,
+            status text not null,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create table if not exists decisions (
+            decision_id text primary key,
+            run_id text not null references platform_runs(run_id),
+            market_ticker text not null references market_instances(market_ticker),
+            decision_timestamp timestamptz not null,
+            outcome text not null,
+            probability_yes numeric,
+            selected_side text,
+            skip_reason text,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now(),
+            unique (run_id, market_ticker)
+        )
+        """,
+        """
+        create table if not exists risk_decisions (
+            risk_decision_id text primary key,
+            decision_id text not null unique references decisions(decision_id),
+            status text not null,
+            reason text,
+            payload jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create table if not exists order_intents (
+            order_intent_id text primary key,
+            risk_decision_id text not null unique references risk_decisions(risk_decision_id),
+            side text not null,
+            price numeric not null,
+            quantity integer not null,
+            max_cost_dollars numeric not null,
+            time_in_force text not null,
+            created_at timestamptz not null default now()
+        )
+        """,
+        "create index if not exists decisions_run_id_idx on decisions(run_id)",
+        "create index if not exists market_instances_series_idx on market_instances(series)",
+    ),
+)
+
+
+MIGRATIONS: tuple[Migration, ...] = (INITIAL_OPERATIONAL_STATE,)

--- a/src/alphadb/state/models.py
+++ b/src/alphadb/state/models.py
@@ -1,0 +1,41 @@
+"""Operational state records used by the first Postgres tracer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OperationalCounts:
+    runs: int
+    market_instances: int
+    decisions: int
+    risk_decisions: int
+    order_intents: int
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "runs": self.runs,
+            "market_instances": self.market_instances,
+            "decisions": self.decisions,
+            "risk_decisions": self.risk_decisions,
+            "order_intents": self.order_intents,
+        }
+
+
+@dataclass(frozen=True)
+class TracerRunRecord:
+    run_id: str
+    market_ticker: str
+    decision_id: str
+    risk_decision_id: str
+    order_intent_id: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "run_id": self.run_id,
+            "market_ticker": self.market_ticker,
+            "decision_id": self.decision_id,
+            "risk_decision_id": self.risk_decision_id,
+            "order_intent_id": self.order_intent_id,
+        }

--- a/src/alphadb/state/repository.py
+++ b/src/alphadb/state/repository.py
@@ -1,0 +1,221 @@
+"""Postgres repository for target-platform operational state."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from alphadb.markets.spec import MarketSpec
+from alphadb.state.migrations import MIGRATIONS
+from alphadb.state.models import OperationalCounts, TracerRunRecord
+
+
+class OperationalStateRepository:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    @contextmanager
+    def connect(self) -> Iterator[psycopg.Connection]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            yield connection
+
+    def apply_migrations(self) -> list[str]:
+        applied: list[str] = []
+        with self.connect() as connection:
+            with connection.cursor() as cursor:
+                for migration in MIGRATIONS:
+                    for statement in migration.statements:
+                        cursor.execute(statement)
+                    cursor.execute(
+                        """
+                        insert into schema_migrations (version)
+                        values (%s)
+                        on conflict (version) do nothing
+                        """,
+                        (migration.version,),
+                    )
+                    if cursor.rowcount:
+                        applied.append(migration.version)
+            connection.commit()
+        return applied
+
+    def create_tracer_run(
+        self,
+        spec: MarketSpec,
+        *,
+        now: datetime | None = None,
+    ) -> TracerRunRecord:
+        timestamp = now or datetime.now(UTC)
+        unique_suffix = uuid4().hex[:12]
+        run_id = f"run_{unique_suffix}"
+        market_ticker = f"{spec.series}-TRACER-{unique_suffix}"
+        decision_id = f"dec_{unique_suffix}"
+        risk_decision_id = f"risk_{unique_suffix}"
+        order_intent_id = f"intent_{unique_suffix}"
+        close_time = timestamp + timedelta(minutes=spec.horizon_minutes)
+
+        with self.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into platform_runs (
+                        run_id, mode, market_series, status, started_at, metadata
+                    )
+                    values (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        run_id,
+                        "tracer",
+                        spec.series,
+                        "completed",
+                        timestamp,
+                        Jsonb({"spec_version": spec.spec_version}),
+                    ),
+                )
+                cursor.execute(
+                    """
+                    insert into market_instances (
+                        market_ticker, series, open_time, close_time, status, metadata
+                    )
+                    values (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        market_ticker,
+                        spec.series,
+                        timestamp,
+                        close_time,
+                        "tracer",
+                        Jsonb({"horizon_minutes": spec.horizon_minutes}),
+                    ),
+                )
+                cursor.execute(
+                    """
+                    insert into decisions (
+                        decision_id,
+                        run_id,
+                        market_ticker,
+                        decision_timestamp,
+                        outcome,
+                        probability_yes,
+                        selected_side,
+                        skip_reason,
+                        metadata
+                    )
+                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        decision_id,
+                        run_id,
+                        market_ticker,
+                        timestamp,
+                        "order_intent",
+                        0.55,
+                        "yes",
+                        None,
+                        Jsonb({"source": "operational_state_tracer"}),
+                    ),
+                )
+                cursor.execute(
+                    """
+                    insert into risk_decisions (
+                        risk_decision_id, decision_id, status, reason, payload
+                    )
+                    values (%s, %s, %s, %s, %s)
+                    """,
+                    (
+                        risk_decision_id,
+                        decision_id,
+                        "approved",
+                        "tracer",
+                        Jsonb({"stake_cap_dollars": spec.risk_config.live_stake_cap_dollars}),
+                    ),
+                )
+                cursor.execute(
+                    """
+                    insert into order_intents (
+                        order_intent_id,
+                        risk_decision_id,
+                        side,
+                        price,
+                        quantity,
+                        max_cost_dollars,
+                        time_in_force
+                    )
+                    values (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        order_intent_id,
+                        risk_decision_id,
+                        "yes",
+                        0.49,
+                        1,
+                        spec.risk_config.live_stake_cap_dollars,
+                        spec.trading_cutoffs.time_in_force,
+                    ),
+                )
+            connection.commit()
+
+        return TracerRunRecord(
+            run_id=run_id,
+            market_ticker=market_ticker,
+            decision_id=decision_id,
+            risk_decision_id=risk_decision_id,
+            order_intent_id=order_intent_id,
+        )
+
+    def get_run_summary(self, run_id: str) -> dict[str, str | int]:
+        with self.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select
+                        r.run_id,
+                        r.mode,
+                        r.market_series,
+                        r.status,
+                        count(distinct d.decision_id)::int as decisions,
+                        count(distinct rd.risk_decision_id)::int as risk_decisions,
+                        count(distinct oi.order_intent_id)::int as order_intents
+                    from platform_runs r
+                    left join decisions d on d.run_id = r.run_id
+                    left join risk_decisions rd on rd.decision_id = d.decision_id
+                    left join order_intents oi on oi.risk_decision_id = rd.risk_decision_id
+                    where r.run_id = %s
+                    group by r.run_id
+                    """,
+                    (run_id,),
+                )
+                row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"unknown run: {run_id}")
+        return dict(row)
+
+    def counts(self) -> OperationalCounts:
+        with self.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select
+                        (select count(*)::int from platform_runs) as runs,
+                        (select count(*)::int from market_instances) as market_instances,
+                        (select count(*)::int from decisions) as decisions,
+                        (select count(*)::int from risk_decisions) as risk_decisions,
+                        (select count(*)::int from order_intents) as order_intents
+                    """
+                )
+                row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("operational state count query returned no rows")
+        return OperationalCounts(
+            runs=int(row["runs"]),
+            market_instances=int(row["market_instances"]),
+            decisions=int(row["decisions"]),
+            risk_decisions=int(row["risk_decisions"]),
+            order_intents=int(row["order_intents"]),
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+from alphadb.config import settings_from_env
+
+
+def test_settings_default_database_url_uses_configurable_local_port() -> None:
+    settings = settings_from_env({})
+
+    assert settings.database_url == "postgresql://alphadb:alphadb@localhost:55433/alphadb"
+    assert settings.streamlit_port == "8501"
+
+
+def test_settings_database_url_can_be_overridden() -> None:
+    settings = settings_from_env(
+        {
+            "DATABASE_URL": "postgresql://user:pass@postgres:5432/custom",
+            "ALPHADB_ENV": "test",
+            "ALPHADB_STREAMLIT_PORT": "18501",
+        }
+    )
+
+    assert settings.database_url == "postgresql://user:pass@postgres:5432/custom"
+    assert settings.environment == "test"
+    assert settings.streamlit_port == "18501"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,57 @@
+from datetime import UTC
+
+from alphadb.config import Settings
+from alphadb.health import ComponentHealth, HealthStatus, collect_health, render_text
+
+
+def ok_package() -> ComponentHealth:
+    return ComponentHealth(
+        name="package",
+        status=HealthStatus.OK,
+        detail="alphadb test",
+    )
+
+
+def test_collect_health_reports_ok_when_components_are_ok() -> None:
+    settings = Settings(
+        environment="test",
+        database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
+        streamlit_port="8501",
+    )
+
+    report = collect_health(
+        settings=settings,
+        database_check=lambda _: ComponentHealth(
+            name="postgres",
+            status=HealthStatus.OK,
+            detail="connection ok",
+        ),
+        package_check=ok_package,
+    )
+
+    assert report.ok is True
+    assert report.service == "alphadb"
+    assert report.environment == "test"
+    assert report.generated_at_utc.tzinfo == UTC
+    assert {component.name for component in report.components} == {"package", "postgres"}
+
+
+def test_collect_health_reports_error_when_database_is_unavailable() -> None:
+    settings = Settings(
+        environment="test",
+        database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
+        streamlit_port="8501",
+    )
+
+    report = collect_health(
+        settings=settings,
+        database_check=lambda _: ComponentHealth(
+            name="postgres",
+            status=HealthStatus.ERROR,
+            detail="connection failed",
+        ),
+        package_check=ok_package,
+    )
+
+    assert report.ok is False
+    assert "postgres: error - connection failed" in render_text(report)

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -1,0 +1,97 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from alphadb.markets.cli import main, render_market_json, render_market_list
+from alphadb.markets.registry import MarketRegistry, default_market_registry
+from alphadb.markets.spec import MarketSpec, kxbtc15m_spec
+
+
+def test_default_registry_contains_kxbtc15m() -> None:
+    spec = default_market_registry().get("KXBTC15M")
+
+    assert spec.series == "KXBTC15M"
+    assert spec.underlying == "BTC"
+    assert spec.horizon_minutes == 15
+    assert spec.settlement_source == "CF Benchmarks RTI"
+    assert spec.discovery_rules.handle_every_instance is True
+    assert spec.feature_config.source == "coinbase_exchange"
+    assert spec.feature_config.external_symbol == "BTC-USD"
+    assert spec.feature_config.granularity_seconds == 60
+    assert spec.feature_config.external_data_role == "feature_only"
+    assert spec.label_function.outcome_source == "kalshi_settlement"
+    assert spec.label_function.no_external_feature_truth is True
+    assert spec.fee_assumptions.role == "taker"
+    assert spec.fee_assumptions.taker_fee_multiplier == 0.07
+    assert spec.fee_assumptions.maker_fee_multiplier == 0.0175
+    assert spec.risk_config.bankroll_dollars == 1000.0
+    assert spec.risk_config.live_stake_cap_dollars == 1.0
+    assert spec.risk_config.max_daily_loss_dollars == 10.0
+    assert spec.trading_cutoffs.decision_minute_offset == 12
+    assert spec.trading_cutoffs.interval_seconds == 60
+    assert spec.trading_cutoffs.settlement_buffer_seconds == 60
+    assert spec.trading_cutoffs.time_in_force == "immediate_or_cancel"
+    assert spec.trading_cutoffs.post_only is False
+
+
+def test_market_spec_requires_core_fields() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload.pop("series")
+
+    with pytest.raises(ValidationError):
+        MarketSpec(**payload)
+
+
+def test_market_spec_rejects_unknown_fields() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload["unexpected"] = True
+
+    with pytest.raises(ValidationError):
+        MarketSpec(**payload)
+
+
+def test_market_spec_rejects_inconsistent_discovery_series() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload["discovery_rules"]["series_ticker"] = "KXETH15M"
+
+    with pytest.raises(ValidationError, match="series_ticker"):
+        MarketSpec(**payload)
+
+
+def test_market_spec_requires_decision_before_horizon() -> None:
+    payload = kxbtc15m_spec().model_dump()
+    payload["trading_cutoffs"]["decision_minute_offset"] = 15
+
+    with pytest.raises(ValidationError, match="decision_minute_offset"):
+        MarketSpec(**payload)
+
+
+def test_registry_rejects_duplicate_specs_and_unknown_series() -> None:
+    registry = MarketRegistry()
+    spec = kxbtc15m_spec()
+    registry.register(spec)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(spec)
+
+    with pytest.raises(KeyError, match="unknown market spec"):
+        registry.get("KXETH15M")
+
+
+def test_market_cli_renderers_expose_registered_spec() -> None:
+    spec = kxbtc15m_spec()
+
+    rendered_list = render_market_list([spec])
+    assert "KXBTC15M BTC 15 BTC-USD immediate_or_cancel" in rendered_list
+
+    rendered_json = json.loads(render_market_json(spec))
+    assert rendered_json["series"] == "KXBTC15M"
+    assert rendered_json["feature_config"]["external_symbol"] == "BTC-USD"
+
+
+def test_market_cli_lists_specs(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["list"]) == 0
+
+    output = capsys.readouterr().out
+    assert "KXBTC15M BTC 15 BTC-USD immediate_or_cancel" in output

--- a/tests/test_operational_state.py
+++ b/tests/test_operational_state.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import psycopg
+import pytest
+from psycopg import errors
+from psycopg.types.json import Jsonb
+
+from alphadb.config import settings_from_env
+from alphadb.markets.spec import kxbtc15m_spec
+from alphadb.state.repository import OperationalStateRepository
+
+
+def repository_or_skip() -> OperationalStateRepository:
+    repository = OperationalStateRepository(settings_from_env().database_url)
+    try:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    return repository
+
+
+def test_migrations_are_idempotent_and_create_complete_tracer_run() -> None:
+    repository = repository_or_skip()
+
+    repository.apply_migrations()
+    assert repository.apply_migrations() == []
+
+    tracer = repository.create_tracer_run(
+        kxbtc15m_spec(),
+        now=datetime(2026, 5, 31, 20, 0, tzinfo=UTC),
+    )
+    summary = repository.get_run_summary(tracer.run_id)
+
+    assert summary["run_id"] == tracer.run_id
+    assert summary["mode"] == "tracer"
+    assert summary["market_series"] == "KXBTC15M"
+    assert summary["decisions"] == 1
+    assert summary["risk_decisions"] == 1
+    assert summary["order_intents"] == 1
+
+    counts = repository.counts()
+    assert counts.runs >= 1
+    assert counts.market_instances >= 1
+    assert counts.decisions >= 1
+    assert counts.risk_decisions >= 1
+    assert counts.order_intents >= 1
+
+
+def test_decision_uniqueness_preserves_one_authoritative_outcome_per_run_instance() -> None:
+    repository = repository_or_skip()
+    repository.apply_migrations()
+    tracer = repository.create_tracer_run(kxbtc15m_spec())
+
+    with pytest.raises(errors.UniqueViolation):
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into decisions (
+                        decision_id,
+                        run_id,
+                        market_ticker,
+                        decision_timestamp,
+                        outcome,
+                        probability_yes,
+                        selected_side,
+                        skip_reason,
+                        metadata
+                    )
+                    values (%s, %s, %s, now(), %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        f"{tracer.decision_id}_duplicate",
+                        tracer.run_id,
+                        tracer.market_ticker,
+                        "skip",
+                        None,
+                        None,
+                        "duplicate",
+                        Jsonb({}),
+                    ),
+                )
+                connection.commit()


### PR DESCRIPTION
## Summary
- add Postgres migrations for platform runs, market instances, decisions, risk decisions, and order intents
- add an OperationalStateRepository that can create and read a complete KXBTC15M tracer run
- expose operational state counts through alphadb-state and the Streamlit dashboard
- test migrations, tracer persistence, counts, and one authoritative decision per run/market instance

## Verification
- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && pytest -q && ruff check . && python - <<"PY"
from alphadb.config import settings_from_env
from alphadb.markets.spec import kxbtc15m_spec
from alphadb.state.repository import OperationalStateRepository
repo = OperationalStateRepository(settings_from_env().database_url)
repo.apply_migrations()
tracer = repo.create_tracer_run(kxbtc15m_spec())
summary = repo.get_run_summary(tracer.run_id)
assert summary["decisions"] == 1
assert summary["risk_decisions"] == 1
assert summary["order_intents"] == 1
print(summary)
print(repo.counts().as_dict())
PY
alphadb-state counts'
- curl -fsS http://localhost:8501/_stcore/health

Stacked on PR #2 / ALP-3.
Linear: ALP-4