### PR TITLE
feat: add REST KXBTC15M collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,22 @@ alphadb-markets list
 alphadb-markets inspect KXBTC15M --json
 ```
 
+Run the bounded, read-only KXBTC15M REST collector smoke with deterministic
+fixture data:
+
+```bash
+alphadb-collect kxbtc15m-smoke --source fixture --max-markets 1
+alphadb-collect status
+```
+
+To opt into Kalshi public market-data endpoints, use
+`--source kalshi-public`. This path only fetches market data and order books;
+it does not have order-entry code.
+
 By default, local Postgres is published on `localhost:55433` and Streamlit on
 `localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
-`ALPHADB_STREAMLIT_PORT` when needed.
+`ALPHADB_STREAMLIT_PORT` when needed. Override the Kalshi REST base URL with
+`ALPHADB_KALSHI_BASE_URL`.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ alphadb-health = "alphadb.health:main"
 alphadb-markets = "alphadb.markets.cli:main"
 alphadb-state = "alphadb.state.cli:main"
 alphadb-events = "alphadb.events.cli:main"
+alphadb-collect = "alphadb.collectors.kalshi_rest:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/src/alphadb/collectors/__init__.py
+++ b/src/alphadb/collectors/__init__.py
@@ -1,0 +1,2 @@
+"""REST-first ingestion collectors for AlphaDB."""
+

--- a/src/alphadb/collectors/kalshi_rest.py
+++ b/src/alphadb/collectors/kalshi_rest.py
@@ -1,0 +1,636 @@
+"""REST-first Kalshi market-data collector.
+
+The collector is intentionally read-only: it discovers markets and records raw
+REST-shaped snapshots, but it has no order-entry dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+from urllib import parse, request
+from uuid import uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from alphadb.config import settings_from_env
+from alphadb.events.log import RawEventLog
+from alphadb.markets.registry import MarketRegistry, default_market_registry
+from alphadb.markets.spec import MarketSpec
+from alphadb.state.repository import OperationalStateRepository
+
+KALSHI_REST_SOURCE = "kalshi_rest"
+MARKET_SNAPSHOT_SCHEMA = "kalshi.market_snapshot.v1"
+ORDERBOOK_SNAPSHOT_SCHEMA = "kalshi.orderbook_snapshot.v1"
+
+
+class KalshiRestClient(Protocol):
+    def list_markets(
+        self,
+        *,
+        series_ticker: str,
+        status: str,
+        limit: int,
+    ) -> Mapping[str, Any]:
+        """Return a Kalshi `GET /markets` compatible payload."""
+
+    def get_orderbook(self, market_ticker: str) -> Mapping[str, Any]:
+        """Return a Kalshi `GET /markets/{ticker}/orderbook` compatible payload."""
+
+
+@dataclass(frozen=True)
+class CollectorError:
+    stage: str
+    message: str
+    market_ticker: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        row = {"stage": self.stage, "message": self.message}
+        if self.market_ticker is not None:
+            row["market_ticker"] = self.market_ticker
+        return row
+
+
+@dataclass(frozen=True)
+class StartedCollectorRun:
+    collector_run_id: str
+    platform_run_id: str
+
+
+@dataclass(frozen=True)
+class CollectorRunSummary:
+    collector_run_id: str
+    platform_run_id: str
+    series: str
+    source: str
+    status: str
+    started_at: datetime
+    finished_at: datetime
+    markets_discovered: int
+    markets_collected: int
+    raw_events_written: int
+    market_tickers: tuple[str, ...]
+    errors: tuple[CollectorError, ...]
+    orders_placed: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "collector_run_id": self.collector_run_id,
+            "platform_run_id": self.platform_run_id,
+            "series": self.series,
+            "source": self.source,
+            "status": self.status,
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat(),
+            "markets_discovered": self.markets_discovered,
+            "markets_collected": self.markets_collected,
+            "raw_events_written": self.raw_events_written,
+            "market_tickers": list(self.market_tickers),
+            "errors": [error.as_dict() for error in self.errors],
+            "orders_placed": self.orders_placed,
+        }
+
+
+class HttpKalshiRestClient:
+    """Tiny public market-data client for Kalshi REST endpoints."""
+
+    def __init__(self, base_url: str, timeout_seconds: float = 10.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+
+    def list_markets(
+        self,
+        *,
+        series_ticker: str,
+        status: str,
+        limit: int,
+    ) -> Mapping[str, Any]:
+        return self._get(
+            "/markets",
+            {
+                "series_ticker": series_ticker,
+                "status": status,
+                "limit": str(limit),
+            },
+        )
+
+    def get_orderbook(self, market_ticker: str) -> Mapping[str, Any]:
+        ticker = parse.quote(market_ticker, safe="")
+        return self._get(f"/markets/{ticker}/orderbook")
+
+    def _get(self, path: str, params: Mapping[str, str] | None = None) -> Mapping[str, Any]:
+        query = f"?{parse.urlencode(params)}" if params else ""
+        url = f"{self.base_url}{path}{query}"
+        http_request = request.Request(
+            url,
+            headers={"Accept": "application/json", "User-Agent": "alphadb/0.1"},
+            method="GET",
+        )
+        with request.urlopen(http_request, timeout=self.timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        if not isinstance(payload, Mapping):
+            raise ValueError(f"Kalshi response was not a JSON object: {url}")
+        return payload
+
+
+class FixtureKalshiRestClient:
+    """Deterministic REST-shaped client for local smoke tests."""
+
+    def __init__(
+        self,
+        *,
+        markets: Sequence[Mapping[str, Any]] | None = None,
+        orderbooks: Mapping[str, Mapping[str, Any]] | None = None,
+    ):
+        self._markets = list(markets) if markets is not None else _default_fixture_markets()
+        self._orderbooks = dict(orderbooks) if orderbooks is not None else _default_fixture_orderbooks()
+        self.list_market_calls: list[dict[str, Any]] = []
+        self.orderbook_calls: list[str] = []
+
+    def list_markets(
+        self,
+        *,
+        series_ticker: str,
+        status: str,
+        limit: int,
+    ) -> Mapping[str, Any]:
+        self.list_market_calls.append(
+            {"series_ticker": series_ticker, "status": status, "limit": limit}
+        )
+        markets = [
+            market
+            for market in self._markets
+            if market.get("series_ticker") == series_ticker and market.get("status") == status
+        ]
+        return {"markets": markets[:limit], "cursor": ""}
+
+    def get_orderbook(self, market_ticker: str) -> Mapping[str, Any]:
+        self.orderbook_calls.append(market_ticker)
+        try:
+            return self._orderbooks[market_ticker]
+        except KeyError as exc:
+            raise KeyError(f"fixture orderbook not found: {market_ticker}") from exc
+
+
+class CollectorRunStore:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def start(
+        self,
+        *,
+        spec: MarketSpec,
+        source: str,
+        started_at: datetime,
+        metadata: Mapping[str, Any],
+    ) -> StartedCollectorRun:
+        suffix = uuid4().hex[:12]
+        platform_run_id = f"run_{suffix}"
+        collector_run_id = f"collector_{suffix}"
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into platform_runs (
+                        run_id, mode, market_series, status, started_at, metadata
+                    )
+                    values (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        platform_run_id,
+                        "rest_collector",
+                        spec.series,
+                        "running",
+                        started_at,
+                        Jsonb({"spec_version": spec.spec_version, **dict(metadata)}),
+                    ),
+                )
+                cursor.execute(
+                    """
+                    insert into collector_runs (
+                        collector_run_id,
+                        platform_run_id,
+                        series,
+                        source,
+                        status,
+                        started_at,
+                        metadata
+                    )
+                    values (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        collector_run_id,
+                        platform_run_id,
+                        spec.series,
+                        source,
+                        "running",
+                        started_at,
+                        Jsonb(dict(metadata)),
+                    ),
+                )
+            connection.commit()
+        return StartedCollectorRun(
+            collector_run_id=collector_run_id,
+            platform_run_id=platform_run_id,
+        )
+
+    def upsert_market_instance(
+        self,
+        *,
+        spec: MarketSpec,
+        market: Mapping[str, Any],
+        observed_at: datetime,
+    ) -> str:
+        market_ticker = str(market["ticker"])
+        open_time = parse_kalshi_datetime(market.get("open_time"), observed_at)
+        close_time = parse_kalshi_datetime(
+            market.get("close_time")
+            or market.get("expected_expiration_time")
+            or market.get("expiration_time"),
+            open_time + timedelta(minutes=spec.horizon_minutes),
+        )
+        status = str(market.get("status") or "unknown")
+        metadata = {
+            "event_ticker": market.get("event_ticker"),
+            "title": market.get("title"),
+            "subtitle": market.get("subtitle"),
+            "yes_bid_dollars": market.get("yes_bid_dollars"),
+            "yes_ask_dollars": market.get("yes_ask_dollars"),
+            "no_bid_dollars": market.get("no_bid_dollars"),
+            "no_ask_dollars": market.get("no_ask_dollars"),
+            "observed_at": observed_at.isoformat(),
+        }
+
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into market_instances (
+                        market_ticker, series, open_time, close_time, status, metadata
+                    )
+                    values (%s, %s, %s, %s, %s, %s)
+                    on conflict (market_ticker) do update set
+                        series = excluded.series,
+                        open_time = excluded.open_time,
+                        close_time = excluded.close_time,
+                        status = excluded.status,
+                        metadata = excluded.metadata
+                    """,
+                    (
+                        market_ticker,
+                        spec.series,
+                        open_time,
+                        close_time,
+                        status,
+                        Jsonb(metadata),
+                    ),
+                )
+            connection.commit()
+        return market_ticker
+
+    def finish(
+        self,
+        *,
+        run: StartedCollectorRun,
+        status: str,
+        finished_at: datetime,
+        markets_discovered: int,
+        markets_collected: int,
+        raw_events_written: int,
+        errors: Sequence[CollectorError],
+    ) -> None:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    update collector_runs
+                    set
+                        status = %s,
+                        finished_at = %s,
+                        markets_discovered = %s,
+                        markets_collected = %s,
+                        raw_events_written = %s,
+                        errors = %s
+                    where collector_run_id = %s
+                    """,
+                    (
+                        status,
+                        finished_at,
+                        markets_discovered,
+                        markets_collected,
+                        raw_events_written,
+                        Jsonb([error.as_dict() for error in errors]),
+                        run.collector_run_id,
+                    ),
+                )
+                cursor.execute(
+                    """
+                    update platform_runs
+                    set status = %s
+                    where run_id = %s
+                    """,
+                    (status, run.platform_run_id),
+                )
+            connection.commit()
+
+    def recent_runs(self, *, limit: int = 10) -> list[dict[str, Any]]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select
+                        collector_run_id,
+                        platform_run_id,
+                        series,
+                        source,
+                        status,
+                        started_at,
+                        finished_at,
+                        markets_discovered,
+                        markets_collected,
+                        raw_events_written,
+                        jsonb_array_length(errors) as errors,
+                        errors->0 as latest_error
+                    from collector_runs
+                    order by started_at desc, collector_run_id desc
+                    limit %s
+                    """,
+                    (limit,),
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+
+class RestKxbtc15mCollector:
+    def __init__(
+        self,
+        *,
+        database_url: str,
+        client: KalshiRestClient,
+        registry: MarketRegistry | None = None,
+        source_mode: str = "fixture",
+    ):
+        self.database_url = database_url
+        self.client = client
+        self.registry = registry or default_market_registry()
+        self.source_mode = source_mode
+        self.repository = OperationalStateRepository(database_url)
+        self.event_log = RawEventLog(database_url)
+        self.run_store = CollectorRunStore(database_url)
+
+    def collect(
+        self,
+        *,
+        series: str = "KXBTC15M",
+        status: str = "open",
+        max_markets: int = 1,
+        now: datetime | None = None,
+    ) -> CollectorRunSummary:
+        if max_markets < 1:
+            raise ValueError("max_markets must be at least 1")
+
+        spec = self.registry.get(series)
+        self.repository.apply_migrations()
+        started_at = now or datetime.now(UTC)
+        run = self.run_store.start(
+            spec=spec,
+            source=KALSHI_REST_SOURCE,
+            started_at=started_at,
+            metadata={"source_mode": self.source_mode, "requested_status": status},
+        )
+
+        errors: list[CollectorError] = []
+        market_tickers: list[str] = []
+        raw_events_written = 0
+        markets_discovered = 0
+
+        try:
+            payload = self.client.list_markets(
+                series_ticker=spec.discovery_rules.series_ticker,
+                status=status,
+                limit=max_markets,
+            )
+            markets = eligible_markets(spec, payload.get("markets", []))
+            markets_discovered = len(markets)
+        except Exception as exc:
+            markets = []
+            errors.append(CollectorError(stage="discover_markets", message=str(exc)))
+
+        for market in markets[:max_markets]:
+            ticker = str(market.get("ticker"))
+            try:
+                market_ticker = self.run_store.upsert_market_instance(
+                    spec=spec,
+                    market=market,
+                    observed_at=started_at,
+                )
+                market_tickers.append(market_ticker)
+                market_event = self.event_log.append(
+                    run_id=run.platform_run_id,
+                    market_ticker=market_ticker,
+                    source=KALSHI_REST_SOURCE,
+                    source_event_id=f"{run.collector_run_id}:{market_ticker}:market",
+                    received_at=started_at,
+                    source_timestamp=parse_kalshi_datetime(market.get("updated_time"), started_at),
+                    schema_version=MARKET_SNAPSHOT_SCHEMA,
+                    payload={
+                        "collector_run_id": run.collector_run_id,
+                        "source_mode": self.source_mode,
+                        "snapshot_type": "market",
+                        "market": dict(market),
+                    },
+                )
+                raw_events_written += int(market_event.inserted)
+
+                orderbook_payload = self.client.get_orderbook(market_ticker)
+                orderbook_event = self.event_log.append(
+                    run_id=run.platform_run_id,
+                    market_ticker=market_ticker,
+                    source=KALSHI_REST_SOURCE,
+                    source_event_id=f"{run.collector_run_id}:{market_ticker}:orderbook",
+                    received_at=started_at,
+                    schema_version=ORDERBOOK_SNAPSHOT_SCHEMA,
+                    payload={
+                        "collector_run_id": run.collector_run_id,
+                        "source_mode": self.source_mode,
+                        "snapshot_type": "orderbook",
+                        "market_ticker": market_ticker,
+                        "orderbook": dict(orderbook_payload),
+                    },
+                )
+                raw_events_written += int(orderbook_event.inserted)
+            except Exception as exc:
+                errors.append(
+                    CollectorError(
+                        stage="collect_market_snapshot",
+                        market_ticker=ticker,
+                        message=str(exc),
+                    )
+                )
+
+        finished_at = datetime.now(UTC)
+        status_value = "completed" if not errors else "completed_with_errors"
+        self.run_store.finish(
+            run=run,
+            status=status_value,
+            finished_at=finished_at,
+            markets_discovered=markets_discovered,
+            markets_collected=len(market_tickers),
+            raw_events_written=raw_events_written,
+            errors=errors,
+        )
+
+        return CollectorRunSummary(
+            collector_run_id=run.collector_run_id,
+            platform_run_id=run.platform_run_id,
+            series=spec.series,
+            source=KALSHI_REST_SOURCE,
+            status=status_value,
+            started_at=started_at,
+            finished_at=finished_at,
+            markets_discovered=markets_discovered,
+            markets_collected=len(market_tickers),
+            raw_events_written=raw_events_written,
+            market_tickers=tuple(market_tickers),
+            errors=tuple(errors),
+        )
+
+
+def eligible_markets(
+    spec: MarketSpec,
+    markets: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    prefix = spec.discovery_rules.market_ticker_prefix
+    return [market for market in markets if str(market.get("ticker", "")).startswith(prefix)]
+
+
+def parse_kalshi_datetime(value: Any, fallback: datetime) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    if isinstance(value, str) and value:
+        normalized = value.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return fallback
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    return fallback
+
+
+def _default_fixture_markets() -> list[Mapping[str, Any]]:
+    return [
+        {
+            "ticker": "KXBTC15M-26MAY312100-00",
+            "series_ticker": "KXBTC15M",
+            "event_ticker": "KXBTC15M-26MAY312100",
+            "status": "open",
+            "open_time": "2026-05-31T21:00:00Z",
+            "close_time": "2026-05-31T21:15:00Z",
+            "updated_time": "2026-05-31T21:12:00Z",
+            "title": "Bitcoin above prior 15 minute mark?",
+            "yes_bid_dollars": "0.4800",
+            "yes_ask_dollars": "0.5200",
+            "no_bid_dollars": "0.4700",
+            "no_ask_dollars": "0.5300",
+        },
+        {
+            "ticker": "KXBTC15M-26MAY312115-15",
+            "series_ticker": "KXBTC15M",
+            "event_ticker": "KXBTC15M-26MAY312115",
+            "status": "open",
+            "open_time": "2026-05-31T21:15:00Z",
+            "close_time": "2026-05-31T21:30:00Z",
+            "updated_time": "2026-05-31T21:12:00Z",
+            "title": "Bitcoin above prior 15 minute mark?",
+            "yes_bid_dollars": "0.4900",
+            "yes_ask_dollars": "0.5100",
+            "no_bid_dollars": "0.4800",
+            "no_ask_dollars": "0.5200",
+        },
+    ]
+
+
+def _default_fixture_orderbooks() -> dict[str, Mapping[str, Any]]:
+    return {
+        "KXBTC15M-26MAY312100-00": {
+            "orderbook_fp": {
+                "yes_dollars": [["0.4800", "14.00"], ["0.4700", "9.00"]],
+                "no_dollars": [["0.4700", "11.00"], ["0.4600", "8.00"]],
+            }
+        },
+        "KXBTC15M-26MAY312115-15": {
+            "orderbook_fp": {
+                "yes_dollars": [["0.4900", "10.00"], ["0.4800", "7.00"]],
+                "no_dollars": [["0.4800", "12.00"], ["0.4700", "5.00"]],
+            }
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-collect")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    smoke_parser = subparsers.add_parser(
+        "kxbtc15m-smoke",
+        help="Run a bounded, read-only KXBTC15M REST collection smoke",
+    )
+    smoke_parser.add_argument("--series", default="KXBTC15M")
+    smoke_parser.add_argument("--status", default="open")
+    smoke_parser.add_argument("--max-markets", type=int, default=1)
+    smoke_parser.add_argument(
+        "--source",
+        choices=("fixture", "kalshi-public"),
+        default="fixture",
+        help="Use deterministic fixture data or Kalshi public REST market-data endpoints",
+    )
+    smoke_parser.add_argument("--base-url", default=None)
+
+    status_parser = subparsers.add_parser("status", help="Show recent collector runs")
+    status_parser.add_argument("--limit", type=int, default=10)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = settings_from_env()
+    repository = OperationalStateRepository(settings.database_url)
+    repository.apply_migrations()
+
+    if args.command == "kxbtc15m-smoke":
+        client: KalshiRestClient
+        if args.source == "fixture":
+            client = FixtureKalshiRestClient()
+        else:
+            client = HttpKalshiRestClient(args.base_url or settings.kalshi_base_url)
+
+        collector = RestKxbtc15mCollector(
+            database_url=settings.database_url,
+            client=client,
+            source_mode=args.source,
+        )
+        summary = collector.collect(
+            series=args.series,
+            status=args.status,
+            max_markets=args.max_markets,
+        )
+        print(json.dumps(summary.as_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "status":
+        rows = CollectorRunStore(settings.database_url).recent_runs(limit=args.limit)
+        print(json.dumps(rows, indent=2, sort_keys=True, default=str))
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/config.py
+++ b/src/alphadb/config.py
@@ -12,6 +12,7 @@ DEFAULT_DATABASE_USER = "alphadb"
 DEFAULT_DATABASE_PASSWORD = "alphadb"
 DEFAULT_DATABASE_HOST = "localhost"
 DEFAULT_DATABASE_PORT = "55433"
+DEFAULT_KALSHI_BASE_URL = "https://external-api.kalshi.com/trade-api/v2"
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,7 @@ class Settings:
     environment: str
     database_url: str
     streamlit_port: str
+    kalshi_base_url: str
 
 
 def settings_from_env(env: Mapping[str, str] | None = None) -> Settings:
@@ -33,4 +35,5 @@ def settings_from_env(env: Mapping[str, str] | None = None) -> Settings:
         environment=values.get("ALPHADB_ENV", "local"),
         database_url=values.get("DATABASE_URL", default_database_url),
         streamlit_port=values.get("ALPHADB_STREAMLIT_PORT", "8501"),
+        kalshi_base_url=values.get("ALPHADB_KALSHI_BASE_URL", DEFAULT_KALSHI_BASE_URL),
     )

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import streamlit as st
 
+from alphadb.collectors.kalshi_rest import CollectorRunStore
 from alphadb.config import settings_from_env
 from alphadb.events.log import RawEventLog
 from alphadb.health import collect_health
@@ -29,6 +30,14 @@ def raw_event_rows(database_url: str) -> list[dict[str, str | int]]:
     except Exception as exc:
         return [{"source": "raw_events", "schema_version": "unavailable", "events": str(exc)}]
     return rows or [{"source": "raw_events", "schema_version": "none", "events": 0}]
+
+
+def collector_status_rows(database_url: str) -> list[dict[str, str | int]]:
+    try:
+        rows = CollectorRunStore(database_url).recent_runs(limit=10)
+    except Exception as exc:
+        return [{"collector_run_id": "collector_runs", "status": "unavailable", "errors": str(exc)}]
+    return rows or [{"collector_run_id": "collector_runs", "status": "none", "errors": 0}]
 
 
 def render() -> None:
@@ -67,6 +76,13 @@ def render() -> None:
     st.subheader("Raw Events")
     st.dataframe(
         raw_event_rows(settings.database_url),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+    st.subheader("Collectors")
+    st.dataframe(
+        collector_status_rows(settings.database_url),
         hide_index=True,
         use_container_width=True,
     )

--- a/src/alphadb/state/migrations.py
+++ b/src/alphadb/state/migrations.py
@@ -120,4 +120,40 @@ RAW_EVENT_LOG = Migration(
 )
 
 
-MIGRATIONS: tuple[Migration, ...] = (INITIAL_OPERATIONAL_STATE, RAW_EVENT_LOG)
+COLLECTOR_RUNS = Migration(
+    version="0003_collector_runs",
+    statements=(
+        """
+        create table if not exists collector_runs (
+            collector_run_id text primary key,
+            platform_run_id text not null references platform_runs(run_id),
+            series text not null,
+            source text not null,
+            status text not null,
+            started_at timestamptz not null,
+            finished_at timestamptz,
+            markets_discovered integer not null default 0,
+            markets_collected integer not null default 0,
+            raw_events_written integer not null default 0,
+            errors jsonb not null default '[]'::jsonb,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create index if not exists collector_runs_series_started_at_idx
+        on collector_runs(series, started_at desc)
+        """,
+        """
+        create index if not exists collector_runs_status_idx
+        on collector_runs(status)
+        """,
+    ),
+)
+
+
+MIGRATIONS: tuple[Migration, ...] = (
+    INITIAL_OPERATIONAL_STATE,
+    RAW_EVENT_LOG,
+    COLLECTOR_RUNS,
+)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ def test_settings_default_database_url_uses_configurable_local_port() -> None:
 
     assert settings.database_url == "postgresql://alphadb:alphadb@localhost:55433/alphadb"
     assert settings.streamlit_port == "8501"
+    assert settings.kalshi_base_url == "https://external-api.kalshi.com/trade-api/v2"
 
 
 def test_settings_database_url_can_be_overridden() -> None:
@@ -14,9 +15,11 @@ def test_settings_database_url_can_be_overridden() -> None:
             "DATABASE_URL": "postgresql://user:pass@postgres:5432/custom",
             "ALPHADB_ENV": "test",
             "ALPHADB_STREAMLIT_PORT": "18501",
+            "ALPHADB_KALSHI_BASE_URL": "https://example.test/trade-api/v2",
         }
     )
 
     assert settings.database_url == "postgresql://user:pass@postgres:5432/custom"
     assert settings.environment == "test"
     assert settings.streamlit_port == "18501"
+    assert settings.kalshi_base_url == "https://example.test/trade-api/v2"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -17,6 +17,7 @@ def test_collect_health_reports_ok_when_components_are_ok() -> None:
         environment="test",
         database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
         streamlit_port="8501",
+        kalshi_base_url="https://external-api.kalshi.com/trade-api/v2",
     )
 
     report = collect_health(
@@ -41,6 +42,7 @@ def test_collect_health_reports_error_when_database_is_unavailable() -> None:
         environment="test",
         database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
         streamlit_port="8501",
+        kalshi_base_url="https://external-api.kalshi.com/trade-api/v2",
     )
 
     report = collect_health(

--- a/tests/test_kalshi_rest_collector.py
+++ b/tests/test_kalshi_rest_collector.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+import psycopg
+import pytest
+
+from alphadb.collectors.kalshi_rest import (
+    FixtureKalshiRestClient,
+    RestKxbtc15mCollector,
+    eligible_markets,
+)
+from alphadb.config import settings_from_env
+from alphadb.events.log import RawEventLog
+from alphadb.markets.spec import kxbtc15m_spec
+from alphadb.state.repository import OperationalStateRepository
+
+
+def collector_or_skip(
+    client: FixtureKalshiRestClient,
+) -> tuple[OperationalStateRepository, RestKxbtc15mCollector]:
+    repository = OperationalStateRepository(settings_from_env().database_url)
+    try:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    repository.apply_migrations()
+    return repository, RestKxbtc15mCollector(
+        database_url=repository.database_url,
+        client=client,
+        source_mode="fixture",
+    )
+
+
+def test_collector_discovers_kxbtc15m_through_registry_and_logs_snapshots() -> None:
+    client = FixtureKalshiRestClient()
+    repository, collector = collector_or_skip(client)
+
+    summary = collector.collect(
+        series="KXBTC15M",
+        max_markets=1,
+        now=datetime(2026, 5, 31, 21, 12, tzinfo=UTC),
+    )
+    replayed = list(RawEventLog(repository.database_url).replay_events(run_id=summary.platform_run_id))
+
+    assert client.list_market_calls == [
+        {"series_ticker": "KXBTC15M", "status": "open", "limit": 1}
+    ]
+    assert client.orderbook_calls == ["KXBTC15M-26MAY312100-00"]
+    assert summary.status == "completed"
+    assert summary.market_tickers == ("KXBTC15M-26MAY312100-00",)
+    assert summary.markets_discovered == 1
+    assert summary.markets_collected == 1
+    assert summary.raw_events_written == 2
+    assert summary.orders_placed == 0
+    assert {row["schema_version"] for row in replayed} == {
+        "kalshi.market_snapshot.v1",
+        "kalshi.orderbook_snapshot.v1",
+    }
+    assert all(row["source"] == "kalshi_rest" for row in replayed)
+
+
+def test_collector_persists_status_and_recent_errors() -> None:
+    class MissingOrderbookClient(FixtureKalshiRestClient):
+        def get_orderbook(self, market_ticker: str) -> Mapping[str, Any]:
+            raise RuntimeError(f"orderbook unavailable: {market_ticker}")
+
+    _repository, collector = collector_or_skip(MissingOrderbookClient())
+
+    summary = collector.collect(
+        series="KXBTC15M",
+        max_markets=1,
+        now=datetime(2026, 5, 31, 21, 12, tzinfo=UTC),
+    )
+    recent_runs = collector.run_store.recent_runs(limit=25)
+    current_run = next(
+        row for row in recent_runs if row["collector_run_id"] == summary.collector_run_id
+    )
+
+    assert summary.status == "completed_with_errors"
+    assert summary.markets_collected == 1
+    assert summary.raw_events_written == 1
+    assert summary.orders_placed == 0
+    assert summary.errors[0].stage == "collect_market_snapshot"
+    assert current_run["status"] == "completed_with_errors"
+    assert current_run["errors"] == 1
+
+
+def test_eligible_markets_are_filtered_by_marketspec_prefix() -> None:
+    spec = kxbtc15m_spec()
+
+    rows = eligible_markets(
+        spec,
+        [
+            {"ticker": "KXBTC15M-26MAY312100-00"},
+            {"ticker": "KXETH15M-26MAY312100-00"},
+            {"ticker": ""},
+        ],
+    )
+
+    assert rows == [{"ticker": "KXBTC15M-26MAY312100-00"}]


### PR DESCRIPTION
## Summary
- Adds a read-only REST-first KXBTC15M collector with fixture and public Kalshi REST clients.
- Persists collector run status, discovered/collected counts, raw event writes, and recent errors.
- Records market and orderbook snapshots into the raw event log with explicit source/schema metadata.
- Adds CLI smoke/status commands and dashboard collector status output.

## Verification
- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && pytest -q && ruff check .'\n- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && alphadb-collect kxbtc15m-smoke --source fixture --max-markets 1 && alphadb-collect status --limit 3 && alphadb-events counts'\n- docker compose --profile dashboard up -d streamlit && curl -fsS http://localhost:${ALPHADB_STREAMLIT_PORT:-8501}/_stcore/health\n- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && alphadb-collect kxbtc15m-smoke --source kalshi-public --max-markets 1'\n\nLinear: ALP-6