### PR TITLE
Fix AWS Cockpit cutover smoke auth

### DIFF
--- a/apps/dashboard/app/api/alphadb/[...path]/route.ts
+++ b/apps/dashboard/app/api/alphadb/[...path]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from "next/server"
 
+import { createAlphaDbApiAuthCookieHeader } from "@/lib/cockpit-auth"
+
 const DEFAULT_API_BASE = "http://127.0.0.1:8501"
 
 type RouteContext = {
@@ -29,6 +31,10 @@ async function proxy(request: NextRequest, context: RouteContext) {
   const contentType = request.headers.get("Content-Type")
   if (contentType) {
     headers.set("Content-Type", contentType)
+  }
+  const apiAuthCookie = await createAlphaDbApiAuthCookieHeader()
+  if (apiAuthCookie) {
+    headers.set("Cookie", apiAuthCookie)
   }
 
   const response = await fetch(upstream, {

--- a/apps/dashboard/lib/cockpit-auth.ts
+++ b/apps/dashboard/lib/cockpit-auth.ts
@@ -14,6 +14,7 @@ export type CockpitAuthConfig = {
 }
 
 const DEFAULT_COOKIE_NAME = "alphadb_cockpit_auth"
+const DEFAULT_LEGACY_DASHBOARD_COOKIE_NAME = "alphadb_dashboard_auth"
 const DEFAULT_COOKIE_TTL_SECONDS = 60 * 60 * 24 * 7
 
 function firstEnv(env: Env, ...keys: string[]) {
@@ -107,6 +108,26 @@ export async function createCockpitAuthToken(
   const encodedPayload = base64UrlEncode(payloadBytes)
   const encodedSignature = await sign(config.cookieSecret, payloadBytes)
   return `${encodedPayload}.${encodedSignature}`
+}
+
+export async function createAlphaDbApiAuthCookieHeader(
+  env: Env = process.env,
+  issuedAt = Math.floor(Date.now() / 1000),
+) {
+  const config = getCockpitAuthConfig(env)
+  if (!authIsActive(config) || !config.cookieSecret) return null
+
+  const cookieName =
+    firstEnv(env, "ALPHADB_DASHBOARD_COOKIE_NAME") || DEFAULT_LEGACY_DASHBOARD_COOKIE_NAME
+  const payload = {
+    exp: issuedAt + config.cookieTtlSeconds,
+    iat: issuedAt,
+    v: 1,
+  }
+  const payloadBytes = new TextEncoder().encode(canonicalJson(payload))
+  const encodedPayload = base64UrlEncode(payloadBytes)
+  const encodedSignature = await sign(config.cookieSecret, payloadBytes)
+  return `${cookieName}=${encodedPayload}.${encodedSignature}`
 }
 
 export async function verifyCockpitAuthToken(

--- a/apps/dashboard/scripts/smoke-auth.sh
+++ b/apps/dashboard/scripts/smoke-auth.sh
@@ -85,6 +85,7 @@ import sys
 with open(sys.argv[1], encoding="utf-8") as handle:
     payload = json.load(handle)
 
+payload = payload.get("data", payload)
 components = {
     component.get("component"): component.get("status")
     for component in payload.get("components", [])

--- a/deploy/aws/ecs-fargate-dashboard.yaml
+++ b/deploy/aws/ecs-fargate-dashboard.yaml
@@ -348,8 +348,6 @@ Resources:
           Subnets: !Ref PrivateSubnetIds
       ServiceRegistries:
         - RegistryArn: !GetAtt AlphaDbApiDiscoveryService.Arn
-          ContainerName: api
-          ContainerPort: !Ref AlphaDbApiPort
 
   CockpitService:
     Type: AWS::ECS::Service

--- a/deploy/aws/smoke-cockpit-stack.sh
+++ b/deploy/aws/smoke-cockpit-stack.sh
@@ -98,6 +98,7 @@ path = sys.argv[1]
 with open(path, encoding="utf-8") as handle:
     payload = json.load(handle)
 
+payload = payload.get("data", payload)
 components = {
     component.get("component"): component.get("status")
     for component in payload.get("components", [])


### PR DESCRIPTION
## Summary
- Add a server-to-server Python dashboard auth cookie when Cockpit proxies `/api/alphadb/*` to the private AlphaDB API.
- Remove `containerPort` from the Cloud Map-backed ECS service registry because `A` records do not require it.
- Let Cockpit smoke scripts validate wrapped AlphaDB API health responses.

## Why
During the ALP-205 AWS Cockpit cutover, the stack deployed successfully but public smoke exposed two issues: CloudFormation rejected the original service registry shape, then proxied health reached Python but returned wrapped `data.components`. The deployed Cockpit image now includes this hotfix and public smoke passes.

## Validation
- `.venv/bin/python -m pytest tests/test_deploy.py -q` -> 11 passed.
- `./node_modules/.bin/tsc --noEmit` in `apps/dashboard` -> passed.
- `./node_modules/.bin/next build` in `apps/dashboard` -> passed.
- `bash -n apps/dashboard/scripts/smoke-auth.sh deploy/aws/smoke-cockpit-stack.sh deploy/aws/deploy-cockpit-stack.sh` -> passed.
- `git diff --check` -> passed.
- `deploy/aws/smoke-cockpit-stack.sh` against `alphadb-dashboard` AWS stack -> passed.