### PR TITLE
feat: add risk gate tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ alphadb-decide evaluate \
 alphadb-decide list --run-id <run_id>
 ```
 
+Apply the fail-closed risk gate and create an approved order intent only when
+policy allows it:
+
+```bash
+alphadb-risk evaluate \
+  --decision-id <decision_id> \
+  --realized-pnl-dollars 0
+alphadb-risk list --decision-id <decision_id>
+```
+
 By default, local Postgres is published on `localhost:55433` and Streamlit on
 `localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
 `ALPHADB_STREAMLIT_PORT` when needed. Override the Kalshi REST base URL with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ alphadb-collect = "alphadb.collectors.kalshi_rest:main"
 alphadb-models = "alphadb.model_registry.registry:main"
 alphadb-features = "alphadb.features.ledger:main"
 alphadb-decide = "alphadb.decision_engine.engine:main"
+alphadb-risk = "alphadb.risk.gate:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -13,6 +13,7 @@ from alphadb.health import collect_health
 from alphadb.markets.cli import spec_summary_row
 from alphadb.markets.registry import default_market_registry
 from alphadb.model_registry.registry import ModelRegistryRepository
+from alphadb.risk.gate import RiskDecisionRepository
 from alphadb.state.repository import OperationalStateRepository
 
 
@@ -65,6 +66,14 @@ def decision_rows(database_url: str) -> list[dict[str, str | int]]:
     except Exception as exc:
         return [{"decision_id": "decisions", "detail": str(exc)}]
     return rows or [{"decision_id": "decisions", "detail": "none"}]
+
+
+def risk_rows(database_url: str) -> list[dict[str, str | int]]:
+    try:
+        rows = RiskDecisionRepository(database_url).list()
+    except Exception as exc:
+        return [{"risk_decision_id": "risk_decisions", "detail": str(exc)}]
+    return rows or [{"risk_decision_id": "risk_decisions", "detail": "none"}]
 
 
 def render() -> None:
@@ -131,6 +140,13 @@ def render() -> None:
     st.subheader("Decisions")
     st.dataframe(
         decision_rows(settings.database_url),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+    st.subheader("Risk")
+    st.dataframe(
+        risk_rows(settings.database_url),
         hide_index=True,
         use_container_width=True,
     )

--- a/src/alphadb/decision_engine/engine.py
+++ b/src/alphadb/decision_engine/engine.py
@@ -279,6 +279,22 @@ class DecisionRepository:
                 rows = cursor.fetchall()
         return [dict(row) for row in rows]
 
+    def get(self, decision_id: str) -> DecisionResult:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select *
+                    from decisions
+                    where decision_id = %s
+                    """,
+                    (decision_id,),
+                )
+                row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"unknown decision_id: {decision_id}")
+        return decision_row_to_result(row)
+
     def _fetch_by_identity(
         self,
         cursor: psycopg.Cursor,

--- a/src/alphadb/risk/__init__.py
+++ b/src/alphadb/risk/__init__.py
@@ -1,0 +1,2 @@
+"""Risk gates and sizing policies."""
+

--- a/src/alphadb/risk/gate.py
+++ b/src/alphadb/risk/gate.py
@@ -1,0 +1,380 @@
+"""Fail-closed risk gate and sizing tracer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from alphadb.config import settings_from_env
+from alphadb.decision_engine.engine import DecisionRepository, DecisionResult
+from alphadb.markets.registry import default_market_registry
+from alphadb.markets.spec import MarketSpec
+from alphadb.state.repository import OperationalStateRepository
+
+RiskStatus = Literal["approved", "denied"]
+
+
+@dataclass(frozen=True)
+class RiskPolicy:
+    max_daily_loss_dollars: float
+    per_trade_max_cost_dollars: float
+    fail_closed: bool
+    time_in_force: str
+
+    @classmethod
+    def from_spec(cls, spec: MarketSpec) -> RiskPolicy:
+        return cls(
+            max_daily_loss_dollars=spec.risk_config.max_daily_loss_dollars,
+            per_trade_max_cost_dollars=spec.risk_config.live_stake_cap_dollars,
+            fail_closed=True,
+            time_in_force=spec.trading_cutoffs.time_in_force,
+        )
+
+
+@dataclass(frozen=True)
+class RiskState:
+    trading_day: date
+    realized_pnl_dollars: float
+
+
+@dataclass(frozen=True)
+class OrderIntentDraft:
+    order_intent_id: str
+    side: str
+    price_dollars: float
+    quantity: int
+    max_cost_dollars: float
+    time_in_force: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "order_intent_id": self.order_intent_id,
+            "side": self.side,
+            "price_dollars": self.price_dollars,
+            "quantity": self.quantity,
+            "max_cost_dollars": self.max_cost_dollars,
+            "time_in_force": self.time_in_force,
+        }
+
+
+@dataclass(frozen=True)
+class RiskDecisionResult:
+    risk_decision_id: str
+    decision_id: str
+    status: RiskStatus
+    reason: str | None
+    order_intent: OrderIntentDraft | None
+    payload: Mapping[str, Any]
+    inserted: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "risk_decision_id": self.risk_decision_id,
+            "decision_id": self.decision_id,
+            "status": self.status,
+            "reason": self.reason,
+            "order_intent": None if self.order_intent is None else self.order_intent.as_dict(),
+            "payload": dict(self.payload),
+            "inserted": self.inserted,
+        }
+
+
+class RiskGate:
+    gate_version = "risk_gate.v1"
+
+    def evaluate(
+        self,
+        *,
+        decision: DecisionResult,
+        policy: RiskPolicy,
+        state: RiskState | None,
+    ) -> RiskDecisionResult:
+        payload: dict[str, Any] = {
+            "gate_version": self.gate_version,
+            "market_ticker": decision.market_ticker,
+            "run_id": decision.run_id,
+            "policy": {
+                "max_daily_loss_dollars": policy.max_daily_loss_dollars,
+                "per_trade_max_cost_dollars": policy.per_trade_max_cost_dollars,
+                "fail_closed": policy.fail_closed,
+            },
+        }
+
+        if state is None:
+            if policy.fail_closed:
+                return denied(decision, "missing_risk_state", payload)
+            state = RiskState(trading_day=date.today(), realized_pnl_dollars=0.0)
+        payload["state"] = {
+            "trading_day": state.trading_day.isoformat(),
+            "realized_pnl_dollars": state.realized_pnl_dollars,
+        }
+
+        realized_loss = max(0.0, -state.realized_pnl_dollars)
+        if realized_loss >= policy.max_daily_loss_dollars:
+            return denied(decision, "daily_loss_limit", payload)
+        if decision.outcome != "order_candidate":
+            return denied(decision, "decision_skip", payload)
+        if decision.selected_side is None or decision.selected_price_dollars is None:
+            return denied(decision, "missing_order_candidate", payload)
+
+        quantity = risk_sized_quantity(
+            decision_quantity=decision.intended_quantity,
+            selected_price_dollars=decision.selected_price_dollars,
+            per_trade_max_cost_dollars=policy.per_trade_max_cost_dollars,
+        )
+        if quantity < 1:
+            return denied(decision, "per_trade_limit", payload)
+
+        max_cost = float(Decimal(str(quantity)) * Decimal(str(decision.selected_price_dollars)))
+        payload["sizing"] = {
+            "decision_quantity": decision.intended_quantity,
+            "approved_quantity": quantity,
+            "selected_price_dollars": decision.selected_price_dollars,
+            "max_cost_dollars": max_cost,
+        }
+        return RiskDecisionResult(
+            risk_decision_id=f"risk_{uuid4().hex[:12]}",
+            decision_id=decision.decision_id,
+            status="approved",
+            reason=None,
+            order_intent=OrderIntentDraft(
+                order_intent_id=f"intent_{uuid4().hex[:12]}",
+                side=decision.selected_side,
+                price_dollars=decision.selected_price_dollars,
+                quantity=quantity,
+                max_cost_dollars=max_cost,
+                time_in_force=policy.time_in_force,
+            ),
+            payload=payload,
+        )
+
+
+class RiskDecisionRepository:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def persist(self, result: RiskDecisionResult) -> RiskDecisionResult:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into risk_decisions (
+                        risk_decision_id, decision_id, status, reason, payload
+                    )
+                    values (%s, %s, %s, %s, %s)
+                    on conflict (decision_id) do nothing
+                    returning *
+                    """,
+                    (
+                        result.risk_decision_id,
+                        result.decision_id,
+                        result.status,
+                        result.reason,
+                        Jsonb(dict(result.payload)),
+                    ),
+                )
+                row = cursor.fetchone()
+                inserted = row is not None
+                if row is not None and result.order_intent is not None:
+                    cursor.execute(
+                        """
+                        insert into order_intents (
+                            order_intent_id,
+                            risk_decision_id,
+                            side,
+                            price,
+                            quantity,
+                            max_cost_dollars,
+                            time_in_force
+                        )
+                        values (%s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            result.order_intent.order_intent_id,
+                            result.risk_decision_id,
+                            result.order_intent.side,
+                            result.order_intent.price_dollars,
+                            result.order_intent.quantity,
+                            result.order_intent.max_cost_dollars,
+                            result.order_intent.time_in_force,
+                        ),
+                    )
+                stored = self._fetch_by_decision_id(cursor, result.decision_id)
+                stored = {**stored, "inserted": inserted}
+            connection.commit()
+        return row_to_risk_decision(stored)
+
+    def list(self, *, decision_id: str | None = None) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[str] = []
+        if decision_id is not None:
+            clauses.append("rd.decision_id = %s")
+            params.append(decision_id)
+        where = f"where {' and '.join(clauses)}" if clauses else ""
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    select
+                        rd.risk_decision_id,
+                        rd.decision_id,
+                        d.run_id,
+                        d.market_ticker,
+                        rd.status,
+                        rd.reason,
+                        rd.payload,
+                        oi.order_intent_id,
+                        oi.side,
+                        oi.price,
+                        oi.quantity,
+                        oi.max_cost_dollars,
+                        oi.time_in_force
+                    from risk_decisions rd
+                    join decisions d on d.decision_id = rd.decision_id
+                    left join order_intents oi on oi.risk_decision_id = rd.risk_decision_id
+                    {where}
+                    order by rd.created_at desc, rd.risk_decision_id desc
+                    """,
+                    params,
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    def _fetch_by_decision_id(
+        self,
+        cursor: psycopg.Cursor,
+        decision_id: str,
+    ) -> Mapping[str, Any]:
+        cursor.execute(
+            """
+            select
+                rd.*,
+                oi.order_intent_id,
+                oi.side,
+                oi.price,
+                oi.quantity,
+                oi.max_cost_dollars,
+                oi.time_in_force
+            from risk_decisions rd
+            left join order_intents oi on oi.risk_decision_id = rd.risk_decision_id
+            where rd.decision_id = %s
+            """,
+            (decision_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("risk decision conflict neither inserted nor found existing row")
+        return row
+
+
+def denied(
+    decision: DecisionResult,
+    reason: str,
+    payload: Mapping[str, Any],
+) -> RiskDecisionResult:
+    return RiskDecisionResult(
+        risk_decision_id=f"risk_{uuid4().hex[:12]}",
+        decision_id=decision.decision_id,
+        status="denied",
+        reason=reason,
+        order_intent=None,
+        payload=payload,
+    )
+
+
+def risk_sized_quantity(
+    *,
+    decision_quantity: int,
+    selected_price_dollars: float,
+    per_trade_max_cost_dollars: float,
+) -> int:
+    if selected_price_dollars <= 0:
+        return 0
+    budget_quantity = int(
+        Decimal(str(per_trade_max_cost_dollars)) // Decimal(str(selected_price_dollars))
+    )
+    return min(decision_quantity, budget_quantity)
+
+
+def row_to_risk_decision(row: Mapping[str, Any]) -> RiskDecisionResult:
+    values = dict(row)
+    order_intent = None
+    if values.get("order_intent_id") is not None:
+        order_intent = OrderIntentDraft(
+            order_intent_id=str(values["order_intent_id"]),
+            side=str(values["side"]),
+            price_dollars=float(values["price"]),
+            quantity=int(values["quantity"]),
+            max_cost_dollars=float(values["max_cost_dollars"]),
+            time_in_force=str(values["time_in_force"]),
+        )
+    return RiskDecisionResult(
+        risk_decision_id=str(values["risk_decision_id"]),
+        decision_id=str(values["decision_id"]),
+        status=values["status"],
+        reason=values["reason"],
+        order_intent=order_intent,
+        payload=dict(values["payload"]),
+        inserted=bool(values.get("inserted", True)),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-risk")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    evaluate_parser = subparsers.add_parser("evaluate", help="Evaluate and persist risk decision")
+    evaluate_parser.add_argument("--decision-id", required=True)
+    evaluate_parser.add_argument("--series", default="KXBTC15M")
+    evaluate_parser.add_argument("--realized-pnl-dollars", type=float, default=0.0)
+    evaluate_parser.add_argument("--trading-day", default=None)
+
+    list_parser = subparsers.add_parser("list", help="List risk decisions")
+    list_parser.add_argument("--decision-id", default=None)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = settings_from_env()
+    OperationalStateRepository(settings.database_url).apply_migrations()
+    repository = RiskDecisionRepository(settings.database_url)
+
+    if args.command == "evaluate":
+        spec = default_market_registry().get(args.series)
+        trading_day = date.fromisoformat(args.trading_day) if args.trading_day else date.today()
+        decision = DecisionRepository(settings.database_url).get(args.decision_id)
+        result = RiskGate().evaluate(
+            decision=decision,
+            policy=RiskPolicy.from_spec(spec),
+            state=RiskState(
+                trading_day=trading_day,
+                realized_pnl_dollars=args.realized_pnl_dollars,
+            ),
+        )
+        print(json.dumps(repository.persist(result).as_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "list":
+        print(
+            json.dumps(
+                repository.list(decision_id=args.decision_id),
+                indent=2,
+                sort_keys=True,
+                default=str,
+            )
+        )
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -1,0 +1,187 @@
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from alphadb.collectors.kalshi_rest import FixtureKalshiRestClient, RestKxbtc15mCollector
+from alphadb.config import settings_from_env
+from alphadb.decision_engine.engine import DecisionEngine, DecisionRepository, build_decision_input
+from alphadb.features.ledger import FeatureRowBuilder
+from alphadb.markets.spec import kxbtc15m_spec
+from alphadb.model_registry.registry import ModelRegistration, ModelRegistryRepository
+from alphadb.risk.gate import (
+    RiskDecisionRepository,
+    RiskGate,
+    RiskPolicy,
+    RiskState,
+)
+from alphadb.state.repository import OperationalStateRepository
+
+
+def risk_dependencies_or_skip() -> tuple[OperationalStateRepository, ModelRegistryRepository]:
+    repository = OperationalStateRepository(settings_from_env().database_url)
+    try:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    repository.apply_migrations()
+    return repository, ModelRegistryRepository(repository.database_url)
+
+
+def persisted_decision(
+    repository: OperationalStateRepository,
+    registry: ModelRegistryRepository,
+    *,
+    probability_yes: float = 0.65,
+    yes_ask_dollars: float = 0.52,
+    no_ask_dollars: float = 0.53,
+):
+    model = registry.register(
+        ModelRegistration(
+            series="KXBTC15M",
+            model_name="risk-gate-test",
+            model_version=f"v-{uuid4().hex}",
+            artifact_uri="artifacts/models/risk-gate-test/model.joblib",
+            artifact_sha256="1" * 64,
+            feature_version="features.kxbtc15m.v1",
+            calibration_version="calibration.none.v1",
+            dataset_id="dataset_risk_gate_v1",
+        )
+    )
+    collector = RestKxbtc15mCollector(
+        database_url=repository.database_url,
+        client=FixtureKalshiRestClient(),
+        source_mode="fixture",
+    )
+    summary = collector.collect(
+        series="KXBTC15M",
+        max_markets=1,
+        now=datetime(2026, 5, 31, 21, 12, tzinfo=UTC),
+    )
+    feature_row = FeatureRowBuilder(repository.database_url).build(
+        run_id=summary.platform_run_id,
+        market_ticker=summary.market_tickers[0],
+        model_id=model.model_id,
+        decision_timestamp=datetime(2026, 5, 31, 21, 13, tzinfo=UTC),
+    )
+    decision = DecisionEngine().evaluate(
+        build_decision_input(
+            spec=kxbtc15m_spec(),
+            feature_row=feature_row,
+            probability_yes=probability_yes,
+            yes_ask_dollars=yes_ask_dollars,
+            no_ask_dollars=no_ask_dollars,
+        )
+    )
+    return DecisionRepository(repository.database_url).persist(decision)
+
+
+def test_risk_gate_approves_trade_and_persists_order_intent() -> None:
+    repository, registry = risk_dependencies_or_skip()
+    decision = persisted_decision(repository, registry)
+    spec = kxbtc15m_spec()
+    result = RiskGate().evaluate(
+        decision=decision,
+        policy=RiskPolicy.from_spec(spec),
+        state=RiskState(trading_day=date(2026, 5, 31), realized_pnl_dollars=0.0),
+    )
+    persisted = RiskDecisionRepository(repository.database_url).persist(result)
+    rows = RiskDecisionRepository(repository.database_url).list(decision_id=decision.decision_id)
+
+    assert persisted.inserted is True
+    assert persisted.status == "approved"
+    assert persisted.reason is None
+    assert persisted.order_intent is not None
+    assert persisted.order_intent.side == "yes"
+    assert persisted.order_intent.quantity == 1
+    assert persisted.order_intent.max_cost_dollars == pytest.approx(0.52)
+    assert rows[0]["status"] == "approved"
+    assert rows[0]["order_intent_id"] == persisted.order_intent.order_intent_id
+
+
+def test_risk_gate_denies_decision_skip_and_too_small_trade_budget() -> None:
+    repository, registry = risk_dependencies_or_skip()
+    skipped_decision = persisted_decision(
+        repository,
+        registry,
+        probability_yes=0.51,
+        yes_ask_dollars=0.52,
+        no_ask_dollars=0.51,
+    )
+    trade_decision = persisted_decision(repository, registry)
+    spec = kxbtc15m_spec()
+    tiny_budget_policy = RiskPolicy(
+        max_daily_loss_dollars=spec.risk_config.max_daily_loss_dollars,
+        per_trade_max_cost_dollars=0.25,
+        fail_closed=True,
+        time_in_force=spec.trading_cutoffs.time_in_force,
+    )
+
+    skipped = RiskGate().evaluate(
+        decision=skipped_decision,
+        policy=RiskPolicy.from_spec(spec),
+        state=RiskState(trading_day=date(2026, 5, 31), realized_pnl_dollars=0.0),
+    )
+    too_small = RiskGate().evaluate(
+        decision=trade_decision,
+        policy=tiny_budget_policy,
+        state=RiskState(trading_day=date(2026, 5, 31), realized_pnl_dollars=0.0),
+    )
+
+    assert skipped.status == "denied"
+    assert skipped.reason == "decision_skip"
+    assert skipped.order_intent is None
+    assert too_small.status == "denied"
+    assert too_small.reason == "per_trade_limit"
+    assert too_small.order_intent is None
+
+
+def test_risk_gate_enforces_daily_loss_limit_and_missing_state_fail_closed() -> None:
+    repository, registry = risk_dependencies_or_skip()
+    decision = persisted_decision(repository, registry)
+    spec = kxbtc15m_spec()
+
+    loss_limit = RiskGate().evaluate(
+        decision=decision,
+        policy=RiskPolicy.from_spec(spec),
+        state=RiskState(
+            trading_day=date(2026, 5, 31),
+            realized_pnl_dollars=-spec.risk_config.max_daily_loss_dollars,
+        ),
+    )
+    missing_state = RiskGate().evaluate(
+        decision=decision,
+        policy=RiskPolicy.from_spec(spec),
+        state=None,
+    )
+
+    assert loss_limit.status == "denied"
+    assert loss_limit.reason == "daily_loss_limit"
+    assert missing_state.status == "denied"
+    assert missing_state.reason == "missing_risk_state"
+
+
+def test_risk_gate_duplicate_instance_protection_returns_existing_authoritative_outcome() -> None:
+    repository, registry = risk_dependencies_or_skip()
+    decision = persisted_decision(repository, registry)
+    spec = kxbtc15m_spec()
+    repository_ = RiskDecisionRepository(repository.database_url)
+    result = RiskGate().evaluate(
+        decision=decision,
+        policy=RiskPolicy.from_spec(spec),
+        state=RiskState(trading_day=date(2026, 5, 31), realized_pnl_dollars=0.0),
+    )
+
+    first = repository_.persist(result)
+    second = repository_.persist(result)
+
+    assert first.inserted is True
+    assert second.inserted is False
+    assert second.risk_decision_id == first.risk_decision_id
+    assert second.order_intent is not None
+    assert first.order_intent is not None
+    assert second.order_intent.order_intent_id == first.order_intent.order_intent_id


### PR DESCRIPTION
## Summary
- Adds a fail-closed risk gate and sizing tracer over persisted decision candidates.
- Enforces daily realized loss, per-trade budget, missing-state denial, and duplicate decision protection.
- Persists risk decisions and approved order intents into the existing operational state path.
- Adds CLI and dashboard visibility for approved/denied risk outcomes.

## Verification
- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && pytest -q && ruff check .'\n- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && alphadb-risk evaluate --decision-id dec_eaa8416bfb8f --realized-pnl-dollars 0 --trading-day 2026-05-31 && alphadb-risk list --decision-id dec_eaa8416bfb8f'\n- docker compose --profile dashboard up -d streamlit && curl -fsS http://localhost:${ALPHADB_STREAMLIT_PORT:-8501}/_stcore/health\n\nLinear: ALP-10