### PR TITLE
feat: add raw event log tracer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 alphadb-health = "alphadb.health:main"
 alphadb-markets = "alphadb.markets.cli:main"
 alphadb-state = "alphadb.state.cli:main"
+alphadb-events = "alphadb.events.cli:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import streamlit as st
 
 from alphadb.config import settings_from_env
+from alphadb.events.log import RawEventLog
 from alphadb.health import collect_health
 from alphadb.markets.cli import spec_summary_row
 from alphadb.markets.registry import default_market_registry
@@ -20,6 +21,14 @@ def operational_state_rows(database_url: str) -> list[dict[str, str | int]]:
         {"metric": metric, "value": value, "detail": "postgres"}
         for metric, value in counts.items()
     ]
+
+
+def raw_event_rows(database_url: str) -> list[dict[str, str | int]]:
+    try:
+        rows = RawEventLog(database_url).counts_by_source_schema()
+    except Exception as exc:
+        return [{"source": "raw_events", "schema_version": "unavailable", "events": str(exc)}]
+    return rows or [{"source": "raw_events", "schema_version": "none", "events": 0}]
 
 
 def render() -> None:
@@ -51,6 +60,13 @@ def render() -> None:
     st.subheader("Operational State")
     st.dataframe(
         operational_state_rows(settings.database_url),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+    st.subheader("Raw Events")
+    st.dataframe(
+        raw_event_rows(settings.database_url),
         hide_index=True,
         use_container_width=True,
     )

--- a/src/alphadb/events/__init__.py
+++ b/src/alphadb/events/__init__.py
@@ -1,0 +1,5 @@
+"""Append-only raw event logging."""
+
+from alphadb.events.log import RawEventLog
+
+__all__ = ["RawEventLog"]

--- a/src/alphadb/events/cli.py
+++ b/src/alphadb/events/cli.py
@@ -1,0 +1,45 @@
+"""Command-line tools for raw event logs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+from alphadb.config import settings_from_env
+from alphadb.events.log import RawEventLog
+from alphadb.state.repository import OperationalStateRepository
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-events")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    append_parser = subparsers.add_parser("append-demo", help="Append one demo raw event")
+    append_parser.add_argument("--source", default="demo")
+    append_parser.add_argument("--schema-version", default="demo.v1")
+
+    subparsers.add_parser("counts", help="Show raw event counts by source/schema")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = settings_from_env()
+    OperationalStateRepository(settings.database_url).apply_migrations()
+    event_log = RawEventLog(settings.database_url)
+
+    if args.command == "append-demo":
+        record = event_log.append(
+            source=args.source,
+            schema_version=args.schema_version,
+            payload={"event": "demo"},
+        )
+        print(json.dumps(record.as_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "counts":
+        print(json.dumps(event_log.counts_by_source_schema(), indent=2, sort_keys=True))
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/events/log.py
+++ b/src/alphadb/events/log.py
@@ -1,0 +1,174 @@
+"""Append-only raw event log backed by Postgres."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+
+def canonical_payload_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class RawEventRecord:
+    raw_event_id: str
+    source: str
+    schema_version: str
+    payload_hash: str
+    inserted: bool
+
+    def as_dict(self) -> dict[str, str | bool]:
+        return {
+            "raw_event_id": self.raw_event_id,
+            "source": self.source,
+            "schema_version": self.schema_version,
+            "payload_hash": self.payload_hash,
+            "inserted": self.inserted,
+        }
+
+
+class RawEventLog:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def append(
+        self,
+        *,
+        source: str,
+        schema_version: str,
+        payload: Mapping[str, Any],
+        run_id: str | None = None,
+        market_ticker: str | None = None,
+        source_event_id: str | None = None,
+        received_at: datetime | None = None,
+        source_timestamp: datetime | None = None,
+    ) -> RawEventRecord:
+        event_id = f"evt_{uuid4().hex}"
+        timestamp = received_at or datetime.now(UTC)
+        payload_hash = canonical_payload_hash(payload)
+
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into raw_events (
+                        raw_event_id,
+                        run_id,
+                        market_ticker,
+                        source,
+                        source_event_id,
+                        received_at,
+                        source_timestamp,
+                        schema_version,
+                        payload_hash,
+                        payload
+                    )
+                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    on conflict (source, source_event_id)
+                    where source_event_id is not null
+                    do nothing
+                    returning raw_event_id
+                    """,
+                    (
+                        event_id,
+                        run_id,
+                        market_ticker,
+                        source,
+                        source_event_id,
+                        timestamp,
+                        source_timestamp,
+                        schema_version,
+                        payload_hash,
+                        Jsonb(dict(payload)),
+                    ),
+                )
+                inserted_row = cursor.fetchone()
+                inserted = inserted_row is not None
+                if inserted_row is None:
+                    cursor.execute(
+                        """
+                        select raw_event_id, payload_hash
+                        from raw_events
+                        where source = %s and source_event_id = %s
+                        """,
+                        (source, source_event_id),
+                    )
+                    existing = cursor.fetchone()
+                    if existing is None:
+                        raise RuntimeError("raw event insert neither inserted nor found existing row")
+                    event_id = str(existing["raw_event_id"])
+                    payload_hash = str(existing["payload_hash"])
+            connection.commit()
+
+        return RawEventRecord(
+            raw_event_id=event_id,
+            source=source,
+            schema_version=schema_version,
+            payload_hash=payload_hash,
+            inserted=inserted,
+        )
+
+    def replay_events(
+        self,
+        *,
+        run_id: str | None = None,
+        market_ticker: str | None = None,
+    ) -> Iterable[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[str] = []
+        if run_id is not None:
+            clauses.append("run_id = %s")
+            params.append(run_id)
+        if market_ticker is not None:
+            clauses.append("market_ticker = %s")
+            params.append(market_ticker)
+        where = f"where {' and '.join(clauses)}" if clauses else ""
+
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    select
+                        raw_event_id,
+                        run_id,
+                        market_ticker,
+                        source,
+                        source_event_id,
+                        received_at,
+                        source_timestamp,
+                        schema_version,
+                        payload_hash,
+                        payload
+                    from raw_events
+                    {where}
+                    order by received_at asc, raw_event_id asc
+                    """,
+                    params,
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    def counts_by_source_schema(self) -> list[dict[str, str | int]]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select source, schema_version, count(*)::int as events
+                    from raw_events
+                    group by source, schema_version
+                    order by source, schema_version
+                    """
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]

--- a/src/alphadb/state/migrations.py
+++ b/src/alphadb/state/migrations.py
@@ -85,4 +85,39 @@ INITIAL_OPERATIONAL_STATE = Migration(
 )
 
 
-MIGRATIONS: tuple[Migration, ...] = (INITIAL_OPERATIONAL_STATE,)
+RAW_EVENT_LOG = Migration(
+    version="0002_raw_event_log",
+    statements=(
+        """
+        create table if not exists raw_events (
+            raw_event_id text primary key,
+            run_id text references platform_runs(run_id),
+            market_ticker text references market_instances(market_ticker),
+            source text not null,
+            source_event_id text,
+            received_at timestamptz not null,
+            source_timestamp timestamptz,
+            schema_version text not null,
+            payload_hash text not null,
+            payload jsonb not null,
+            created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create unique index if not exists raw_events_source_event_id_idx
+        on raw_events(source, source_event_id)
+        where source_event_id is not null
+        """,
+        """
+        create index if not exists raw_events_replay_order_idx
+        on raw_events(run_id, market_ticker, received_at, raw_event_id)
+        """,
+        """
+        create index if not exists raw_events_source_schema_idx
+        on raw_events(source, schema_version)
+        """,
+    ),
+)
+
+
+MIGRATIONS: tuple[Migration, ...] = (INITIAL_OPERATIONAL_STATE, RAW_EVENT_LOG)

--- a/tests/test_raw_events.py
+++ b/tests/test_raw_events.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import psycopg
+import pytest
+
+from alphadb.config import settings_from_env
+from alphadb.events.log import RawEventLog, canonical_payload_hash
+from alphadb.markets.spec import kxbtc15m_spec
+from alphadb.state.repository import OperationalStateRepository
+
+
+def event_log_or_skip() -> tuple[OperationalStateRepository, RawEventLog]:
+    repository = OperationalStateRepository(settings_from_env().database_url)
+    try:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    repository.apply_migrations()
+    return repository, RawEventLog(repository.database_url)
+
+
+def test_append_raw_event_records_hash_and_payload_metadata() -> None:
+    repository, event_log = event_log_or_skip()
+    tracer = repository.create_tracer_run(kxbtc15m_spec())
+    payload = {"bid": 49, "ask": 51, "ticker": tracer.market_ticker}
+
+    record = event_log.append(
+        run_id=tracer.run_id,
+        market_ticker=tracer.market_ticker,
+        source="kalshi_rest",
+        source_event_id=f"{tracer.market_ticker}:snapshot:1",
+        schema_version="kalshi.orderbook_snapshot.v1",
+        received_at=datetime(2026, 5, 31, 20, 0, tzinfo=UTC),
+        payload=payload,
+    )
+    replayed = list(event_log.replay_events(run_id=tracer.run_id))
+
+    assert record.inserted is True
+    assert record.payload_hash == canonical_payload_hash(payload)
+    assert len(replayed) == 1
+    assert replayed[0]["source"] == "kalshi_rest"
+    assert replayed[0]["schema_version"] == "kalshi.orderbook_snapshot.v1"
+    assert replayed[0]["payload_hash"] == record.payload_hash
+    assert replayed[0]["payload"] == payload
+
+
+def test_duplicate_source_event_id_is_idempotent() -> None:
+    repository, event_log = event_log_or_skip()
+    tracer = repository.create_tracer_run(kxbtc15m_spec())
+    source_event_id = f"{tracer.market_ticker}:snapshot:duplicate"
+
+    first = event_log.append(
+        run_id=tracer.run_id,
+        market_ticker=tracer.market_ticker,
+        source="kalshi_rest",
+        source_event_id=source_event_id,
+        schema_version="kalshi.orderbook_snapshot.v1",
+        payload={"sequence": 1},
+    )
+    second = event_log.append(
+        run_id=tracer.run_id,
+        market_ticker=tracer.market_ticker,
+        source="kalshi_rest",
+        source_event_id=source_event_id,
+        schema_version="kalshi.orderbook_snapshot.v1",
+        payload={"sequence": 1},
+    )
+
+    assert first.inserted is True
+    assert second.inserted is False
+    assert second.raw_event_id == first.raw_event_id
+    assert len(list(event_log.replay_events(run_id=tracer.run_id))) == 1
+
+
+def test_replay_reader_orders_events_deterministically_and_counts_by_source_schema() -> None:
+    repository, event_log = event_log_or_skip()
+    tracer = repository.create_tracer_run(kxbtc15m_spec())
+    base_time = datetime(2026, 5, 31, 20, 0, tzinfo=UTC)
+
+    later = event_log.append(
+        run_id=tracer.run_id,
+        market_ticker=tracer.market_ticker,
+        source="coinbase",
+        source_event_id=f"{tracer.market_ticker}:coinbase:2",
+        schema_version="coinbase.candle.v1",
+        received_at=base_time + timedelta(seconds=2),
+        payload={"close": 100_001},
+    )
+    earlier = event_log.append(
+        run_id=tracer.run_id,
+        market_ticker=tracer.market_ticker,
+        source="coinbase",
+        source_event_id=f"{tracer.market_ticker}:coinbase:1",
+        schema_version="coinbase.candle.v1",
+        received_at=base_time,
+        payload={"close": 100_000},
+    )
+
+    replayed_ids = [row["raw_event_id"] for row in event_log.replay_events(run_id=tracer.run_id)]
+    assert replayed_ids == [earlier.raw_event_id, later.raw_event_id]
+
+    count_rows = event_log.counts_by_source_schema()
+    assert any(
+        row["source"] == "coinbase"
+        and row["schema_version"] == "coinbase.candle.v1"
+        and row["events"] >= 2
+        for row in count_rows
+    )


### PR DESCRIPTION
## Summary
- add raw_events migration with source/schema indexes and source_event_id idempotency
- add RawEventLog append, replay, payload hashing, and counts APIs
- expose raw event counts through alphadb-events and the Streamlit dashboard
- test payload metadata, idempotent duplicate handling, deterministic replay ordering, and counts

## Verification
- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && pytest -q && ruff check . && alphadb-events append-demo && alphadb-events counts'
- curl -fsS http://localhost:8501/_stcore/health

Stacked on PR #3 / ALP-4.
Linear: ALP-5