### PR TITLE
Fix ALP-214 to ALP-217 live readiness gates

### DIFF
--- a/scripts/validate-fair-value-live-smoke.py
+++ b/scripts/validate-fair-value-live-smoke.py
@@ -38,19 +38,110 @@ def validate_smoke_evidence(payload: Mapping[str, Any]) -> list[str]:
         failures.append("overlapping_task_count must be 0")
     if _int(payload.get("stale_task_count")) != 0:
         failures.append("stale_task_count must be 0")
-    if _float(payload.get("max_quote_age_seconds")) > MAX_QUOTE_AGE_SECONDS:
-        failures.append("max_quote_age_seconds must be <= 15")
-    if _float(payload.get("min_contract_price")) != REQUIRED_MIN_CONTRACT_PRICE:
+
+    quote_evidence = _quote_evidence(payload)
+    if _quote_source(quote_evidence, payload) != "kalshi_orderbook":
+        failures.append("executable quote source must be kalshi_orderbook")
+    if _quote_age(quote_evidence, payload) > MAX_QUOTE_AGE_SECONDS:
+        failures.append("executable quote age must be <= 15")
+
+    runtime_guard = _runtime_guard(payload)
+    if runtime_guard.get("credentials_present") is not True:
+        failures.append("runtime_guard.credentials_present must be true")
+    if runtime_guard.get("can_submit_live_orders") is not True:
+        failures.append("runtime_guard.can_submit_live_orders must be true")
+    if payload.get("live_order_guards_preserved") is not True:
+        failures.append("live_order_guards_preserved must be true")
+
+    risk_state = _risk_state(payload)
+    risk_status = str(risk_state.get("status") or risk_state.get("risk_state_status") or "")
+    risk_reason = risk_state.get("reason", risk_state.get("risk_state_reason"))
+    if risk_status != "active":
+        failures.append("live risk admission state must be active")
+    if risk_reason not in (None, "", "fresh"):
+        failures.append("live risk admission state must be fresh")
+
+    if _float(_runtime_value(payload, "min_contract_price")) != REQUIRED_MIN_CONTRACT_PRICE:
         failures.append("min_contract_price must be 0.25")
-    if _float(payload.get("min_edge")) != REQUIRED_MIN_EDGE:
+    if _float(_runtime_value(payload, "min_edge")) != REQUIRED_MIN_EDGE:
         failures.append("min_edge must remain 0")
     if payload.get("task_definition_one_cycle") is not True:
         failures.append("task_definition_one_cycle must be true")
-    if payload.get("live_order_guards_preserved") is not True:
-        failures.append("live_order_guards_preserved must be true")
     if str(payload.get("schedule_state_before") or "").upper() != "DISABLED":
         failures.append("schedule_state_before must be DISABLED")
     return failures
+
+
+def _quote_evidence(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    for key in ("executable_quote", "quote_freshness"):
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def _quote_source(quote_evidence: Mapping[str, Any], payload: Mapping[str, Any]) -> str:
+    return str(
+        quote_evidence.get("source")
+        or quote_evidence.get("quote_source")
+        or payload.get("quote_source")
+        or ""
+    )
+
+
+def _quote_age(quote_evidence: Mapping[str, Any], payload: Mapping[str, Any]) -> float:
+    freshness = quote_evidence.get("freshness")
+    freshness_map = freshness if isinstance(freshness, Mapping) else {}
+    for value in (
+        quote_evidence.get("max_quote_age_seconds"),
+        quote_evidence.get("quote_age_seconds"),
+        freshness_map.get("quote_age_seconds"),
+        payload.get("max_quote_age_seconds"),
+    ):
+        parsed = _float(value)
+        if parsed != float("inf"):
+            return parsed
+    return float("inf")
+
+
+def _runtime_guard(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    runtime_guard = payload.get("runtime_guard")
+    if isinstance(runtime_guard, Mapping):
+        return runtime_guard
+    runtime_controls = payload.get("runtime_controls")
+    if isinstance(runtime_controls, Mapping):
+        nested = runtime_controls.get("runtime_guard")
+        if isinstance(nested, Mapping):
+            return nested
+    return {}
+
+
+def _risk_state(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    for key in ("live_risk_admission_state", "risk_state", "admission_daily_loss_accounting"):
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            return value
+    runtime_controls = payload.get("runtime_controls")
+    if isinstance(runtime_controls, Mapping):
+        for key in ("admission_daily_loss_accounting", "daily_loss_accounting"):
+            value = runtime_controls.get(key)
+            if isinstance(value, Mapping):
+                return value
+    return {}
+
+
+def _runtime_value(payload: Mapping[str, Any], key: str) -> Any:
+    if key in payload:
+        return payload[key]
+    runtime_controls = payload.get("runtime_controls")
+    if isinstance(runtime_controls, Mapping) and key in runtime_controls:
+        return runtime_controls[key]
+    runtime_config = payload.get("runtime_config")
+    if isinstance(runtime_config, Mapping):
+        snapshot = runtime_config.get("snapshot")
+        if isinstance(snapshot, Mapping) and key in snapshot:
+            return snapshot[key]
+    return None
 
 
 def _float(value: Any) -> float:

--- a/src/alphadb/live_orders.py
+++ b/src/alphadb/live_orders.py
@@ -431,6 +431,14 @@ def materialize_private_key_from_env(
     path = Path(default_path)
     path.write_text(pem.replace("\\n", "\n"), encoding="utf-8")
     path.chmod(0o600)
+    try:
+        load_private_key(path)
+    except Exception as exc:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        raise LiveOrderError("KALSHI_PRIVATE_KEY_PEM is not a valid RSA private key") from exc
     os.environ[path_env_var] = str(path)
     return path
 

--- a/src/alphadb/live_risk.py
+++ b/src/alphadb/live_risk.py
@@ -197,6 +197,64 @@ class LiveRiskAdmissionRepository:
                 row = cursor.fetchone()
         return None if row is None else state_from_row(row)
 
+    def create_zero_state_if_missing(
+        self,
+        *,
+        strategy: str = FAIR_VALUE_LIVE_STRATEGY,
+        live_risk_day: date,
+        updated_at: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> tuple[LiveRiskAdmissionState, bool]:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        observed_at = ensure_utc(updated_at or datetime.now(UTC))
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into live_risk_admission_states (
+                        strategy,
+                        live_risk_day,
+                        daily_loss_used_dollars,
+                        open_exposure_dollars,
+                        pending_exposure_dollars,
+                        per_market_exposure,
+                        pending_reservations,
+                        updated_at,
+                        version,
+                        status,
+                        metadata
+                    )
+                    values (%s, %s, 0, 0, 0, %s, %s, %s, 1, 'active', %s)
+                    on conflict (strategy, live_risk_day) do nothing
+                    returning *
+                    """,
+                    (
+                        strategy,
+                        live_risk_day,
+                        Jsonb({}),
+                        Jsonb({}),
+                        observed_at,
+                        Jsonb(dict(metadata or {})),
+                    ),
+                )
+                row = cursor.fetchone()
+                if row is not None:
+                    connection.commit()
+                    return state_from_row(row), True
+                cursor.execute(
+                    """
+                    select *
+                    from live_risk_admission_states
+                    where strategy = %s and live_risk_day = %s
+                    """,
+                    (strategy, live_risk_day),
+                )
+                existing = cursor.fetchone()
+            connection.commit()
+        if existing is None:
+            raise RuntimeError("live risk admission state bootstrap returned no row")
+        return state_from_row(existing), False
+
     def admit_order(
         self,
         *,

--- a/src/alphadb/model_evaluation/fair_value_live.py
+++ b/src/alphadb/model_evaluation/fair_value_live.py
@@ -161,14 +161,35 @@ class FairValueDecisionRowCollector:
             or market.get("expiration_time"),
             open_time + timedelta(minutes=self.spec.horizon_minutes),
         )
-        yes_ask = quote_price(market, ("yes_ask_dollars", "yes_ask", "yes_price"))
-        no_ask = quote_price(market, ("no_ask_dollars", "no_ask", "no_price"))
+        market_list_yes_ask = quote_price(market, ("yes_ask_dollars", "yes_ask", "yes_price"))
+        market_list_no_ask = quote_price(market, ("no_ask_dollars", "no_ask", "no_price"))
         threshold = payout_threshold(market)
-        quote_observed_at = parse_kalshi_datetime(market.get("updated_time"), now)
+        market_metadata_updated_at = parse_kalshi_datetime(market.get("updated_time"), now)
         try:
             orderbook = self.kalshi_client.get_orderbook(market_ticker)
         except Exception as exc:
             return skip_row(base, "missing_quote", error_type=type(exc).__name__, error_message=str(exc))
+        quote_observed_at = now
+        if threshold is None:
+            return skip_row(
+                {
+                    **base,
+                    "market_open_time": open_time.isoformat(),
+                    "close_time": close_time.isoformat(),
+                    "yes_ask": market_list_yes_ask,
+                    "no_ask": market_list_no_ask,
+                    "quote_observed_at": quote_observed_at.isoformat(),
+                    "market_metadata_updated_at": market_metadata_updated_at.isoformat(),
+                    "market_list_yes_ask": market_list_yes_ask,
+                    "market_list_no_ask": market_list_no_ask,
+                    "orderbook_observed": True,
+                    "orderbook_shape": orderbook_shape(orderbook),
+                },
+                "unsupported_market_shape",
+            )
+        executable_quotes = executable_orderbook_quotes(orderbook)
+        yes_ask = executable_quotes["yes_ask"]
+        no_ask = executable_quotes["no_ask"]
         if yes_ask is None or no_ask is None:
             return skip_row(
                 {
@@ -176,22 +197,14 @@ class FairValueDecisionRowCollector:
                     "market_open_time": open_time.isoformat(),
                     "close_time": close_time.isoformat(),
                     "quote_observed_at": quote_observed_at.isoformat(),
-                },
-                "missing_quote",
-            )
-        if threshold is None:
-            return skip_row(
-                {
-                    **base,
-                    "market_open_time": open_time.isoformat(),
-                    "close_time": close_time.isoformat(),
-                    "yes_ask": yes_ask,
-                    "no_ask": no_ask,
-                    "quote_observed_at": quote_observed_at.isoformat(),
+                    "market_metadata_updated_at": market_metadata_updated_at.isoformat(),
+                    "market_list_yes_ask": market_list_yes_ask,
+                    "market_list_no_ask": market_list_no_ask,
                     "orderbook_observed": True,
                     "orderbook_shape": orderbook_shape(orderbook),
+                    "quote_source": "kalshi_orderbook",
                 },
-                "unsupported_market_shape",
+                "missing_orderbook_quote",
             )
 
         try:
@@ -205,6 +218,10 @@ class FairValueDecisionRowCollector:
                     "yes_ask": yes_ask,
                     "no_ask": no_ask,
                     "quote_observed_at": quote_observed_at.isoformat(),
+                    "market_metadata_updated_at": market_metadata_updated_at.isoformat(),
+                    "market_list_yes_ask": market_list_yes_ask,
+                    "market_list_no_ask": market_list_no_ask,
+                    **executable_quotes,
                     "payout_threshold": threshold,
                 },
                 "missing_feature_data",
@@ -221,9 +238,14 @@ class FairValueDecisionRowCollector:
             "yes_ask": yes_ask,
             "no_ask": no_ask,
             "quote_observed_at": quote_observed_at.isoformat(),
+            "quote_source": "kalshi_orderbook",
+            "market_metadata_updated_at": market_metadata_updated_at.isoformat(),
+            "market_list_yes_ask": market_list_yes_ask,
+            "market_list_no_ask": market_list_no_ask,
             "payout_threshold": threshold,
             "orderbook_observed": True,
             "orderbook_shape": orderbook_shape(orderbook),
+            **executable_quotes,
             **features,
             **feature_metadata,
         }
@@ -339,10 +361,54 @@ def quote_price(market: Mapping[str, Any], keys: Sequence[str]) -> float | None:
     return None
 
 
+def executable_orderbook_quotes(orderbook: Mapping[str, Any]) -> dict[str, float | None]:
+    payload = orderbook_payload(orderbook)
+    yes_bid = first_level_contract_price(payload.get("yes_dollars") or payload.get("yes") or [])
+    no_bid = first_level_contract_price(payload.get("no_dollars") or payload.get("no") or [])
+    yes_ask = round(1.0 - no_bid, 6) if no_bid is not None else None
+    no_ask = round(1.0 - yes_bid, 6) if yes_bid is not None else None
+    return {
+        "yes_ask": yes_ask,
+        "no_ask": no_ask,
+        "orderbook_yes_bid": yes_bid,
+        "orderbook_no_bid": no_bid,
+    }
+
+
+def orderbook_payload(orderbook: Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(orderbook.get("orderbook_fp"), Mapping):
+        return orderbook["orderbook_fp"]
+    if isinstance(orderbook.get("orderbook"), Mapping):
+        nested = orderbook["orderbook"]
+        if isinstance(nested.get("orderbook_fp"), Mapping):
+            return nested["orderbook_fp"]
+        return nested
+    return orderbook
+
+
+def first_level_contract_price(levels: Any) -> float | None:
+    price = first_level_price(levels)
+    if price is None:
+        return None
+    price = price / 100.0 if price > 1.0 else price
+    if price <= 0.0 or price >= 1.0:
+        return None
+    return round(price, 6)
+
+
+def first_level_price(levels: Any) -> float | None:
+    if not levels:
+        return None
+    first = levels[0]
+    if not isinstance(first, Sequence) or isinstance(first, (str, bytes)) or not first:
+        return None
+    return optional_float(first[0])
+
+
 def orderbook_shape(orderbook: Mapping[str, Any]) -> dict[str, Any]:
-    payload = orderbook.get("orderbook_fp") if isinstance(orderbook.get("orderbook_fp"), Mapping) else orderbook
-    yes = payload.get("yes_dollars") if isinstance(payload, Mapping) else None
-    no = payload.get("no_dollars") if isinstance(payload, Mapping) else None
+    payload = orderbook_payload(orderbook)
+    yes = (payload.get("yes_dollars") or payload.get("yes")) if isinstance(payload, Mapping) else None
+    no = (payload.get("no_dollars") or payload.get("no")) if isinstance(payload, Mapping) else None
     return {
         "yes_levels": len(yes) if isinstance(yes, list) else 0,
         "no_levels": len(no) if isinstance(no, list) else 0,

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -123,7 +123,7 @@ class FairValueLiveTradingJob:
         self.order_client = order_client or HttpKalshiLiveOrderClient()
 
     def run(self, *, now: datetime | None = None) -> dict[str, Any]:
-        settings = self._settings or settings_from_env()
+        settings, credential_materialization = settings_with_materialized_private_key(self._settings)
         original_config = self.config
         generated_at = ensure_utc(now or datetime.now(UTC))
         run_id = f"fv_live_{generated_at.strftime('%Y%m%dT%H%M%SZ')}"
@@ -179,7 +179,10 @@ class FairValueLiveTradingJob:
                         live_risk_timezone=original_config.live_risk_timezone,
                         reason="live_run_lock_held",
                     ),
-                    runtime_guard=evaluate_runtime_guard(settings).as_dict(),
+                    runtime_guard=runtime_guard_with_credential_materialization(
+                        settings=settings,
+                        credential_materialization=credential_materialization,
+                    ).as_dict(),
                     live_run_lock=live_run_lock,
                     timer=timer,
                     require_postgres=False,
@@ -192,7 +195,10 @@ class FairValueLiveTradingJob:
                     settings=settings,
                 )
                 self.config = effective_config
-                guard = evaluate_runtime_guard(settings)
+                guard = runtime_guard_with_credential_materialization(
+                    settings=settings,
+                    credential_materialization=credential_materialization,
+                )
             with timer.phase("collection"):
                 collector = FairValueDecisionRowCollector(
                     kalshi_client=make_kalshi_client(self.config.source, settings),
@@ -229,18 +235,33 @@ class FairValueLiveTradingJob:
                 live_risk_timezone=self.config.live_risk_timezone,
             )
             admission_state: LiveRiskAdmissionState | None = None
-            if self.config.submit_live_orders:
+            risk_state_read: Mapping[str, Any] = {
+                "risk_state_bootstrapped": False,
+                "risk_state_read_reason": "risk_state_not_required",
+            }
+            should_prepare_risk_state = (
+                self.config.submit_live_orders
+                and guard.can_submit_live_orders
+                and selected_decision.get("decision") == "trade"
+            )
+            if should_prepare_risk_state:
                 with timer.phase("risk_state_read"):
-                    admission_state = live_risk_state_for_day(
+                    admission_state, risk_state_read = live_risk_state_for_admission(
                         settings=settings,
                         strategy=FAIR_VALUE_LIVE_STRATEGY,
                         live_risk_day=live_risk_day,
+                        generated_at=generated_at,
+                        run_id=run_id,
                     )
-            admission_daily_loss_accounting = live_risk_accounting_report(
-                admission_state,
-                generated_at=generated_at,
-                live_risk_timezone=self.config.live_risk_timezone,
-            )
+            admission_daily_loss_accounting = {
+                **live_risk_accounting_report(
+                    admission_state,
+                    generated_at=generated_at,
+                    live_risk_timezone=self.config.live_risk_timezone,
+                    stale_after_seconds=self.config.live_risk_state_stale_seconds,
+                ),
+                **dict(risk_state_read),
+            }
             live_attempt, risk_transition, order_submit_at = self._submit_one_cycle_attempt(
                 decision=selected_decision,
                 decision_row=selected_row,
@@ -270,6 +291,7 @@ class FairValueLiveTradingJob:
                 final_state or admission_state,
                 generated_at=generated_at,
                 live_risk_timezone=self.config.live_risk_timezone,
+                stale_after_seconds=self.config.live_risk_state_stale_seconds,
             )
             live_attempts_payload = {
                 "schema_version": FAIR_VALUE_LIVE_ATTEMPTS_SCHEMA,
@@ -351,6 +373,7 @@ class FairValueLiveTradingJob:
             else 0.0
         )
         risk_before = admission_state.total_risk_used_dollars if admission_state else 0.0
+        freshness = live_decision_freshness(decision_row, generated_at=generated_at)
         base = {
             "attempt_id": f"fv_live_order_{uuid4().hex[:12]}",
             "run_id": run_id,
@@ -378,7 +401,10 @@ class FairValueLiveTradingJob:
                     or 0
                 ),
             },
-            "freshness": live_decision_freshness(decision_row, generated_at=generated_at),
+            "quote_source": (decision_row or {}).get("quote_source"),
+            "quote_seen_at": freshness.get("quote_seen_at"),
+            "quote_age_seconds": freshness.get("quote_age_seconds"),
+            "freshness": freshness,
             "runtime_guard": dict(runtime_guard),
             "live_run_lock": live_run_lock.as_dict(),
             "attempt_index": 0,
@@ -559,6 +585,7 @@ class FairValueLiveTradingJob:
         collected_counts = as_mapping((collected or {}).get("counts"))
         selected_trade = (selected_decision or {}).get("decision") == "trade"
         latest_attempt = dict(live_attempts[-1]) if live_attempts else {}
+        latest_freshness = as_mapping(latest_attempt.get("freshness"))
         manifest = {
             "schema_version": FAIR_VALUE_LIVE_JOB_SCHEMA,
             "run_id": run_id,
@@ -577,12 +604,27 @@ class FairValueLiveTradingJob:
                 "max_market_exposure_dollars": self.config.max_ticker_exposure_dollars,
                 "max_ticker_exposure_dollars": self.config.max_ticker_exposure_dollars,
                 "max_daily_loss_dollars": self.config.max_daily_loss_dollars,
+                "min_edge": self.config.min_edge,
                 "min_contract_price": self.config.min_contract_price,
                 "admission_daily_loss_accounting": dict(admission_daily_loss_accounting),
                 "daily_loss_accounting": dict(daily_loss_accounting),
                 "runtime_guard": dict(runtime_guard),
                 "live_run_lock": live_run_lock.as_dict(),
                 "live_status_materialized": False,
+            },
+            "executable_quote": {
+                "source": latest_attempt.get("quote_source"),
+                "quote_seen_at": latest_attempt.get("quote_seen_at"),
+                "max_quote_age_seconds": latest_attempt.get("quote_age_seconds"),
+                "freshness": dict(latest_freshness),
+            },
+            "live_risk_admission_state": {
+                "status": daily_loss_accounting.get("risk_state_status"),
+                "reason": daily_loss_accounting.get("risk_state_reason"),
+                "updated_at": daily_loss_accounting.get("risk_state_updated_at"),
+                "version": daily_loss_accounting.get("risk_state_version"),
+                "bootstrapped": daily_loss_accounting.get("risk_state_bootstrapped"),
+                "read_reason": daily_loss_accounting.get("risk_state_read_reason"),
             },
             "selected_decision": dict(selected_decision or {}),
             "selected_row": dict(selected_row or {}),
@@ -876,6 +918,50 @@ def runtime_config_snapshot(config: FairValueLiveTradingJobConfig) -> dict[str, 
     }
 
 
+def settings_with_materialized_private_key(
+    settings: Settings | None,
+) -> tuple[Settings, dict[str, Any]]:
+    materialization: dict[str, Any] = {
+        "private_key_pem_present": bool(os.environ.get("KALSHI_PRIVATE_KEY_PEM")),
+        "private_key_path_materialized": False,
+        "credential_error": None,
+    }
+    if settings is not None and settings.kalshi_private_key_path:
+        return settings, materialization
+    try:
+        materialized_path = materialize_private_key_from_env()
+    except Exception as exc:
+        materialization["credential_error"] = "invalid_kalshi_credentials"
+        materialization["error_type"] = type(exc).__name__
+        return settings or settings_from_env(), materialization
+    effective = settings or settings_from_env()
+    if materialized_path is not None and not effective.kalshi_private_key_path:
+        effective = replace(effective, kalshi_private_key_path=str(materialized_path))
+        materialization["private_key_path_materialized"] = True
+    return effective, materialization
+
+
+def runtime_guard_with_credential_materialization(
+    *,
+    settings: Settings,
+    credential_materialization: Mapping[str, Any],
+):
+    guard = evaluate_runtime_guard(settings)
+    if (
+        credential_materialization.get("credential_error")
+        and guard.runtime_mode.value == "gated-live"
+        and settings.enable_live_orders
+    ):
+        return replace(
+            guard,
+            live_enabled=False,
+            can_submit_live_orders=False,
+            denial_reason=str(credential_materialization["credential_error"]),
+            credentials_present=False,
+        )
+    return guard
+
+
 def lock_held_attempt(
     *,
     run_id: str,
@@ -1034,11 +1120,59 @@ def live_risk_state_for_day(
         return None
 
 
+def live_risk_state_for_admission(
+    *,
+    settings: Settings,
+    strategy: str,
+    live_risk_day: date,
+    generated_at: datetime,
+    run_id: str,
+) -> tuple[LiveRiskAdmissionState | None, dict[str, Any]]:
+    repository = LiveRiskAdmissionRepository(settings.database_url)
+    try:
+        state = repository.get_state(strategy=strategy, live_risk_day=live_risk_day)
+    except Exception as exc:
+        return None, {
+            "risk_state_bootstrapped": False,
+            "risk_state_read_reason": "risk_state_unavailable",
+            "risk_state_error_type": type(exc).__name__,
+        }
+    if state is not None:
+        return state, {
+            "risk_state_bootstrapped": False,
+            "risk_state_read_reason": "existing_current_live_risk_day",
+        }
+    try:
+        state, created = repository.create_zero_state_if_missing(
+            strategy=strategy,
+            live_risk_day=live_risk_day,
+            updated_at=generated_at,
+            metadata={
+                "bootstrap_reason": "missing_current_live_risk_day",
+                "bootstrap_run_id": run_id,
+                "full_reconciliation_performed": False,
+            },
+        )
+    except Exception as exc:
+        return None, {
+            "risk_state_bootstrapped": False,
+            "risk_state_read_reason": "risk_state_unavailable",
+            "risk_state_error_type": type(exc).__name__,
+        }
+    return state, {
+        "risk_state_bootstrapped": created,
+        "risk_state_read_reason": "bootstrapped_missing_current_live_risk_day"
+        if created
+        else "existing_current_live_risk_day",
+    }
+
+
 def live_risk_accounting_report(
     state: LiveRiskAdmissionState | None,
     *,
     generated_at: datetime,
     live_risk_timezone: str,
+    stale_after_seconds: int = DEFAULT_LIVE_RISK_STALE_SECONDS,
 ) -> dict[str, Any]:
     live_risk_day, window_start_utc, window_end_utc = live_risk_window(
         generated_at=generated_at,
@@ -1056,7 +1190,7 @@ def live_risk_accounting_report(
     invalid_reason = state_denial_reason(
         state,
         now=generated_at,
-        stale_after_seconds=DEFAULT_LIVE_RISK_STALE_SECONDS,
+        stale_after_seconds=stale_after_seconds,
     )
     return {
         "schema_version": FAIR_VALUE_LIVE_DAILY_LOSS_ACCOUNTING_SCHEMA,

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from copy import deepcopy
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -301,40 +302,31 @@ def test_fair_value_live_aws_template_enables_live_money_with_minimal_caps() -> 
 
 def test_fair_value_live_smoke_validator_requires_runtime_gate_evidence(tmp_path: Path) -> None:
     script = Path("scripts/validate-fair-value-live-smoke.py")
-    passing = tmp_path / "passing.json"
-    passing.write_text(
-        json.dumps(
-            {
-                "p95_runtime_seconds": 44.9,
-                "overlapping_task_count": 0,
-                "stale_task_count": 0,
-                "max_quote_age_seconds": 15,
-                "min_contract_price": 0.25,
-                "min_edge": 0,
-                "task_definition_one_cycle": True,
-                "live_order_guards_preserved": True,
-                "schedule_state_before": "DISABLED",
-            }
-        ),
-        encoding="utf-8",
-    )
-    failing = tmp_path / "failing.json"
-    failing.write_text(
-        json.dumps(
-            {
-                "p95_runtime_seconds": 45,
-                "overlapping_task_count": 1,
-                "stale_task_count": 0,
-                "max_quote_age_seconds": 16,
-                "min_contract_price": 0.2,
-                "min_edge": 0.01,
-                "task_definition_one_cycle": False,
-                "live_order_guards_preserved": True,
-                "schedule_state_before": "ENABLED",
-            }
-        ),
-        encoding="utf-8",
-    )
+    passing_payload = {
+        "p95_runtime_seconds": 44.9,
+        "overlapping_task_count": 0,
+        "stale_task_count": 0,
+        "executable_quote": {
+            "source": "kalshi_orderbook",
+            "max_quote_age_seconds": 15,
+        },
+        "runtime_guard": {
+            "credentials_present": True,
+            "can_submit_live_orders": True,
+        },
+        "live_risk_admission_state": {
+            "status": "active",
+            "reason": None,
+        },
+        "runtime_controls": {
+            "min_contract_price": 0.25,
+            "min_edge": 0,
+        },
+        "task_definition_one_cycle": True,
+        "live_order_guards_preserved": True,
+        "schedule_state_before": "DISABLED",
+    }
+    passing = write_smoke_payload(tmp_path, "passing", passing_payload)
 
     ok = subprocess.run(
         [sys.executable, str(script), str(passing)],
@@ -342,17 +334,75 @@ def test_fair_value_live_smoke_validator_requires_runtime_gate_evidence(tmp_path
         capture_output=True,
         text=True,
     )
-    bad = subprocess.run(
-        [sys.executable, str(script), str(failing)],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
 
     assert ok.returncode == 0
-    assert bad.returncode == 1
-    assert "p95_runtime_seconds" in bad.stderr
-    assert "schedule_state_before" in bad.stderr
+
+    cases = {
+        "p95_runtime": (
+            lambda payload: payload.update({"p95_runtime_seconds": 45}),
+            "p95_runtime_seconds",
+        ),
+        "quote_age": (
+            lambda payload: payload["executable_quote"].update({"max_quote_age_seconds": 16}),
+            "executable quote age",
+        ),
+        "credentials": (
+            lambda payload: payload["runtime_guard"].update({"credentials_present": False}),
+            "credentials_present",
+        ),
+        "live_order_guards": (
+            lambda payload: payload.update({"live_order_guards_preserved": False}),
+            "live_order_guards_preserved",
+        ),
+        "risk_state": (
+            lambda payload: payload["live_risk_admission_state"].update(
+                {"status": "active", "reason": "risk_state_stale"}
+            ),
+            "live risk admission state must be fresh",
+        ),
+        "schedule": (
+            lambda payload: payload.update({"schedule_state_before": "ENABLED"}),
+            "schedule_state_before",
+        ),
+        "min_contract_price": (
+            lambda payload: payload["runtime_controls"].update({"min_contract_price": 0.2}),
+            "min_contract_price",
+        ),
+        "min_edge": (
+            lambda payload: payload["runtime_controls"].update({"min_edge": 0.01}),
+            "min_edge",
+        ),
+        "overlap": (
+            lambda payload: payload.update({"overlapping_task_count": 1}),
+            "overlapping_task_count",
+        ),
+        "stale_tasks": (
+            lambda payload: payload.update({"stale_task_count": 1}),
+            "stale_task_count",
+        ),
+        "one_cycle": (
+            lambda payload: payload.update({"task_definition_one_cycle": False}),
+            "task_definition_one_cycle",
+        ),
+    }
+    for name, (mutate, expected) in cases.items():
+        payload = deepcopy(passing_payload)
+        mutate(payload)
+        path = write_smoke_payload(tmp_path, name, payload)
+        bad = subprocess.run(
+            [sys.executable, str(script), str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert bad.returncode == 1
+        assert expected in bad.stderr
+
+
+def write_smoke_payload(tmp_path: Path, name: str, payload: dict) -> Path:
+    path = tmp_path / f"{name}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
 
 
 def test_runtime_config_status_reports_readable_active_config(monkeypatch) -> None:

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 
 import psycopg
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from alphadb.collectors.coinbase import FixtureCoinbaseClient
 from alphadb.collectors.kalshi_rest import FixtureKalshiRestClient
@@ -237,7 +240,7 @@ def test_live_fair_value_collector_outputs_decision_rows_without_orders() -> Non
                 "status": "open",
                 "open_time": (now - timedelta(minutes=10)).isoformat(),
                 "close_time": (now + timedelta(minutes=5)).isoformat(),
-                "updated_time": (now - timedelta(seconds=1)).isoformat(),
+                "updated_time": (now - timedelta(minutes=5)).isoformat(),
                 "title": "Bitcoin above $100?",
                 "payout_threshold": "100.00",
                 "yes_ask_dollars": "0.40",
@@ -269,7 +272,12 @@ def test_live_fair_value_collector_outputs_decision_rows_without_orders() -> Non
     assert row["row_type"] == "decision"
     assert row["p_yes"] > 0.5
     assert row["no_lookahead_source_check"] is True
-    assert row["yes_ask"] == 0.40
+    assert row["yes_ask"] == 0.41
+    assert row["no_ask"] == 0.61
+    assert row["quote_source"] == "kalshi_orderbook"
+    assert row["quote_observed_at"] == now.isoformat()
+    assert row["market_metadata_updated_at"] == (now - timedelta(minutes=5)).isoformat()
+    assert row["market_list_yes_ask"] == 0.40
 
 
 def test_live_fair_value_collector_records_skip_reasons() -> None:
@@ -305,6 +313,42 @@ def test_live_fair_value_collector_records_skip_reasons() -> None:
     assert payload["counts"]["skips"] == 1
     assert payload["skip_reasons"] == [{"reason": "unsupported_market_shape", "count": 1}]
     assert payload["orders_placed"] == 0
+
+
+def test_live_fair_value_collector_skips_missing_orderbook_quotes() -> None:
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-MISSING-ORDERBOOK"
+    kalshi = FixtureKalshiRestClient(
+        markets=[
+            {
+                "ticker": ticker,
+                "series_ticker": "KXBTC15M",
+                "status": "open",
+                "open_time": (now - timedelta(minutes=10)).isoformat(),
+                "close_time": (now + timedelta(minutes=5)).isoformat(),
+                "updated_time": (now - timedelta(minutes=5)).isoformat(),
+                "title": "Bitcoin above $100?",
+                "payout_threshold": "100.00",
+                "yes_ask_dollars": "0.40",
+                "no_ask_dollars": "0.60",
+            }
+        ],
+        orderbooks={ticker: {"orderbook_fp": {"yes_dollars": [], "no_dollars": []}}},
+    )
+
+    payload = (
+        FairValueDecisionRowCollector(
+            kalshi_client=kalshi,
+            coinbase_client=FixtureCoinbaseClient(candles=fixture_candles(now)),
+            config=FairValueDecisionRowCollectorConfig(max_markets=1),
+        )
+        .collect(now=now)
+        .as_dict()
+    )
+
+    assert payload["counts"]["skips"] == 1
+    assert payload["skip_reasons"] == [{"reason": "missing_orderbook_quote", "count": 1}]
+    assert payload["rows"][0]["quote_source"] == "kalshi_orderbook"
 
 
 def test_live_trading_job_submits_capped_order_and_reports_settled_pnl(
@@ -379,6 +423,9 @@ def test_live_trading_job_submits_capped_order_and_reports_settled_pnl(
     assert manifest["runtime_controls"]["report_only"] is False
     assert manifest["runtime_controls"]["live_orders_enabled"] is True
     assert manifest["runtime_controls"]["orders_placed"] == 1
+    assert manifest["runtime_controls"]["admission_daily_loss_accounting"][
+        "risk_state_bootstrapped"
+    ] is False
     assert client.requests[0]["time_in_force"] == "immediate_or_cancel"
     assert float(client.requests[0]["count"]) >= 1
     assert manifest["hot_path_scope"] == "one_current_decision_no_replay_no_walk_forward_no_full_history"
@@ -392,6 +439,83 @@ def test_live_trading_job_submits_capped_order_and_reports_settled_pnl(
     assert reconciliation["scope"] == "current_attempt_compact"
     assert reconciliation["settlement"]["status"] == "unreconciled"
     assert reconciliation["pnl"]["filled_contracts"] == 2
+
+
+def test_live_trading_job_materializes_aws_pem_before_runtime_guard(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-PEM"
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    seed_live_risk_state(now=now)
+    monkeypatch.setenv("ALPHADB_RUNTIME_MODE", "gated-live")
+    monkeypatch.setenv("ALPHADB_ENABLE_LIVE_ORDERS", "1")
+    monkeypatch.setenv("ALPHADB_HUMAN_CUTOVER_APPROVED", "1")
+    monkeypatch.setenv("KALSHI_API_KEY_ID", "key-id")
+    monkeypatch.delenv("KALSHI_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.setenv("KALSHI_PRIVATE_KEY_PEM", sample_private_key_pem())
+    client = SequencedOrderClient([{"fill_count": 1, "cost": 0.4, "fees": 0.01}])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+        ),
+        order_client=client,
+    ).run(now=now)
+    os.environ.pop("KALSHI_PRIVATE_KEY_PATH", None)
+
+    guard = manifest["runtime_controls"]["runtime_guard"]
+    assert guard["credentials_present"] is True
+    assert guard["can_submit_live_orders"] is True
+    assert len(client.requests) == 1
+    assert "BEGIN RSA PRIVATE KEY" not in json.dumps(manifest)
+
+
+def test_live_trading_job_fails_closed_for_invalid_aws_pem(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-BAD-PEM"
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    seed_live_risk_state(now=now)
+    monkeypatch.setenv("ALPHADB_RUNTIME_MODE", "gated-live")
+    monkeypatch.setenv("ALPHADB_ENABLE_LIVE_ORDERS", "1")
+    monkeypatch.setenv("ALPHADB_HUMAN_CUTOVER_APPROVED", "1")
+    monkeypatch.setenv("KALSHI_API_KEY_ID", "key-id")
+    monkeypatch.delenv("KALSHI_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.setenv("KALSHI_PRIVATE_KEY_PEM", "not a private key")
+    client = SequencedOrderClient([{"fill_count": 1, "cost": 0.4, "fees": 0.01}])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+        ),
+        order_client=client,
+    ).run(now=now)
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    guard = manifest["runtime_controls"]["runtime_guard"]
+    assert client.requests == []
+    assert guard["credentials_present"] is False
+    assert guard["can_submit_live_orders"] is False
+    assert guard["denial_reason"] == "invalid_kalshi_credentials"
+    assert attempts["attempts"][0]["reason"] == "invalid_kalshi_credentials"
 
 
 def test_live_trading_cli_uses_env_caps_when_flags_are_omitted(
@@ -524,12 +648,12 @@ def test_live_trading_job_records_replay_skip_as_live_attempt(
     assert attempts["skip_reasons"] == [{"reason": "edge_below_min", "count": 1}]
 
 
-def test_live_trading_job_fails_closed_when_risk_state_is_missing(
+def test_live_trading_job_bootstraps_missing_current_live_risk_day_state(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
-    ticker = "KXBTC15M-FV-MISSING-RISK"
+    ticker = "KXBTC15M-FV-BOOTSTRAP-RISK"
     install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
     delete_live_risk_states(settings_from_env().database_url)
     client = SequencedOrderClient([{"fill_count": 1, "cost": 0.4, "fees": 0.01}])
@@ -550,18 +674,65 @@ def test_live_trading_job_fails_closed_when_risk_state_is_missing(
     ).run(now=now)
 
     attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
-    assert client.requests == []
-    assert attempts["attempts"][0]["status"] == "skipped"
-    assert attempts["attempts"][0]["reason"] == "risk_state_missing"
+    assert len(client.requests) == 1
+    assert attempts["admission_daily_loss_accounting"]["risk_state_bootstrapped"] is True
+    assert (
+        attempts["admission_daily_loss_accounting"]["risk_state_read_reason"]
+        == "bootstrapped_missing_current_live_risk_day"
+    )
+    assert attempts["attempts"][0]["status"] == "submitted"
+    assert attempts["attempts"][0]["risk_admission"]["status"] == "approved"
+    state = live_risk_state(now=now)
+    assert state.metadata["bootstrap_reason"] == "missing_current_live_risk_day"
+    assert state.metadata["full_reconciliation_performed"] is False
 
 
-def test_live_trading_job_skips_stale_quote_before_risk_admission(
+def test_live_trading_job_does_not_bootstrap_over_stale_risk_state(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
-    ticker = "KXBTC15M-FV-STALE-QUOTE"
-    install_live_job_fixture(monkeypatch, now=now - timedelta(minutes=2), ticker=ticker)
+    ticker = "KXBTC15M-FV-STALE-RISK"
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    seed_live_risk_state(now=now - timedelta(minutes=5))
+    client = SequencedOrderClient([{"fill_count": 1, "cost": 0.4, "fees": 0.01}])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+            live_risk_state_stale_seconds=60,
+        ),
+        settings=live_enabled_settings(),
+        order_client=client,
+    ).run(now=now)
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    assert client.requests == []
+    assert attempts["admission_daily_loss_accounting"]["risk_state_bootstrapped"] is False
+    assert attempts["admission_daily_loss_accounting"]["risk_state_reason"] == "risk_state_stale"
+    assert attempts["attempts"][0]["status"] == "skipped"
+    assert attempts["attempts"][0]["reason"] == "risk_state_stale"
+
+
+def test_live_trading_job_uses_orderbook_freshness_not_stale_market_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-FRESH-ORDERBOOK"
+    install_live_job_fixture(
+        monkeypatch,
+        now=now,
+        ticker=ticker,
+        market_updated_at=now - timedelta(minutes=2),
+    )
     seed_live_risk_state(now=now)
     client = SequencedOrderClient([{"fill_count": 1, "cost": 0.4, "fees": 0.01}])
 
@@ -581,9 +752,13 @@ def test_live_trading_job_skips_stale_quote_before_risk_admission(
     ).run(now=now)
 
     attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
-    assert client.requests == []
-    assert attempts["attempts"][0]["reason"] == "quote_stale"
-    assert attempts["attempts"][0].get("risk_admission") is None
+    assert len(client.requests) == 1
+    assert attempts["attempts"][0]["status"] == "submitted"
+    assert attempts["attempts"][0]["quote_source"] == "kalshi_orderbook"
+    assert attempts["attempts"][0]["quote_age_seconds"] == 0.0
+    assert manifest["selected_row"]["market_metadata_updated_at"] == (
+        now - timedelta(minutes=2)
+    ).isoformat()
 
 
 def test_live_trading_job_blocks_duplicate_fill_after_ticker_cap(
@@ -1141,6 +1316,15 @@ def fixture_candles(now: datetime) -> list[list[float]]:
     ]
 
 
+def sample_private_key_pem() -> str:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+
+
 class SequencedOrderClient:
     def __init__(self, fills: list[dict], *, order_details: dict[str, dict] | None = None):
         self.fills = list(fills)
@@ -1183,7 +1367,14 @@ def live_enabled_settings():
     )
 
 
-def install_live_job_fixture(monkeypatch, *, now: datetime, ticker: str) -> None:
+def install_live_job_fixture(
+    monkeypatch,
+    *,
+    now: datetime,
+    ticker: str,
+    market_updated_at: datetime | None = None,
+) -> None:
+    market_updated_at = market_updated_at or now - timedelta(seconds=1)
     kalshi = FixtureKalshiRestClient(
         markets=[
             {
@@ -1193,7 +1384,7 @@ def install_live_job_fixture(monkeypatch, *, now: datetime, ticker: str) -> None
                 "status": "open",
                 "open_time": (now - timedelta(minutes=10)).isoformat(),
                 "close_time": (now + timedelta(minutes=5)).isoformat(),
-                "updated_time": (now - timedelta(seconds=1)).isoformat(),
+                "updated_time": market_updated_at.isoformat(),
                 "title": "Bitcoin above $100?",
                 "payout_threshold": "100.00",
                 "yes_ask_dollars": "0.40",


### PR DESCRIPTION
## Summary

Completes the scoped AFK MVP live trading readiness fixes for ALP-214, ALP-215, ALP-216, and ALP-217.

- Uses freshly fetched Kalshi orderbook top-of-book as the fair-value live executable quote source and quote freshness authority, while preserving market-list metadata for audit context.
- Materializes AWS `KALSHI_PRIVATE_KEY_PEM` before settings/runtime guard evaluation and fails closed for invalid PEM without exposing key material.
- Bootstraps a missing current live-risk-day admission state conservatively as active zero-state only on the guarded trade path; stale/locked/unavailable states still deny admission.
- Strengthens fair-value live smoke validation for executable quote evidence, runtime credentials, active/fresh risk state, one-cycle scope, no overlaps/stale tasks, `min_contract_price=0.25`, and `min_edge=0`.

No strategy formula, min-edge policy, risk caps, max order config, execution policy, dashboard UI, schedule state, or EventBridge enablement changes. This stops before ALP-218.

## Tests

- `.venv/bin/ruff check src/alphadb/model_evaluation/fair_value_live.py src/alphadb/model_evaluation/fair_value_live_job.py src/alphadb/live_orders.py src/alphadb/live_risk.py scripts/validate-fair-value-live-smoke.py tests/test_fair_value_mvp.py tests/test_deploy.py`
- `.venv/bin/pytest tests/test_fair_value_mvp.py tests/test_live_orders.py tests/test_live_risk.py tests/test_runtime_guard.py tests/test_deploy.py tests/test_live_runtime.py -q` (`56 passed`)
- `.venv/bin/pytest -q` (`234 passed, 22 warnings`)