### PR TITLE
feat: add websocket ingestion readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ alphadb-shadow compare \
 alphadb-shadow status
 ```
 
+Exercise WebSocket ingestion readiness with mocked events. Live WebSocket smoke
+is opt-in only and requires credentials from environment variables outside Git:
+
+```bash
+alphadb-ws mock-smoke --market-ticker <market_ticker> --run-id <run_id>
+
+ALPHADB_ENABLE_LIVE_WS_SMOKE=1 \
+ALPHADB_KALSHI_WS_URL=wss://... \
+KALSHI_API_KEY_ID=... \
+KALSHI_PRIVATE_KEY_PATH=/path/to/private-key.pem \
+alphadb-ws live-smoke
+```
+
 By default, local Postgres is published on `localhost:55433` and Streamlit on
 `localhost:8501`. Override those with `ALPHADB_POSTGRES_PORT` and
 `ALPHADB_STREAMLIT_PORT` when needed. Override the Kalshi REST base URL with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ alphadb-risk = "alphadb.risk.gate:main"
 alphadb-paper = "alphadb.paper.ioc:main"
 alphadb-replay = "alphadb.replay.report:main"
 alphadb-shadow = "alphadb.shadow.comparison:main"
+alphadb-ws = "alphadb.collectors.kalshi_ws:main"
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.35"]

--- a/src/alphadb/collectors/kalshi_ws.py
+++ b/src/alphadb/collectors/kalshi_ws.py
@@ -1,0 +1,209 @@
+"""Authenticated Kalshi WebSocket ingestion readiness.
+
+Normal tests and local smoke paths use mocked WebSocket events. Live smoke is
+guarded behind explicit environment configuration and does not run by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from alphadb.config import Settings, settings_from_env
+from alphadb.events.log import RawEventLog
+from alphadb.state.repository import OperationalStateRepository
+
+KALSHI_WS_SOURCE = "kalshi_ws"
+ORDERBOOK_DELTA_SCHEMA = "kalshi.ws.orderbook_delta.v1"
+TRADE_SCHEMA = "kalshi.ws.trade.v1"
+
+
+class LiveWebSocketSmokeGuardError(RuntimeError):
+    """Raised when live WebSocket smoke is not explicitly enabled."""
+
+
+@dataclass(frozen=True)
+class KalshiWebSocketCredentials:
+    api_key_id: str
+    private_key_path: str
+    websocket_url: str
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> KalshiWebSocketCredentials:
+        missing = []
+        if not settings.kalshi_api_key_id:
+            missing.append("KALSHI_API_KEY_ID")
+        if not settings.kalshi_private_key_path:
+            missing.append("KALSHI_PRIVATE_KEY_PATH")
+        if not settings.kalshi_ws_url:
+            missing.append("ALPHADB_KALSHI_WS_URL")
+        if missing:
+            raise ValueError(f"missing WebSocket credential settings: {', '.join(missing)}")
+        private_key_path = Path(settings.kalshi_private_key_path)
+        if not private_key_path.exists():
+            raise ValueError(f"KALSHI_PRIVATE_KEY_PATH does not exist: {private_key_path}")
+        return cls(
+            api_key_id=settings.kalshi_api_key_id,
+            private_key_path=str(private_key_path),
+            websocket_url=settings.kalshi_ws_url,
+        )
+
+
+@dataclass(frozen=True)
+class WebSocketEvent:
+    channel: str
+    market_ticker: str
+    sequence: int
+    payload: Mapping[str, Any]
+    received_at: datetime
+    source_timestamp: datetime | None = None
+
+    @property
+    def schema_version(self) -> str:
+        if self.channel == "orderbook_delta":
+            return ORDERBOOK_DELTA_SCHEMA
+        if self.channel == "trade":
+            return TRADE_SCHEMA
+        return f"kalshi.ws.{self.channel}.v1"
+
+    @property
+    def source_event_id(self) -> str:
+        return f"{self.channel}:{self.market_ticker}:{self.sequence}"
+
+
+@dataclass(frozen=True)
+class WebSocketIngestResult:
+    source: str
+    events_seen: int
+    events_inserted: int
+    schemas: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "events_seen": self.events_seen,
+            "events_inserted": self.events_inserted,
+            "schemas": list(self.schemas),
+        }
+
+
+class KalshiWebSocketIngestor:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+        self.event_log = RawEventLog(database_url)
+
+    def ingest(
+        self,
+        events: Iterable[WebSocketEvent],
+        *,
+        run_id: str | None = None,
+    ) -> WebSocketIngestResult:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        seen = 0
+        inserted = 0
+        schemas: set[str] = set()
+        for event in events:
+            seen += 1
+            schemas.add(event.schema_version)
+            record = self.event_log.append(
+                run_id=run_id,
+                market_ticker=event.market_ticker,
+                source=KALSHI_WS_SOURCE,
+                source_event_id=event.source_event_id,
+                received_at=event.received_at,
+                source_timestamp=event.source_timestamp,
+                schema_version=event.schema_version,
+                payload={
+                    "channel": event.channel,
+                    "market_ticker": event.market_ticker,
+                    "sequence": event.sequence,
+                    "payload": dict(event.payload),
+                },
+            )
+            inserted += int(record.inserted)
+        return WebSocketIngestResult(
+            source=KALSHI_WS_SOURCE,
+            events_seen=seen,
+            events_inserted=inserted,
+            schemas=tuple(sorted(schemas)),
+        )
+
+
+class MockKalshiWebSocketClient:
+    def __init__(self, events: Sequence[WebSocketEvent]):
+        self.events = tuple(events)
+
+    def receive(self) -> Iterable[WebSocketEvent]:
+        return self.events
+
+
+def default_mock_event(market_ticker: str) -> WebSocketEvent:
+    return WebSocketEvent(
+        channel="orderbook_delta",
+        market_ticker=market_ticker,
+        sequence=1,
+        received_at=datetime.now(UTC),
+        source_timestamp=datetime.now(UTC),
+        payload={
+            "yes": [["0.5100", "3"]],
+            "no": [["0.4800", "4"]],
+        },
+    )
+
+
+def assert_live_smoke_enabled(settings: Settings) -> KalshiWebSocketCredentials:
+    if not settings.enable_live_ws_smoke:
+        raise LiveWebSocketSmokeGuardError(
+            "live WebSocket smoke requires ALPHADB_ENABLE_LIVE_WS_SMOKE=1"
+        )
+    return KalshiWebSocketCredentials.from_settings(settings)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-ws")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    mock_parser = subparsers.add_parser("mock-smoke", help="Ingest deterministic mocked WS event")
+    mock_parser.add_argument("--market-ticker", required=True)
+    mock_parser.add_argument("--run-id", default=None)
+
+    subparsers.add_parser("live-smoke", help="Validate guarded live WS smoke configuration")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    settings = settings_from_env()
+    OperationalStateRepository(settings.database_url).apply_migrations()
+
+    if args.command == "mock-smoke":
+        client = MockKalshiWebSocketClient([default_mock_event(args.market_ticker)])
+        result = KalshiWebSocketIngestor(settings.database_url).ingest(
+            client.receive(),
+            run_id=args.run_id,
+        )
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "live-smoke":
+        credentials = assert_live_smoke_enabled(settings)
+        print(
+            json.dumps(
+                {
+                    "status": "ready",
+                    "websocket_url": credentials.websocket_url,
+                    "api_key_id_present": bool(credentials.api_key_id),
+                    "private_key_path": credentials.private_key_path,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/config.py
+++ b/src/alphadb/config.py
@@ -21,6 +21,10 @@ class Settings:
     database_url: str
     streamlit_port: str
     kalshi_base_url: str
+    kalshi_ws_url: str | None
+    kalshi_api_key_id: str | None
+    kalshi_private_key_path: str | None
+    enable_live_ws_smoke: bool
 
 
 def settings_from_env(env: Mapping[str, str] | None = None) -> Settings:
@@ -36,4 +40,8 @@ def settings_from_env(env: Mapping[str, str] | None = None) -> Settings:
         database_url=values.get("DATABASE_URL", default_database_url),
         streamlit_port=values.get("ALPHADB_STREAMLIT_PORT", "8501"),
         kalshi_base_url=values.get("ALPHADB_KALSHI_BASE_URL", DEFAULT_KALSHI_BASE_URL),
+        kalshi_ws_url=values.get("ALPHADB_KALSHI_WS_URL"),
+        kalshi_api_key_id=values.get("KALSHI_API_KEY_ID"),
+        kalshi_private_key_path=values.get("KALSHI_PRIVATE_KEY_PATH"),
+        enable_live_ws_smoke=values.get("ALPHADB_ENABLE_LIVE_WS_SMOKE") == "1",
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,10 @@ def test_settings_default_database_url_uses_configurable_local_port() -> None:
     assert settings.database_url == "postgresql://alphadb:alphadb@localhost:55433/alphadb"
     assert settings.streamlit_port == "8501"
     assert settings.kalshi_base_url == "https://external-api.kalshi.com/trade-api/v2"
+    assert settings.kalshi_ws_url is None
+    assert settings.kalshi_api_key_id is None
+    assert settings.kalshi_private_key_path is None
+    assert settings.enable_live_ws_smoke is False
 
 
 def test_settings_database_url_can_be_overridden() -> None:
@@ -16,6 +20,10 @@ def test_settings_database_url_can_be_overridden() -> None:
             "ALPHADB_ENV": "test",
             "ALPHADB_STREAMLIT_PORT": "18501",
             "ALPHADB_KALSHI_BASE_URL": "https://example.test/trade-api/v2",
+            "ALPHADB_KALSHI_WS_URL": "wss://example.test/ws",
+            "KALSHI_API_KEY_ID": "key-id",
+            "KALSHI_PRIVATE_KEY_PATH": "/tmp/key.pem",
+            "ALPHADB_ENABLE_LIVE_WS_SMOKE": "1",
         }
     )
 
@@ -23,3 +31,7 @@ def test_settings_database_url_can_be_overridden() -> None:
     assert settings.environment == "test"
     assert settings.streamlit_port == "18501"
     assert settings.kalshi_base_url == "https://example.test/trade-api/v2"
+    assert settings.kalshi_ws_url == "wss://example.test/ws"
+    assert settings.kalshi_api_key_id == "key-id"
+    assert settings.kalshi_private_key_path == "/tmp/key.pem"
+    assert settings.enable_live_ws_smoke is True

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -18,6 +18,10 @@ def test_collect_health_reports_ok_when_components_are_ok() -> None:
         database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
         streamlit_port="8501",
         kalshi_base_url="https://external-api.kalshi.com/trade-api/v2",
+        kalshi_ws_url=None,
+        kalshi_api_key_id=None,
+        kalshi_private_key_path=None,
+        enable_live_ws_smoke=False,
     )
 
     report = collect_health(
@@ -43,6 +47,10 @@ def test_collect_health_reports_error_when_database_is_unavailable() -> None:
         database_url="postgresql://alphadb:alphadb@localhost:55433/alphadb",
         streamlit_port="8501",
         kalshi_base_url="https://external-api.kalshi.com/trade-api/v2",
+        kalshi_ws_url=None,
+        kalshi_api_key_id=None,
+        kalshi_private_key_path=None,
+        enable_live_ws_smoke=False,
     )
 
     report = collect_health(

--- a/tests/test_kalshi_ws.py
+++ b/tests/test_kalshi_ws.py
@@ -1,0 +1,124 @@
+from datetime import UTC, datetime
+
+import psycopg
+import pytest
+
+from alphadb.collectors.kalshi_ws import (
+    KALSHI_WS_SOURCE,
+    KalshiWebSocketCredentials,
+    KalshiWebSocketIngestor,
+    LiveWebSocketSmokeGuardError,
+    MockKalshiWebSocketClient,
+    WebSocketEvent,
+    assert_live_smoke_enabled,
+)
+from alphadb.config import settings_from_env
+from alphadb.events.log import RawEventLog
+from alphadb.markets.spec import kxbtc15m_spec
+from alphadb.state.repository import OperationalStateRepository
+
+
+def ws_repository_or_skip() -> OperationalStateRepository:
+    repository = OperationalStateRepository(settings_from_env().database_url)
+    try:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    repository.apply_migrations()
+    return repository
+
+
+def test_mock_websocket_ingestion_writes_raw_events_without_credentials() -> None:
+    repository = ws_repository_or_skip()
+    tracer = repository.create_tracer_run(kxbtc15m_spec())
+    event = WebSocketEvent(
+        channel="orderbook_delta",
+        market_ticker=tracer.market_ticker,
+        sequence=42,
+        received_at=datetime(2026, 5, 31, 21, 45, tzinfo=UTC),
+        source_timestamp=datetime(2026, 5, 31, 21, 45, tzinfo=UTC),
+        payload={"yes": [["0.5100", "3"]], "no": [["0.4800", "4"]]},
+    )
+
+    result = KalshiWebSocketIngestor(repository.database_url).ingest(
+        MockKalshiWebSocketClient([event]).receive(),
+        run_id=tracer.run_id,
+    )
+    replayed = list(RawEventLog(repository.database_url).replay_events(run_id=tracer.run_id))
+
+    assert result.source == KALSHI_WS_SOURCE
+    assert result.events_seen == 1
+    assert result.events_inserted == 1
+    assert result.schemas == ("kalshi.ws.orderbook_delta.v1",)
+    assert any(row["source"] == "kalshi_ws" for row in replayed)
+
+
+def test_websocket_and_rest_sources_are_distinguishable_in_counts() -> None:
+    repository = ws_repository_or_skip()
+    tracer = repository.create_tracer_run(kxbtc15m_spec())
+    RawEventLog(repository.database_url).append(
+        run_id=tracer.run_id,
+        market_ticker=tracer.market_ticker,
+        source="kalshi_rest",
+        source_event_id=f"{tracer.market_ticker}:rest-for-ws-counts",
+        schema_version="kalshi.orderbook_snapshot.v1",
+        payload={"fixture": "rest"},
+    )
+    KalshiWebSocketIngestor(repository.database_url).ingest(
+        [
+            WebSocketEvent(
+                channel="orderbook_delta",
+                market_ticker=tracer.market_ticker,
+                sequence=43,
+                received_at=datetime(2026, 5, 31, 21, 46, tzinfo=UTC),
+                payload={"fixture": "ws"},
+            )
+        ],
+        run_id=tracer.run_id,
+    )
+    counts = RawEventLog(repository.database_url).counts_by_source_schema()
+
+    assert any(row["source"] == "kalshi_rest" for row in counts)
+    assert any(row["source"] == "kalshi_ws" for row in counts)
+    assert all("schema_version" in row for row in counts)
+
+
+def test_websocket_credentials_load_only_from_environment_and_validate_key_path(tmp_path) -> None:
+    key_path = tmp_path / "kalshi.key"
+    key_path.write_text("private-key", encoding="utf-8")
+    settings = settings_from_env(
+        {
+            "ALPHADB_KALSHI_WS_URL": "wss://example.test/ws",
+            "KALSHI_API_KEY_ID": "key-id",
+            "KALSHI_PRIVATE_KEY_PATH": str(key_path),
+        }
+    )
+
+    credentials = KalshiWebSocketCredentials.from_settings(settings)
+
+    assert credentials.api_key_id == "key-id"
+    assert credentials.private_key_path == str(key_path)
+    assert credentials.websocket_url == "wss://example.test/ws"
+
+
+def test_live_websocket_smoke_is_explicitly_guarded(tmp_path) -> None:
+    key_path = tmp_path / "kalshi.key"
+    key_path.write_text("private-key", encoding="utf-8")
+
+    with pytest.raises(LiveWebSocketSmokeGuardError):
+        assert_live_smoke_enabled(settings_from_env({}))
+
+    settings = settings_from_env(
+        {
+            "ALPHADB_ENABLE_LIVE_WS_SMOKE": "1",
+            "ALPHADB_KALSHI_WS_URL": "wss://example.test/ws",
+            "KALSHI_API_KEY_ID": "key-id",
+            "KALSHI_PRIVATE_KEY_PATH": str(key_path),
+        }
+    )
+
+    credentials = assert_live_smoke_enabled(settings)
+    assert credentials.api_key_id == "key-id"


### PR DESCRIPTION
## Summary
- Adds a Kalshi WebSocket ingestion boundary that writes mocked WS events through the raw event log contract.
- Loads WebSocket auth settings only from environment/config and keeps normal tests credential-free.
- Adds guarded `live-smoke` readiness checks behind `ALPHADB_ENABLE_LIVE_WS_SMOKE=1`.
- Documents mock and live-smoke commands and verifies REST/WS source separation in event counts.

## Verification
- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && pytest -q && ruff check .'\n- docker compose run --rm app bash -lc 'python -m pip install -e ".[dev,dashboard]" >/dev/null && alphadb-ws mock-smoke --market-ticker KXBTC15M-26MAY312100-00 --run-id run_0e2c52eefa1e && alphadb-events counts'\n- docker compose --profile dashboard up -d streamlit && curl -fsS http://localhost:${ALPHADB_STREAMLIT_PORT:-8501}/_stcore/health\n\nLinear: ALP-14