### PR TITLE
fix: preserve live status on lock-held duplicate

### DIFF
--- a/docs/deployment/aws-dashboard.md
+++ b/docs/deployment/aws-dashboard.md
@@ -217,6 +217,12 @@ managed Postgres secret. The worker task security group/subnets must be able to
 reach the database, and the task command should include
 `--runtime-config-source postgres`.
 
+The fair-value live worker uses a single S3 live-run lock under the configured
+artifact prefix to prevent overlapping scheduled ECS tasks from submitting
+duplicate orders. A task that cannot acquire that lock should leave auditable
+run artifacts, but it must not replace the dashboard's latest actionable live
+status with `live_run_lock_held` / `not_submitted`.
+
 Use `docs/deployment/live-money-cutover-checklist.md` as the ALP-157 checklist
 and evidence template before any live-money authority change.
 

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -45,9 +45,7 @@ FAIR_VALUE_LIVE_JOB_SCHEMA = "kxbtc_fair_value_live_trading_job.v1"
 FAIR_VALUE_LIVE_ATTEMPTS_SCHEMA = "kxbtc_fair_value_live_order_attempts.v1"
 FAIR_VALUE_LIVE_RECONCILIATION_SCHEMA = "kxbtc_fair_value_live_reconciliation.v1"
 FAIR_VALUE_LIVE_LOCK_SCHEMA = "kxbtc_fair_value_live_run_lock.v1"
-FAIR_VALUE_LIVE_DAILY_LOSS_ACCOUNTING_SCHEMA = (
-    "kxbtc_fair_value_live_daily_loss_accounting.v1"
-)
+FAIR_VALUE_LIVE_DAILY_LOSS_ACCOUNTING_SCHEMA = "kxbtc_fair_value_live_daily_loss_accounting.v1"
 FAIR_VALUE_LIVE_LOCK_TTL_SECONDS = 180
 DEFAULT_LIVE_RISK_TIMEZONE = "America/Los_Angeles"
 RuntimeConfigSource = Literal["auto", "postgres", "cli"]
@@ -246,6 +244,7 @@ class FairValueLiveTradingJob:
                     "daily_loss_accounting": daily_loss_accounting,
                     "runtime_guard": guard.as_dict(),
                     "live_run_lock": live_run_lock.as_dict(),
+                    "live_status_materialized": should_materialize_live_run_status(live_run_lock),
                 },
                 "counts": {
                     "collected_rows": collected["counts"]["rows"],
@@ -269,9 +268,7 @@ class FairValueLiveTradingJob:
                     "simulated_replay_net_pnl_dollars": replay["pnl"]["net_pnl_dollars"],
                     "simulated_replay_settlement_status": replay["settlement"]["status"],
                     "daily_loss_live_risk_day": daily_loss_accounting["live_risk_day"],
-                    "daily_loss_used_dollars": daily_loss_accounting[
-                        "daily_loss_used_dollars"
-                    ],
+                    "daily_loss_used_dollars": daily_loss_accounting["daily_loss_used_dollars"],
                     "live_reconciliation_scope": "full_history_loaded_attempts",
                     "live_full_history_net_pnl_dollars": live_reconciliation["pnl"][
                         "net_pnl_dollars"
@@ -288,13 +285,14 @@ class FairValueLiveTradingJob:
                 },
                 "artifacts": artifact_records(artifacts),
             }
-            materialize_live_run_status(
-                settings=settings,
-                manifest=manifest,
-                live_attempts_payload=live_attempts_payload,
-                live_reconciliation=live_reconciliation,
-                require_postgres=runtime_config.get("source") == "dashboard_postgres",
-            )
+            if should_materialize_live_run_status(live_run_lock):
+                materialize_live_run_status(
+                    settings=settings,
+                    manifest=manifest,
+                    live_attempts_payload=live_attempts_payload,
+                    live_reconciliation=live_reconciliation,
+                    require_postgres=runtime_config.get("source") == "dashboard_postgres",
+                )
             write_json(run_dir / "manifest.json", manifest)
             manifest["artifacts"]["manifest"] = artifact_record(run_dir / "manifest.json")
             if self.config.s3_prefix:
@@ -413,7 +411,9 @@ class FairValueLiveTradingJob:
                 "attempt_index": index,
             }
             if sized_order is None:
-                attempts.append({**base, "status": "skipped", "reason": "market_exposure_cap_reached"})
+                attempts.append(
+                    {**base, "status": "skipped", "reason": "market_exposure_cap_reached"}
+                )
                 continue
             if not live_run_lock.acquired:
                 attempts.append(
@@ -516,6 +516,10 @@ class LiveRunLock:
                 key=self.key,
                 token=self.token,
             )
+
+
+def should_materialize_live_run_status(live_run_lock: LiveRunLock) -> bool:
+    return live_run_lock.acquired or live_run_lock.reason != "live_run_lock_held"
 
 
 def acquire_live_run_lock(
@@ -917,7 +921,9 @@ def reconcile_live_attempt(
         "market_ticker": market_ticker,
         "side": side,
         "order_status": attempt.get("status"),
-        "order_id": attempt.get("order_id") or response.get("order_id") or detail_order.get("order_id"),
+        "order_id": attempt.get("order_id")
+        or response.get("order_id")
+        or detail_order.get("order_id"),
         "client_order_id": attempt.get("client_order_id")
         or response.get("client_order_id")
         or detail_order.get("client_order_id"),
@@ -941,7 +947,9 @@ def order_detail_for_attempt(
     settings: Settings,
     order_client: KalshiLiveOrderClient,
 ) -> Mapping[str, Any]:
-    order_id = attempt.get("order_id") or as_mapping(attempt.get("response_payload")).get("order_id")
+    order_id = attempt.get("order_id") or as_mapping(attempt.get("response_payload")).get(
+        "order_id"
+    )
     if not order_id:
         return {}
     try:
@@ -999,9 +1007,7 @@ def daily_loss_accounting_report(
         window_start_utc=window_start_utc,
         window_end_utc=window_end_utc,
     )
-    filled_rows = [
-        row for row in same_day_rows if int(row.get("filled_contracts") or 0) > 0
-    ]
+    filled_rows = [row for row in same_day_rows if int(row.get("filled_contracts") or 0) > 0]
     return {
         "schema_version": FAIR_VALUE_LIVE_DAILY_LOSS_ACCOUNTING_SCHEMA,
         "basis": "submitted_at_in_live_risk_day",
@@ -1125,7 +1131,9 @@ def load_prior_live_attempts(
     return attempts
 
 
-def load_prior_live_attempts_from_s3(*, s3_prefix: str, current_run_id: str) -> list[dict[str, Any]]:
+def load_prior_live_attempts_from_s3(
+    *, s3_prefix: str, current_run_id: str
+) -> list[dict[str, Any]]:
     bucket, prefix = parse_s3_prefix(s3_prefix)
     try:
         import boto3  # type: ignore[import-not-found]

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from uuid import uuid4
 
 import psycopg
 import pytest
@@ -35,8 +36,10 @@ from alphadb.model_evaluation.fair_value_replay import (
 from alphadb.config import settings_from_env
 from alphadb.live_runtime import (
     DEFAULT_FAIR_VALUE_LIVE_CONFIG,
+    LiveRunStatusRepository,
     LiveRuntimeConfig,
     LiveRuntimeConfigRepository,
+    build_fair_value_live_status,
 )
 from alphadb.state.repository import OperationalStateRepository
 
@@ -251,11 +254,15 @@ def test_live_fair_value_collector_records_skip_reasons() -> None:
         orderbooks={ticker: {"orderbook_fp": {"yes_dollars": [], "no_dollars": []}}},
     )
 
-    payload = FairValueDecisionRowCollector(
-        kalshi_client=kalshi,
-        coinbase_client=FixtureCoinbaseClient(candles=fixture_candles(now)),
-        config=FairValueDecisionRowCollectorConfig(max_markets=1),
-    ).collect(now=now).as_dict()
+    payload = (
+        FairValueDecisionRowCollector(
+            kalshi_client=kalshi,
+            coinbase_client=FixtureCoinbaseClient(candles=fixture_candles(now)),
+            config=FairValueDecisionRowCollectorConfig(max_markets=1),
+        )
+        .collect(now=now)
+        .as_dict()
+    )
 
     assert payload["counts"]["skips"] == 1
     assert payload["skip_reasons"] == [{"reason": "unsupported_market_shape", "count": 1}]
@@ -553,6 +560,94 @@ def test_live_trading_job_skips_order_when_live_run_lock_is_held(
     assert attempts["skip_reasons"] == [{"reason": "live_run_lock_held", "count": 1}]
 
 
+def test_lock_held_duplicate_does_not_replace_latest_dashboard_status(
+    tmp_path: Path,
+    monkeypatch,
+    request,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    status_repository = LiveRunStatusRepository(settings.database_url)
+    delete_lock_duplicate_test_statuses(settings.database_url)
+    request.addfinalizer(lambda: delete_lock_duplicate_test_statuses(settings.database_url))
+    prior_run_id = f"fv_live_prior_{uuid4().hex[:8]}"
+    prior_status = build_fair_value_live_status(
+        manifest={
+            "run_id": prior_run_id,
+            "generated_at": "2099-06-04T15:00:00+00:00",
+            "runtime_config": {"config_id": "cfg_existing", "version": 1, "snapshot": {}},
+            "runtime_controls": {"live_orders_enabled": True, "orders_placed": 1},
+            "counts": {"live_attempts": 1, "replay_trades": 1},
+        },
+        attempts_payload={
+            "attempts": [
+                {
+                    "attempt_id": f"attempt_{prior_run_id}",
+                    "submitted_at": "2099-06-04T15:00:00+00:00",
+                    "market_ticker": "KXBTC15M-FV-PRIOR",
+                    "side": "yes",
+                    "status": "submitted",
+                    "reason": "submitted",
+                }
+            ]
+        },
+        reconciliation={
+            "rows": [
+                {
+                    "attempt_id": f"attempt_{prior_run_id}",
+                    "market_ticker": "KXBTC15M-FV-PRIOR",
+                    "filled_contracts": 0,
+                    "settlement_status": "no_fill",
+                }
+            ],
+            "per_market_exposure": {"markets": []},
+        },
+    )
+    status_repository.persist(prior_status)
+
+    now = datetime(2099, 6, 4, 15, 1, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-DUPLICATE-LOCK"
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "public_market_result",
+        lambda *, settings, ticker: {"status": "active", "result": None},
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "acquire_live_run_lock",
+        lambda **kwargs: fair_value_live_job.LiveRunLock(
+            backend="test",
+            acquired=False,
+            token="existing-lock",
+            reason="live_run_lock_held",
+            existing={"run_id": prior_run_id},
+        ),
+    )
+    client = SequencedOrderClient([{"fill_count": 2, "cost": 0.8, "fees": 0.02}])
+
+    FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now)
+
+    latest = status_repository.latest_status()
+    assert client.requests == []
+    assert latest.run_id == prior_run_id
+    assert latest.latest_attempt_reason == "submitted"
+    assert latest.fill_status == "no_fill"
+
+
 def test_live_trading_job_preserves_daily_cap_from_prior_exposure(
     tmp_path: Path,
     monkeypatch,
@@ -801,9 +896,7 @@ def test_live_trading_job_daily_cap_counts_settled_loss_and_unsettled_exposure_o
     assert admission_accounting["same_live_risk_day_unsettled_rows"] == 1
     assert admission_accounting["daily_loss_used_dollars"] == 44.75
     assert attempts["attempts"][0]["daily_loss_used_before_dollars"] == 44.75
-    assert manifest["runtime_controls"]["daily_loss_accounting"][
-        "daily_loss_used_dollars"
-    ] == 45.16
+    assert manifest["runtime_controls"]["daily_loss_accounting"]["daily_loss_used_dollars"] == 45.16
 
 
 def test_live_trading_job_uses_dashboard_config_for_order_sizing_and_manifest(
@@ -1055,7 +1148,10 @@ def write_prior_attempt(
                 "reason": "submitted",
                 "order_id": order_id,
                 "fill_count": fill_count,
-                "response_payload": {"order_id": order_id, "fill_count": f"{float(fill_count):.2f}"},
+                "response_payload": {
+                    "order_id": order_id,
+                    "fill_count": f"{float(fill_count):.2f}",
+                },
             }
         ],
     }
@@ -1074,3 +1170,16 @@ def live_runtime_repository_or_skip() -> LiveRuntimeConfigRepository:
         pytest.skip(f"Postgres is not available: {exc}")
     repository.apply_migrations()
     return LiveRuntimeConfigRepository(database_url)
+
+
+def delete_lock_duplicate_test_statuses(database_url: str) -> None:
+    with OperationalStateRepository(database_url).connect() as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                delete from live_run_statuses
+                where run_id like 'fv_live_prior_%'
+                   or run_id like 'fv_live_2099%'
+                """
+            )
+        connection.commit()


### PR DESCRIPTION
## Summary

Fixes ALP-188 by preventing duplicate scheduled live-worker invocations that lose the live-run lock from replacing the operator console's latest actionable live status.

## Root Cause

The AWS fair-value live worker can overlap at the current EventBridge cadence. The S3 live-run lock correctly prevents duplicate live order submission, but a lock-losing duplicate still materialized a `live_run_statuses` projection with `reason=live_run_lock_held` and `fill_status=not_submitted`. That made the dashboard look like the latest strategy decision did not submit, even when a nearby lock-owning run submitted normally.

## Changes

- Adds a narrow live-status materialization policy: lock-held duplicates still write auditable artifacts, but do not replace the dashboard projection.
- Records `runtime_controls.live_status_materialized` in the run manifest for handoff/debugging.
- Adds a regression test through the public `FairValueLiveTradingJob.run()` path.
- Updates the AWS dashboard runbook with the intended lock/projection behavior.

## Validation

- `.venv/bin/ruff check src/alphadb/model_evaluation/fair_value_live_job.py tests/test_fair_value_mvp.py`
- `.venv/bin/ruff format --check src/alphadb/model_evaluation/fair_value_live_job.py tests/test_fair_value_mvp.py`
- `.venv/bin/pytest tests/test_fair_value_mvp.py tests/test_live_runtime.py -q` (`25 passed`)
- `.venv/bin/pytest -q` (`222 passed, 22 warnings`; warnings are existing sklearn/scipy deprecations)