### PR TITLE
feat: add paper IOC execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ alphadb-risk evaluate \
 alphadb-risk list --decision-id <decision_id>
 ```
 
+Run paper-only taker IOC execution and reconciliation:
+
+```bash
+alphadb-paper execute \
+  --order-intent-id <order_intent_id> \
+  --side yes \
+  --available-price-dollars 0.52 \
+  --available-quantity 1
+alphadb-paper status
+```
+
 By default, local Postgres is published on `localhost:55433` and Streamlit on
 `localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
 `ALPHADB_STREAMLIT_PORT` when needed. Override the Kalshi REST base URL with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ alphadb-models = "alphadb.model_registry.registry:main"
 alphadb-features = "alphadb.features.ledger:main"
 alphadb-decide = "alphadb.decision_engine.engine:main"
 alphadb-risk = "alphadb.risk.gate:main"
+alphadb-paper = "alphadb.paper.ioc:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -13,6 +13,7 @@ from alphadb.health import collect_health
 from alphadb.markets.cli import spec_summary_row
 from alphadb.markets.registry import default_market_registry
 from alphadb.model_registry.registry import ModelRegistryRepository
+from alphadb.paper.ioc import PaperExecutionRepository
 from alphadb.risk.gate import RiskDecisionRepository
 from alphadb.state.repository import OperationalStateRepository
 
@@ -74,6 +75,20 @@ def risk_rows(database_url: str) -> list[dict[str, str | int]]:
     except Exception as exc:
         return [{"risk_decision_id": "risk_decisions", "detail": str(exc)}]
     return rows or [{"risk_decision_id": "risk_decisions", "detail": "none"}]
+
+
+def paper_status_rows(database_url: str) -> dict[str, list[dict[str, str | int]]]:
+    try:
+        repository = PaperExecutionRepository(database_url)
+        return {
+            "orders": repository.list_orders(),
+            "fills": repository.list_fills(),
+            "positions": repository.list_positions(),
+            "reconciliations": repository.list_reconciliations(),
+        }
+    except Exception as exc:
+        row = [{"paper": "unavailable", "detail": str(exc)}]
+        return {"orders": row, "fills": row, "positions": row, "reconciliations": row}
 
 
 def render() -> None:
@@ -150,6 +165,16 @@ def render() -> None:
         hide_index=True,
         use_container_width=True,
     )
+
+    paper = paper_status_rows(settings.database_url)
+    st.subheader("Paper Orders")
+    st.dataframe(paper["orders"], hide_index=True, use_container_width=True)
+    st.subheader("Paper Fills")
+    st.dataframe(paper["fills"], hide_index=True, use_container_width=True)
+    st.subheader("Paper Positions")
+    st.dataframe(paper["positions"], hide_index=True, use_container_width=True)
+    st.subheader("Paper Reconciliation")
+    st.dataframe(paper["reconciliations"], hide_index=True, use_container_width=True)
 
     st.caption(f"Generated {report.generated_at_utc.isoformat()}")
 

--- a/src/alphadb/paper/__init__.py
+++ b/src/alphadb/paper/__init__.py
@@ -1,0 +1,2 @@
+"""Paper execution and reconciliation."""
+

--- a/src/alphadb/paper/ioc.py
+++ b/src/alphadb/paper/ioc.py
@@ -1,0 +1,535 @@
+"""Paper taker-only IOC execution and reconciliation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from alphadb.config import settings_from_env
+from alphadb.state.repository import OperationalStateRepository
+
+PaperOrderStatus = Literal["filled", "partial", "unfilled"]
+
+
+@dataclass(frozen=True)
+class ApprovedOrderIntent:
+    order_intent_id: str
+    risk_decision_id: str
+    market_ticker: str
+    side: Literal["yes", "no"]
+    limit_price_dollars: float
+    quantity: int
+    max_cost_dollars: float
+    time_in_force: str
+
+
+@dataclass(frozen=True)
+class PaperLiquidity:
+    side: Literal["yes", "no"]
+    available_price_dollars: float | None
+    available_quantity: int
+    mark_price_dollars: float | None = None
+
+
+@dataclass(frozen=True)
+class PaperExecutionResult:
+    paper_order_id: str
+    order_intent_id: str
+    market_ticker: str
+    side: Literal["yes", "no"]
+    status: PaperOrderStatus
+    limit_price_dollars: float
+    requested_quantity: int
+    filled_quantity: int
+    fill_price_dollars: float | None
+    position_quantity: int
+    realized_pnl_dollars: float
+    unrealized_pnl_dollars: float
+    reconciliation_id: str
+    live_orders_sent: int = 0
+    inserted: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "paper_order_id": self.paper_order_id,
+            "order_intent_id": self.order_intent_id,
+            "market_ticker": self.market_ticker,
+            "side": self.side,
+            "status": self.status,
+            "limit_price_dollars": self.limit_price_dollars,
+            "requested_quantity": self.requested_quantity,
+            "filled_quantity": self.filled_quantity,
+            "fill_price_dollars": self.fill_price_dollars,
+            "position_quantity": self.position_quantity,
+            "realized_pnl_dollars": self.realized_pnl_dollars,
+            "unrealized_pnl_dollars": self.unrealized_pnl_dollars,
+            "reconciliation_id": self.reconciliation_id,
+            "live_orders_sent": self.live_orders_sent,
+            "inserted": self.inserted,
+        }
+
+
+class PaperIocExecutor:
+    execution_mode = "paper"
+    live_order_client = None
+
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+        self.repository = PaperExecutionRepository(database_url)
+
+    def execute(
+        self,
+        *,
+        order_intent_id: str,
+        liquidity: PaperLiquidity,
+        executed_at: datetime | None = None,
+    ) -> PaperExecutionResult:
+        executed_at = executed_at or datetime.now(UTC)
+        intent = self.repository.get_approved_order_intent(order_intent_id)
+        filled_quantity, status, fill_price = simulate_ioc(intent, liquidity)
+        mark_price = liquidity.mark_price_dollars if liquidity.mark_price_dollars is not None else fill_price
+        return self.repository.persist_execution(
+            intent=intent,
+            liquidity=liquidity,
+            status=status,
+            filled_quantity=filled_quantity,
+            fill_price_dollars=fill_price,
+            mark_price_dollars=mark_price,
+            executed_at=executed_at,
+        )
+
+
+class PaperExecutionRepository:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def get_approved_order_intent(self, order_intent_id: str) -> ApprovedOrderIntent:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select
+                        oi.order_intent_id,
+                        oi.risk_decision_id,
+                        d.market_ticker,
+                        oi.side,
+                        oi.price,
+                        oi.quantity,
+                        oi.max_cost_dollars,
+                        oi.time_in_force,
+                        rd.status as risk_status
+                    from order_intents oi
+                    join risk_decisions rd on rd.risk_decision_id = oi.risk_decision_id
+                    join decisions d on d.decision_id = rd.decision_id
+                    where oi.order_intent_id = %s
+                    """,
+                    (order_intent_id,),
+                )
+                row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"unknown order_intent_id: {order_intent_id}")
+        if row["risk_status"] != "approved":
+            raise ValueError(f"order intent is not risk-approved: {order_intent_id}")
+        return ApprovedOrderIntent(
+            order_intent_id=str(row["order_intent_id"]),
+            risk_decision_id=str(row["risk_decision_id"]),
+            market_ticker=str(row["market_ticker"]),
+            side=row["side"],
+            limit_price_dollars=float(row["price"]),
+            quantity=int(row["quantity"]),
+            max_cost_dollars=float(row["max_cost_dollars"]),
+            time_in_force=str(row["time_in_force"]),
+        )
+
+    def persist_execution(
+        self,
+        *,
+        intent: ApprovedOrderIntent,
+        liquidity: PaperLiquidity,
+        status: PaperOrderStatus,
+        filled_quantity: int,
+        fill_price_dollars: float | None,
+        mark_price_dollars: float | None,
+        executed_at: datetime,
+    ) -> PaperExecutionResult:
+        paper_order_id = f"paper_order_{uuid4().hex[:12]}"
+        reconciliation_id = f"recon_{uuid4().hex[:12]}"
+        position_quantity = 0
+        realized_pnl = Decimal("0")
+        unrealized_pnl = Decimal("0")
+
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into paper_orders (
+                        paper_order_id,
+                        order_intent_id,
+                        risk_decision_id,
+                        market_ticker,
+                        side,
+                        limit_price,
+                        quantity,
+                        filled_quantity,
+                        status,
+                        time_in_force,
+                        submitted_at,
+                        metadata
+                    )
+                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    on conflict (order_intent_id) do nothing
+                    returning paper_order_id
+                    """,
+                    (
+                        paper_order_id,
+                        intent.order_intent_id,
+                        intent.risk_decision_id,
+                        intent.market_ticker,
+                        intent.side,
+                        intent.limit_price_dollars,
+                        intent.quantity,
+                        filled_quantity,
+                        status,
+                        intent.time_in_force,
+                        executed_at,
+                        Jsonb(
+                            {
+                                "execution_mode": PaperIocExecutor.execution_mode,
+                                "liquidity": liquidity.__dict__,
+                            }
+                        ),
+                    ),
+                )
+                inserted_row = cursor.fetchone()
+                inserted = inserted_row is not None
+                if inserted and filled_quantity > 0 and fill_price_dollars is not None:
+                    paper_fill_id = f"paper_fill_{uuid4().hex[:12]}"
+                    cursor.execute(
+                        """
+                        insert into paper_fills (
+                            paper_fill_id,
+                            paper_order_id,
+                            market_ticker,
+                            side,
+                            fill_price,
+                            quantity,
+                            liquidity_role,
+                            filled_at,
+                            fee_dollars,
+                            metadata
+                        )
+                        values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            paper_fill_id,
+                            paper_order_id,
+                            intent.market_ticker,
+                            intent.side,
+                            fill_price_dollars,
+                            filled_quantity,
+                            "taker",
+                            executed_at,
+                            0,
+                            Jsonb({"paper_order_id": paper_order_id}),
+                        ),
+                    )
+                    position_quantity, realized_pnl, unrealized_pnl = self._upsert_position(
+                        cursor=cursor,
+                        intent=intent,
+                        fill_price_dollars=fill_price_dollars,
+                        filled_quantity=filled_quantity,
+                        mark_price_dollars=mark_price_dollars,
+                        updated_at=executed_at,
+                    )
+                if inserted:
+                    cursor.execute(
+                        """
+                        insert into paper_reconciliations (
+                            reconciliation_id,
+                            paper_order_id,
+                            status,
+                            expected_quantity,
+                            filled_quantity,
+                            open_quantity,
+                            realized_pnl_dollars,
+                            unrealized_pnl_dollars,
+                            metadata
+                        )
+                        values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            reconciliation_id,
+                            paper_order_id,
+                            status,
+                            intent.quantity,
+                            filled_quantity,
+                            intent.quantity - filled_quantity,
+                            realized_pnl,
+                            unrealized_pnl,
+                            Jsonb({"execution_mode": PaperIocExecutor.execution_mode}),
+                        ),
+                    )
+                stored = self._fetch_execution(cursor, intent.order_intent_id)
+                stored = {**stored, "inserted": inserted}
+            connection.commit()
+        return row_to_execution_result(stored)
+
+    def list_orders(self) -> list[dict[str, Any]]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select *
+                    from paper_orders
+                    order by submitted_at desc, paper_order_id desc
+                    """
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    def list_fills(self) -> list[dict[str, Any]]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select *
+                    from paper_fills
+                    order by filled_at desc, paper_fill_id desc
+                    """
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    def list_positions(self) -> list[dict[str, Any]]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select *
+                    from paper_positions
+                    order by updated_at desc, position_id desc
+                    """
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    def list_reconciliations(self) -> list[dict[str, Any]]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select *
+                    from paper_reconciliations
+                    order by created_at desc, reconciliation_id desc
+                    """
+                )
+                rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    def _upsert_position(
+        self,
+        *,
+        cursor: psycopg.Cursor,
+        intent: ApprovedOrderIntent,
+        fill_price_dollars: float,
+        filled_quantity: int,
+        mark_price_dollars: float | None,
+        updated_at: datetime,
+    ) -> tuple[int, Decimal, Decimal]:
+        fill_price = Decimal(str(fill_price_dollars))
+        mark_price = Decimal(str(mark_price_dollars if mark_price_dollars is not None else fill_price))
+        cursor.execute(
+            """
+            select *
+            from paper_positions
+            where market_ticker = %s and side = %s
+            for update
+            """,
+            (intent.market_ticker, intent.side),
+        )
+        existing = cursor.fetchone()
+        if existing is None:
+            position_id = f"position_{uuid4().hex[:12]}"
+            quantity = filled_quantity
+            avg_price = fill_price
+            realized_pnl = Decimal("0")
+        else:
+            position_id = str(existing["position_id"])
+            old_quantity = int(existing["quantity"])
+            old_avg = Decimal(str(existing["avg_price"]))
+            quantity = old_quantity + filled_quantity
+            avg_price = (
+                (old_avg * Decimal(old_quantity)) + (fill_price * Decimal(filled_quantity))
+            ) / Decimal(quantity)
+            realized_pnl = Decimal(str(existing["realized_pnl_dollars"]))
+        unrealized_pnl = (mark_price - avg_price) * Decimal(quantity)
+        cursor.execute(
+            """
+            insert into paper_positions (
+                position_id,
+                market_ticker,
+                side,
+                quantity,
+                avg_price,
+                realized_pnl_dollars,
+                unrealized_pnl_dollars,
+                updated_at,
+                metadata
+            )
+            values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            on conflict (market_ticker, side) do update set
+                quantity = excluded.quantity,
+                avg_price = excluded.avg_price,
+                realized_pnl_dollars = excluded.realized_pnl_dollars,
+                unrealized_pnl_dollars = excluded.unrealized_pnl_dollars,
+                updated_at = excluded.updated_at,
+                metadata = excluded.metadata
+            """,
+            (
+                position_id,
+                intent.market_ticker,
+                intent.side,
+                quantity,
+                avg_price,
+                realized_pnl,
+                unrealized_pnl,
+                updated_at,
+                Jsonb({"execution_mode": PaperIocExecutor.execution_mode}),
+            ),
+        )
+        return quantity, realized_pnl, unrealized_pnl
+
+    def _fetch_execution(
+        self,
+        cursor: psycopg.Cursor,
+        order_intent_id: str,
+    ) -> Mapping[str, Any]:
+        cursor.execute(
+            """
+            select
+                po.paper_order_id,
+                po.order_intent_id,
+                po.market_ticker,
+                po.side,
+                po.status,
+                po.limit_price,
+                po.quantity,
+                po.filled_quantity,
+                pf.fill_price,
+                coalesce(pp.quantity, 0) as position_quantity,
+                pr.realized_pnl_dollars,
+                pr.unrealized_pnl_dollars,
+                pr.reconciliation_id
+            from paper_orders po
+            left join paper_fills pf on pf.paper_order_id = po.paper_order_id
+            left join paper_positions pp
+                on pp.market_ticker = po.market_ticker and pp.side = po.side
+            join paper_reconciliations pr on pr.paper_order_id = po.paper_order_id
+            where po.order_intent_id = %s
+            """,
+            (order_intent_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("paper execution neither inserted nor found existing row")
+        return row
+
+
+def simulate_ioc(
+    intent: ApprovedOrderIntent,
+    liquidity: PaperLiquidity,
+) -> tuple[int, PaperOrderStatus, float | None]:
+    if liquidity.side != intent.side:
+        return 0, "unfilled", None
+    if liquidity.available_price_dollars is None or liquidity.available_quantity <= 0:
+        return 0, "unfilled", None
+    if liquidity.available_price_dollars > intent.limit_price_dollars:
+        return 0, "unfilled", None
+    filled_quantity = min(intent.quantity, liquidity.available_quantity)
+    status: PaperOrderStatus = "filled" if filled_quantity == intent.quantity else "partial"
+    return filled_quantity, status, liquidity.available_price_dollars
+
+
+def row_to_execution_result(row: Mapping[str, Any]) -> PaperExecutionResult:
+    values = dict(row)
+    fill_price = values.get("fill_price")
+    return PaperExecutionResult(
+        paper_order_id=str(values["paper_order_id"]),
+        order_intent_id=str(values["order_intent_id"]),
+        market_ticker=str(values["market_ticker"]),
+        side=values["side"],
+        status=values["status"],
+        limit_price_dollars=float(values["limit_price"]),
+        requested_quantity=int(values["quantity"]),
+        filled_quantity=int(values["filled_quantity"]),
+        fill_price_dollars=None if fill_price is None else float(fill_price),
+        position_quantity=int(values["position_quantity"]),
+        realized_pnl_dollars=float(values["realized_pnl_dollars"]),
+        unrealized_pnl_dollars=float(values["unrealized_pnl_dollars"]),
+        reconciliation_id=str(values["reconciliation_id"]),
+        inserted=bool(values.get("inserted", True)),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-paper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    execute_parser = subparsers.add_parser("execute", help="Execute one paper IOC order")
+    execute_parser.add_argument("--order-intent-id", required=True)
+    execute_parser.add_argument("--side", choices=("yes", "no"), required=True)
+    execute_parser.add_argument("--available-price-dollars", type=float, default=None)
+    execute_parser.add_argument("--available-quantity", type=int, default=0)
+    execute_parser.add_argument("--mark-price-dollars", type=float, default=None)
+
+    subparsers.add_parser("status", help="Show paper orders, fills, positions, and PnL")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = settings_from_env()
+    OperationalStateRepository(settings.database_url).apply_migrations()
+    repository = PaperExecutionRepository(settings.database_url)
+
+    if args.command == "execute":
+        result = PaperIocExecutor(settings.database_url).execute(
+            order_intent_id=args.order_intent_id,
+            liquidity=PaperLiquidity(
+                side=args.side,
+                available_price_dollars=args.available_price_dollars,
+                available_quantity=args.available_quantity,
+                mark_price_dollars=args.mark_price_dollars,
+            ),
+        )
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "status":
+        print(
+            json.dumps(
+                {
+                    "orders": repository.list_orders(),
+                    "fills": repository.list_fills(),
+                    "positions": repository.list_positions(),
+                    "reconciliations": repository.list_reconciliations(),
+                },
+                indent=2,
+                sort_keys=True,
+                default=str,
+            )
+        )
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/state/migrations.py
+++ b/src/alphadb/state/migrations.py
@@ -230,10 +230,80 @@ FEATURE_ROWS = Migration(
 )
 
 
+PAPER_EXECUTION = Migration(
+    version="0006_paper_execution",
+    statements=(
+        """
+        create table if not exists paper_orders (
+            paper_order_id text primary key,
+            order_intent_id text not null unique references order_intents(order_intent_id),
+            risk_decision_id text not null references risk_decisions(risk_decision_id),
+            market_ticker text not null references market_instances(market_ticker),
+            side text not null check (side in ('yes', 'no')),
+            limit_price numeric not null,
+            quantity integer not null,
+            filled_quantity integer not null default 0,
+            status text not null,
+            time_in_force text not null,
+            submitted_at timestamptz not null,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create table if not exists paper_fills (
+            paper_fill_id text primary key,
+            paper_order_id text not null references paper_orders(paper_order_id),
+            market_ticker text not null references market_instances(market_ticker),
+            side text not null check (side in ('yes', 'no')),
+            fill_price numeric not null,
+            quantity integer not null,
+            liquidity_role text not null,
+            filled_at timestamptz not null,
+            fee_dollars numeric not null default 0,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create table if not exists paper_positions (
+            position_id text primary key,
+            market_ticker text not null references market_instances(market_ticker),
+            side text not null check (side in ('yes', 'no')),
+            quantity integer not null,
+            avg_price numeric not null,
+            realized_pnl_dollars numeric not null default 0,
+            unrealized_pnl_dollars numeric not null default 0,
+            updated_at timestamptz not null,
+            metadata jsonb not null default '{}'::jsonb,
+            unique (market_ticker, side)
+        )
+        """,
+        """
+        create table if not exists paper_reconciliations (
+            reconciliation_id text primary key,
+            paper_order_id text not null unique references paper_orders(paper_order_id),
+            status text not null,
+            expected_quantity integer not null,
+            filled_quantity integer not null,
+            open_quantity integer not null,
+            realized_pnl_dollars numeric not null default 0,
+            unrealized_pnl_dollars numeric not null default 0,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now()
+        )
+        """,
+        "create index if not exists paper_orders_market_idx on paper_orders(market_ticker)",
+        "create index if not exists paper_fills_market_idx on paper_fills(market_ticker)",
+    ),
+)
+
+
 MIGRATIONS: tuple[Migration, ...] = (
     INITIAL_OPERATIONAL_STATE,
     RAW_EVENT_LOG,
     COLLECTOR_RUNS,
     MODEL_REGISTRY,
     FEATURE_ROWS,
+    PAPER_EXECUTION,
 )

--- a/tests/test_kalshi_rest_collector.py
+++ b/tests/test_kalshi_rest_collector.py
@@ -77,7 +77,7 @@ def test_collector_persists_status_and_recent_errors() -> None:
         max_markets=1,
         now=datetime(2026, 5, 31, 21, 12, tzinfo=UTC),
     )
-    recent_runs = collector.run_store.recent_runs(limit=25)
+    recent_runs = collector.run_store.recent_runs(limit=1000)
     current_run = next(
         row for row in recent_runs if row["collector_run_id"] == summary.collector_run_id
     )

--- a/tests/test_paper_ioc.py
+++ b/tests/test_paper_ioc.py
@@ -1,0 +1,163 @@
+from datetime import UTC, datetime
+
+import psycopg
+import pytest
+from psycopg.types.json import Jsonb
+
+from alphadb.config import settings_from_env
+from alphadb.markets.spec import kxbtc15m_spec
+from alphadb.paper.ioc import (
+    PaperExecutionRepository,
+    PaperIocExecutor,
+    PaperLiquidity,
+)
+from alphadb.state.repository import OperationalStateRepository
+
+
+def paper_repository_or_skip() -> OperationalStateRepository:
+    repository = OperationalStateRepository(settings_from_env().database_url)
+    try:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    repository.apply_migrations()
+    return repository
+
+
+def approved_yes_intent(repository: OperationalStateRepository) -> str:
+    return repository.create_tracer_run(kxbtc15m_spec()).order_intent_id
+
+
+def approved_no_intent(repository: OperationalStateRepository) -> str:
+    tracer = repository.create_tracer_run(kxbtc15m_spec())
+    with repository.connect() as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                update decisions
+                set probability_yes = %s, selected_side = %s, metadata = %s
+                where decision_id = %s
+                """,
+                (0.35, "no", Jsonb({"test_side": "no"}), tracer.decision_id),
+            )
+            cursor.execute(
+                """
+                update order_intents
+                set side = %s, price = %s, quantity = %s, max_cost_dollars = %s
+                where order_intent_id = %s
+                """,
+                ("no", 0.40, 2, 0.80, tracer.order_intent_id),
+            )
+        connection.commit()
+    return tracer.order_intent_id
+
+
+def test_paper_ioc_fills_approved_yes_order_and_updates_position_reconciliation() -> None:
+    repository = paper_repository_or_skip()
+    order_intent_id = approved_yes_intent(repository)
+
+    result = PaperIocExecutor(repository.database_url).execute(
+        order_intent_id=order_intent_id,
+        liquidity=PaperLiquidity(
+            side="yes",
+            available_price_dollars=0.49,
+            available_quantity=10,
+            mark_price_dollars=0.55,
+        ),
+        executed_at=datetime(2026, 5, 31, 21, 20, tzinfo=UTC),
+    )
+
+    assert result.status == "filled"
+    assert result.side == "yes"
+    assert result.filled_quantity == 1
+    assert result.fill_price_dollars == 0.49
+    assert result.position_quantity == 1
+    assert result.realized_pnl_dollars == 0
+    assert result.unrealized_pnl_dollars == pytest.approx(0.06)
+    assert result.live_orders_sent == 0
+
+
+def test_paper_ioc_represents_no_side_price_semantics() -> None:
+    repository = paper_repository_or_skip()
+    order_intent_id = approved_no_intent(repository)
+
+    result = PaperIocExecutor(repository.database_url).execute(
+        order_intent_id=order_intent_id,
+        liquidity=PaperLiquidity(
+            side="no",
+            available_price_dollars=0.39,
+            available_quantity=2,
+            mark_price_dollars=0.45,
+        ),
+    )
+
+    assert result.status == "filled"
+    assert result.side == "no"
+    assert result.limit_price_dollars == 0.40
+    assert result.fill_price_dollars == 0.39
+    assert result.filled_quantity == 2
+    assert result.unrealized_pnl_dollars == pytest.approx(0.12)
+
+
+def test_paper_ioc_handles_non_fill_and_partial_fill_cases() -> None:
+    repository = paper_repository_or_skip()
+    unfilled_intent = approved_yes_intent(repository)
+    partial_intent = approved_no_intent(repository)
+
+    unfilled = PaperIocExecutor(repository.database_url).execute(
+        order_intent_id=unfilled_intent,
+        liquidity=PaperLiquidity(
+            side="yes",
+            available_price_dollars=0.99,
+            available_quantity=5,
+        ),
+    )
+    partial = PaperIocExecutor(repository.database_url).execute(
+        order_intent_id=partial_intent,
+        liquidity=PaperLiquidity(
+            side="no",
+            available_price_dollars=0.39,
+            available_quantity=1,
+            mark_price_dollars=0.40,
+        ),
+    )
+
+    assert unfilled.status == "unfilled"
+    assert unfilled.filled_quantity == 0
+    assert unfilled.fill_price_dollars is None
+    assert unfilled.position_quantity == 0
+    assert partial.status == "partial"
+    assert partial.filled_quantity == 1
+    assert partial.position_quantity >= 1
+
+
+def test_paper_ioc_has_no_live_order_client_and_is_idempotent() -> None:
+    repository = paper_repository_or_skip()
+    order_intent_id = approved_yes_intent(repository)
+    executor = PaperIocExecutor(repository.database_url)
+
+    first = executor.execute(
+        order_intent_id=order_intent_id,
+        liquidity=PaperLiquidity(
+            side="yes",
+            available_price_dollars=0.49,
+            available_quantity=1,
+        ),
+    )
+    second = executor.execute(
+        order_intent_id=order_intent_id,
+        liquidity=PaperLiquidity(
+            side="yes",
+            available_price_dollars=0.49,
+            available_quantity=1,
+        ),
+    )
+
+    assert executor.live_order_client is None
+    assert first.inserted is True
+    assert second.inserted is False
+    assert second.paper_order_id == first.paper_order_id
+    assert len(PaperExecutionRepository(repository.database_url).list_fills()) >= 1


### PR DESCRIPTION
## Summary
- Adds paper-only taker IOC execution tables for orders, fills, positions, and reconciliations.
- Converts risk-approved order intents into simulated IOC orders without any live order client.
- Persists YES/NO side semantics, fill/non-fill/partial outcomes, position PnL, and reconciliation rows.
- Adds CLI and dashboard visibility for paper execution state.

## Verification
- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && pytest -q && ruff check .'\n- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && alphadb-paper execute --order-intent-id intent_8aa7b8495e31 --side yes --available-price-dollars 0.52 --available-quantity 1 --mark-price-dollars 0.55 && alphadb-paper status'\n- docker compose --profile dashboard up -d streamlit && curl -fsS http://localhost:${ALPHADB_STREAMLIT_PORT:-8501}/_stcore/health\n\nLinear: ALP-11