### PR TITLE
[codex] Add Cockpit performance section

### DIFF
--- a/apps/dashboard/app/performance/page.tsx
+++ b/apps/dashboard/app/performance/page.tsx
@@ -1,0 +1,10 @@
+import { AppShell } from "@/components/app-shell"
+import { PerformanceSection } from "@/components/performance/performance-section"
+
+export default function PerformancePage() {
+  return (
+    <AppShell>
+      <PerformanceSection />
+    </AppShell>
+  )
+}

--- a/apps/dashboard/components/nav/side-nav.tsx
+++ b/apps/dashboard/components/nav/side-nav.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
-import { Activity, Database, FlaskConical, Layers, Zap } from "lucide-react"
+import { Activity, Database, FlaskConical, Layers, TrendingUp, Zap } from "lucide-react"
 
 const navItems = [
   { href: "/", label: "Live", icon: Activity },
+  { href: "/performance", label: "Performance", icon: TrendingUp },
   { href: "/strategies", label: "Strategies", icon: Layers },
   { href: "/data", label: "Data", icon: Database },
   { href: "/lab", label: "Lab", icon: FlaskConical },

--- a/apps/dashboard/components/performance/performance-section.tsx
+++ b/apps/dashboard/components/performance/performance-section.tsx
@@ -1,0 +1,394 @@
+"use client"
+
+import { useEffect, useState, type ReactNode } from "react"
+import { apiGet } from "@/lib/alphadb-api"
+import { Button } from "@/components/ui/button"
+import { Activity, CircleDollarSign, RefreshCw, ShieldAlert, TrendingUp } from "lucide-react"
+
+type Tone = "good" | "warn" | "bad" | "muted"
+
+interface PerformancePayload {
+  schema_version: string
+  strategy: string
+  market_series: string
+  generated_at_utc: string
+  data_status: string
+  data_status_detail: string
+  config: {
+    status: string
+    version: number | null
+    config_id: string | null
+    limits: Record<string, number | null>
+  }
+  freshness: {
+    status: string
+    latest_run_generated_at_utc: string | null
+    age_seconds: number | null
+    stale: boolean
+    stale_after_seconds: number
+  }
+  risk_budget: {
+    status: string
+    daily_loss_used_dollars: number | null
+    daily_loss_limit_dollars: number | null
+    daily_loss_remaining_dollars: number | null
+    daily_loss_usage_fraction: number | null
+    market_exposure_used_dollars: number | null
+    market_exposure_limit_dollars: number | null
+    market_exposure_usage_fraction: number | null
+  }
+  execution: {
+    data_status: string
+    data_status_detail: string
+    counts: Record<"submitted" | "skipped" | "rejected" | "filled" | "no_fill" | "unknown", number>
+    skip_reasons: Array<{ reason: string; count: number }>
+    recent_runs: RecentRun[]
+  }
+  pnl: {
+    status: string
+    status_detail: string
+    settlement_state: string
+    fees_status: string
+    net_pnl_dollars: number | null
+    realized_pnl_dollars: number | null
+    unrealized_pnl_dollars: number | null
+    fees_dollars: number | null
+    unsettled_exposure_dollars: number | null
+    filled_contracts: number
+    order_count: number
+    fill_count: number
+    position_count: number
+    latest_observed_at_utc: string | null
+    reconciliation_counts: Record<string, number>
+  }
+  recent_runs: RecentRun[]
+}
+
+interface RecentRun {
+  run_id: string | null
+  generated_at_utc: string | null
+  market_ticker: string | null
+  decision_outcome: string | null
+  selected_side: string | null
+  skip_reason: string | null
+  attempt_status: string | null
+  attempt_reason: string | null
+  fill_status: string | null
+  config_version: number | null
+  daily_loss_used_dollars: number | null
+  market_exposure_used_dollars: number | null
+}
+
+function text(value: unknown, fallback = "--") {
+  if (value === null || value === undefined || value === "") return fallback
+  return String(value)
+}
+
+function optionalMoney(value: unknown) {
+  if (value === null || value === undefined || value === "") return "--"
+  const number = Number(value)
+  if (!Number.isFinite(number)) return "--"
+  return `$${number.toFixed(2)}`
+}
+
+function optionalPercent(value: unknown) {
+  if (value === null || value === undefined || value === "") return "--"
+  const number = Number(value)
+  if (!Number.isFinite(number)) return "--"
+  return `${(number * 100).toFixed(0)}%`
+}
+
+function shortTime(value: unknown) {
+  if (!value) return "--"
+  const date = new Date(String(value))
+  if (Number.isNaN(date.getTime())) return String(value)
+  return date.toLocaleString([], {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+export function PerformanceSection() {
+  const [payload, setPayload] = useState<PerformancePayload | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const load = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setPayload(await apiGet<PerformancePayload>("/performance"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load performance")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    const id = window.setInterval(load, 30000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  const pnl = payload?.pnl
+  const execution = payload?.execution
+  const risk = payload?.risk_budget
+  const recentRuns = payload?.recent_runs || []
+  const statusTone = toneForStatus(payload?.data_status, loading, error)
+
+  return (
+    <div className="p-6 space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-semibold text-foreground">Performance</h1>
+            <StatusDot tone={statusTone} label={text(payload?.data_status, loading ? "loading" : "unknown")} />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {text(payload?.strategy, "strategy unknown")} · {text(payload?.market_series, "series unknown")} · {shortTime(payload?.generated_at_utc)}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={load} disabled={loading}>
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <div className="border border-destructive/40 bg-destructive/10 rounded-lg p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <section className="grid gap-3 md:grid-cols-4">
+        <Metric
+          label="Net PnL"
+          value={optionalMoney(pnl?.net_pnl_dollars)}
+          detail={`${text(pnl?.status, "unknown")} · ${text(pnl?.settlement_state, "settlement unknown")}`}
+          tone={moneyTone(pnl?.net_pnl_dollars, pnl?.status)}
+        />
+        <Metric
+          label="Realized / Unrealized"
+          value={`${optionalMoney(pnl?.realized_pnl_dollars)} / ${optionalMoney(pnl?.unrealized_pnl_dollars)}`}
+          detail={`${text(pnl?.filled_contracts, "0")} filled contracts`}
+        />
+        <Metric
+          label="Fees"
+          value={optionalMoney(pnl?.fees_dollars)}
+          detail={text(pnl?.fees_status, "unknown")}
+        />
+        <Metric
+          label="Exposure"
+          value={optionalMoney(pnl?.unsettled_exposure_dollars)}
+          detail={`${optionalMoney(risk?.market_exposure_used_dollars)} / ${optionalMoney(risk?.market_exposure_limit_dollars)} market risk`}
+        />
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="space-y-3">
+          <Panel
+            title="Recent Run Trend"
+            icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
+          >
+            <TrendStrip runs={recentRuns} />
+          </Panel>
+
+          <Panel
+            title="Recent Runs"
+            icon={<Activity className="h-4 w-4 text-muted-foreground" />}
+          >
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead className="text-muted-foreground">
+                  <tr className="border-b border-border">
+                    <th className="text-left py-2 pr-3 font-medium">Time</th>
+                    <th className="text-left py-2 pr-3 font-medium">Market</th>
+                    <th className="text-left py-2 pr-3 font-medium">Outcome</th>
+                    <th className="text-left py-2 pr-3 font-medium">Attempt</th>
+                    <th className="text-left py-2 pr-3 font-medium">Fill</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recentRuns.length ? recentRuns.map((run, index) => (
+                    <tr key={`${run.run_id || "run"}-${index}`} className="border-b border-border/70 last:border-0">
+                      <td className="py-2 pr-3 text-muted-foreground">{shortTime(run.generated_at_utc)}</td>
+                      <td className="py-2 pr-3 font-mono text-xs">{text(run.market_ticker)}</td>
+                      <td className="py-2 pr-3">{text(run.decision_outcome)}</td>
+                      <td className="py-2 pr-3 text-muted-foreground">{text(run.attempt_status || run.attempt_reason)}</td>
+                      <td className="py-2 pr-3">{text(run.fill_status)}</td>
+                    </tr>
+                  )) : (
+                    <tr>
+                      <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                        No recent runs.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </Panel>
+        </div>
+
+        <div className="space-y-3">
+          <Panel
+            title="Execution Outcomes"
+            icon={<CircleDollarSign className="h-4 w-4 text-muted-foreground" />}
+          >
+            <div className="space-y-2 text-sm">
+              {(["submitted", "filled", "no_fill", "skipped", "rejected", "unknown"] as const).map((key) => (
+                <Value key={key} label={labelForCount(key)} value={text(execution?.counts?.[key], "0")} />
+              ))}
+            </div>
+          </Panel>
+
+          <Panel title="Risk Budget">
+            <div className="space-y-2 text-sm">
+              <Value label="Daily used" value={optionalMoney(risk?.daily_loss_used_dollars)} />
+              <Value label="Daily limit" value={optionalMoney(risk?.daily_loss_limit_dollars)} />
+              <Value label="Daily remaining" value={optionalMoney(risk?.daily_loss_remaining_dollars)} />
+              <Value label="Daily usage" value={optionalPercent(risk?.daily_loss_usage_fraction)} />
+              <Value label="Market usage" value={optionalPercent(risk?.market_exposure_usage_fraction)} />
+            </div>
+          </Panel>
+
+          <Panel title="Skip Reasons">
+            <div className="space-y-2 text-sm">
+              {execution?.skip_reasons?.length ? execution.skip_reasons.map((row) => (
+                <Value key={row.reason} label={row.reason} value={String(row.count)} />
+              )) : (
+                <EmptyLine>No skip reasons recorded.</EmptyLine>
+              )}
+            </div>
+          </Panel>
+
+          <Panel title="Data Freshness">
+            <div className="space-y-2 text-sm">
+              <Value label="Latest run" value={shortTime(payload?.freshness.latest_run_generated_at_utc)} />
+              <Value label="Age" value={payload?.freshness.age_seconds === null || payload?.freshness.age_seconds === undefined ? "--" : `${payload.freshness.age_seconds}s`} />
+              <Value label="Latest PnL row" value={shortTime(pnl?.latest_observed_at_utc)} />
+              <Value label="Config" value={payload?.config.version ? `v${payload.config.version}` : text(payload?.config.status)} />
+            </div>
+            {payload?.data_status_detail && (
+              <div className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
+                <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{payload.data_status_detail}</span>
+              </div>
+            )}
+          </Panel>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function TrendStrip({ runs }: { runs: RecentRun[] }) {
+  const visible = runs.slice(0, 24).reverse()
+  if (!visible.length) {
+    return <EmptyLine>No trend yet.</EmptyLine>
+  }
+  return (
+    <div className="grid grid-cols-12 gap-1 md:grid-cols-[repeat(24,minmax(0,1fr))]">
+      {visible.map((run, index) => (
+        <div
+          key={`${run.run_id || "run"}-${index}`}
+          aria-label={`${text(run.decision_outcome)} ${shortTime(run.generated_at_utc)}`}
+          className={`h-8 rounded-sm ${trendClass(run)}`}
+          title={`${text(run.decision_outcome)} · ${text(run.market_ticker)} · ${shortTime(run.generated_at_utc)}`}
+        />
+      ))}
+    </div>
+  )
+}
+
+function Metric({ label, value, detail, tone = "muted" }: { label: string; value: string; detail?: string; tone?: Tone }) {
+  return (
+    <div className="border border-border rounded-lg bg-card p-4 min-h-24">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className={`mt-2 text-xl font-semibold ${toneTextClass(tone)}`}>{value}</div>
+      {detail && <div className="mt-1 text-xs text-muted-foreground truncate">{detail}</div>}
+    </div>
+  )
+}
+
+function Panel({ title, icon, children }: { title: string; icon?: ReactNode; children: ReactNode }) {
+  return (
+    <div className="border border-border rounded-lg bg-card p-4">
+      <div className="mb-3 flex items-center gap-2">
+        {icon}
+        <h2 className="text-sm font-medium">{title}</h2>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function Value({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-h-6 items-center justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono text-xs text-foreground">{value}</span>
+    </div>
+  )
+}
+
+function EmptyLine({ children }: { children: ReactNode }) {
+  return <div className="text-sm text-muted-foreground">{children}</div>
+}
+
+function StatusDot({ tone, label }: { tone: Tone; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span className={`h-2 w-2 rounded-full ${toneDotClass(tone)}`} />
+      {label}
+    </span>
+  )
+}
+
+function toneForStatus(status: string | undefined, loading: boolean, error: string | null): Tone {
+  if (error) return "bad"
+  if (loading && !status) return "warn"
+  if (status === "ok") return "good"
+  if (status === "stale" || status === "partial" || status === "empty") return "warn"
+  return "muted"
+}
+
+function moneyTone(value: unknown, status: string | undefined): Tone {
+  if (status === "unavailable") return "muted"
+  const number = Number(value)
+  if (!Number.isFinite(number)) return "warn"
+  if (number > 0) return "good"
+  if (number < 0) return "bad"
+  return "muted"
+}
+
+function trendClass(run: RecentRun) {
+  if (run.fill_status === "filled") return "bg-success"
+  if (run.fill_status === "no_fill") return "bg-warning"
+  if (run.decision_outcome === "skipped") return "bg-muted-foreground"
+  if (run.decision_outcome === "rejected" || run.decision_outcome === "error") return "bg-destructive"
+  if (run.decision_outcome === "submitted") return "bg-chart-1"
+  return "bg-muted"
+}
+
+function toneTextClass(tone: Tone) {
+  if (tone === "good") return "text-success"
+  if (tone === "warn") return "text-warning"
+  if (tone === "bad") return "text-destructive"
+  return "text-foreground"
+}
+
+function toneDotClass(tone: Tone) {
+  if (tone === "good") return "bg-success"
+  if (tone === "warn") return "bg-warning"
+  if (tone === "bad") return "bg-destructive"
+  return "bg-muted-foreground"
+}
+
+function labelForCount(key: string) {
+  if (key === "no_fill") return "No fill"
+  return key.charAt(0).toUpperCase() + key.slice(1)
+}

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -29,6 +29,7 @@ from alphadb.live_runtime import (
     LiveRuntimeConfig,
     LiveRuntimeConfigRepository,
 )
+from alphadb.performance import PerformanceSummaryRepository
 from alphadb.portfolio import cached_portfolio_balance_payload
 
 
@@ -37,6 +38,7 @@ StatusRepositoryFactory = Callable[[str], LiveRunStatusRepository]
 StrategyRepositoryFactory = Callable[[str], DashboardStrategyRepository]
 DataExplorerRepositoryFactory = Callable[[str], DashboardDataExplorerRepository]
 LabRepositoryFactory = Callable[[str], DashboardLabRepository]
+PerformanceRepositoryFactory = Callable[[str], PerformanceSummaryRepository]
 HealthCollector = Callable[[Settings], HealthReport]
 PortfolioBalanceProvider = Callable[[Settings], Mapping[str, Any]]
 
@@ -51,6 +53,7 @@ class DashboardService:
         DashboardDataExplorerRepository
     )
     lab_repository_factory: LabRepositoryFactory = DashboardLabRepository
+    performance_repository_factory: PerformanceRepositoryFactory = PerformanceSummaryRepository
     health_collector: HealthCollector = collect_health
     portfolio_balance_provider: PortfolioBalanceProvider = cached_portfolio_balance_payload
 
@@ -88,6 +91,13 @@ class DashboardService:
                 limit=8,
             ),
         }
+
+    def performance_payload(self) -> dict[str, Any]:
+        return dict(
+            self.performance_repository_factory(self.settings.database_url).summary(
+                strategy=FAIR_VALUE_LIVE_STRATEGY
+            )
+        )
 
     def save_config(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         config_repository = self.config_repository_factory(self.settings.database_url)
@@ -503,6 +513,9 @@ def make_handler(service: DashboardService) -> type[BaseHTTPRequestHandler]:
             try:
                 if path == "/api/health":
                     self._json_ok(service.api_health())
+                    return
+                if path == "/api/performance":
+                    self._json_ok(service.performance_payload())
                     return
                 if path == "/api/strategies":
                     self._json_ok(

--- a/src/alphadb/performance.py
+++ b/src/alphadb/performance.py
@@ -1,0 +1,743 @@
+"""Cockpit performance summaries backed by Operational State."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+from alphadb.live_runtime import FAIR_VALUE_LIVE_STRATEGY
+from alphadb.state.repository import OperationalStateRepository
+
+
+PERFORMANCE_SCHEMA_VERSION = "alphadb_performance_summary.v1"
+DEFAULT_MARKET_SERIES = "KXBTC15M"
+PERFORMANCE_STALE_AFTER_SECONDS = 300
+DEFAULT_RECENT_RUN_LIMIT = 25
+DEFAULT_PAPER_ROW_LIMIT = 500
+
+
+class PerformanceSummaryRepository:
+    """Read-only Operational State projection for Cockpit Performance."""
+
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def summary(
+        self,
+        *,
+        strategy: str = FAIR_VALUE_LIVE_STRATEGY,
+        market_series: str = DEFAULT_MARKET_SERIES,
+        recent_limit: int = DEFAULT_RECENT_RUN_LIMIT,
+    ) -> dict[str, Any]:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                config_row = _active_config_row(cursor, strategy=strategy)
+                status_rows = _recent_status_rows(
+                    cursor,
+                    strategy=strategy,
+                    limit=recent_limit,
+                )
+                order_rows = _paper_order_rows(
+                    cursor,
+                    market_series=market_series,
+                    limit=DEFAULT_PAPER_ROW_LIMIT,
+                )
+                fill_rows = _paper_fill_rows(
+                    cursor,
+                    market_series=market_series,
+                    limit=DEFAULT_PAPER_ROW_LIMIT,
+                )
+                position_rows = _paper_position_rows(
+                    cursor,
+                    market_series=market_series,
+                    limit=DEFAULT_PAPER_ROW_LIMIT,
+                )
+        return build_performance_summary(
+            strategy=strategy,
+            market_series=market_series,
+            generated_at=datetime.now(UTC),
+            config_row=config_row,
+            status_rows=status_rows,
+            order_rows=order_rows,
+            fill_rows=fill_rows,
+            position_rows=position_rows,
+        )
+
+
+def build_performance_summary(
+    *,
+    strategy: str,
+    market_series: str,
+    generated_at: datetime,
+    config_row: Mapping[str, Any] | None = None,
+    status_rows: Sequence[Mapping[str, Any]] = (),
+    order_rows: Sequence[Mapping[str, Any]] = (),
+    fill_rows: Sequence[Mapping[str, Any]] = (),
+    position_rows: Sequence[Mapping[str, Any]] = (),
+    stale_after_seconds: int = PERFORMANCE_STALE_AFTER_SECONDS,
+) -> dict[str, Any]:
+    rows = [dict(row) for row in status_rows]
+    execution = summarize_execution(rows)
+    pnl = summarize_pnl(
+        order_rows=order_rows,
+        fill_rows=fill_rows,
+        position_rows=position_rows,
+    )
+    freshness = summarize_freshness(
+        rows,
+        generated_at=generated_at,
+        stale_after_seconds=stale_after_seconds,
+    )
+    risk_budget = summarize_risk_budget(rows)
+    data_status = _overall_data_status(execution, pnl, freshness)
+    return {
+        "schema_version": PERFORMANCE_SCHEMA_VERSION,
+        "strategy": strategy,
+        "market_series": market_series,
+        "generated_at_utc": _iso(generated_at),
+        "data_status": data_status,
+        "data_status_detail": _data_status_detail(data_status, execution, pnl, freshness),
+        "config": _config_payload(config_row),
+        "freshness": freshness,
+        "risk_budget": risk_budget,
+        "execution": execution,
+        "pnl": pnl,
+        "recent_runs": execution["recent_runs"],
+    }
+
+
+def summarize_execution(status_rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    rows = [dict(row) for row in status_rows]
+    counts = {
+        "submitted": 0,
+        "skipped": 0,
+        "rejected": 0,
+        "filled": 0,
+        "no_fill": 0,
+        "unknown": 0,
+    }
+    skip_reasons: Counter[str] = Counter()
+
+    if rows:
+        total_attempts = sum(_int(row.get("recent_attempt_count")) for row in rows)
+        if total_attempts:
+            counts["submitted"] = sum(_int(row.get("recent_submitted_count")) for row in rows)
+            counts["skipped"] = sum(_int(row.get("recent_skipped_count")) for row in rows)
+            counts["filled"] = sum(_int(row.get("recent_filled_count")) for row in rows)
+            counts["no_fill"] = sum(_int(row.get("recent_no_fill_count")) for row in rows)
+            counts["rejected"] = sum(
+                1
+                for row in rows
+                if _text(row.get("latest_attempt_status")) in {"rejected", "error"}
+            )
+            counts["unknown"] = max(
+                0,
+                total_attempts
+                - counts["submitted"]
+                - counts["skipped"]
+                - counts["rejected"],
+            )
+        else:
+            for row in rows:
+                _add_single_run_execution_count(counts, row)
+
+        for row in rows:
+            reason = _skip_reason(row)
+            if reason:
+                skip_reasons[reason] += 1
+
+    return {
+        "data_status": "ok" if rows else "empty",
+        "data_status_detail": "Recent live run statuses found."
+        if rows
+        else "No live run statuses recorded.",
+        "counts": counts,
+        "skip_reasons": [
+            {"reason": reason, "count": count}
+            for reason, count in sorted(
+                skip_reasons.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ],
+        "recent_runs": [_recent_run_payload(row) for row in rows],
+    }
+
+
+def summarize_pnl(
+    *,
+    order_rows: Sequence[Mapping[str, Any]] = (),
+    fill_rows: Sequence[Mapping[str, Any]] = (),
+    position_rows: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    orders = [dict(row) for row in order_rows]
+    fills = [dict(row) for row in fill_rows]
+    positions = [dict(row) for row in position_rows]
+    observations = bool(orders or fills or positions)
+    if not observations:
+        return {
+            "status": "unavailable",
+            "status_detail": "No paper execution, fill, or position rows recorded.",
+            "settlement_state": "unavailable",
+            "fees_status": "unavailable",
+            "net_pnl_dollars": None,
+            "realized_pnl_dollars": None,
+            "unrealized_pnl_dollars": None,
+            "fees_dollars": None,
+            "unsettled_exposure_dollars": None,
+            "filled_contracts": 0,
+            "order_count": 0,
+            "fill_count": 0,
+            "position_count": 0,
+            "latest_observed_at_utc": None,
+            "reconciliation_counts": {},
+        }
+
+    realized = _sum_field(orders, "reconciliation_realized_pnl_dollars")
+    unrealized = _sum_field(orders, "reconciliation_unrealized_pnl_dollars")
+    if realized is None:
+        realized = _sum_field(positions, "realized_pnl_dollars")
+    if unrealized is None:
+        unrealized = _sum_field(positions, "unrealized_pnl_dollars")
+
+    filled_contracts = _filled_contracts(orders=orders, fills=fills)
+    fees = _sum_field(fills, "fee_dollars")
+    fees_status = "available" if fills else "unavailable"
+    if fees is None and filled_contracts == 0:
+        fees = 0.0
+        fees_status = "not_applicable"
+
+    settlement_state = _settlement_state(orders=orders, positions=positions)
+    unsettled_exposure = _unsettled_exposure(orders=orders, positions=positions)
+    net_pnl = None
+    if realized is not None and unrealized is not None and fees is not None:
+        net_pnl = realized + unrealized - fees
+
+    status = "ok"
+    detail = "Paper performance rows are available."
+    if net_pnl is None or fees_status == "unavailable" or settlement_state in {
+        "partial",
+        "unknown",
+    }:
+        status = "partial"
+        detail = "Some PnL, fee, or settlement fields are unavailable."
+
+    return {
+        "status": status,
+        "status_detail": detail,
+        "settlement_state": settlement_state,
+        "fees_status": fees_status,
+        "net_pnl_dollars": _money(net_pnl),
+        "realized_pnl_dollars": _money(realized),
+        "unrealized_pnl_dollars": _money(unrealized),
+        "fees_dollars": _money(fees),
+        "unsettled_exposure_dollars": _money(unsettled_exposure),
+        "filled_contracts": filled_contracts,
+        "order_count": len(orders),
+        "fill_count": len(fills),
+        "position_count": len(positions),
+        "latest_observed_at_utc": _iso(_latest_observed_at(orders, fills, positions)),
+        "reconciliation_counts": dict(
+            sorted(
+                Counter(_order_reconciliation_status(row) for row in orders).items(),
+                key=lambda item: item[0],
+            )
+        ),
+    }
+
+
+def summarize_freshness(
+    status_rows: Sequence[Mapping[str, Any]],
+    *,
+    generated_at: datetime,
+    stale_after_seconds: int = PERFORMANCE_STALE_AFTER_SECONDS,
+) -> dict[str, Any]:
+    latest = _datetime(status_rows[0].get("generated_at")) if status_rows else None
+    if latest is None:
+        return {
+            "status": "empty",
+            "latest_run_generated_at_utc": None,
+            "age_seconds": None,
+            "stale": False,
+            "stale_after_seconds": stale_after_seconds,
+        }
+    age_seconds = max(0, int((generated_at - latest).total_seconds()))
+    stale = age_seconds > stale_after_seconds
+    return {
+        "status": "stale" if stale else "fresh",
+        "latest_run_generated_at_utc": _iso(latest),
+        "age_seconds": age_seconds,
+        "stale": stale,
+        "stale_after_seconds": stale_after_seconds,
+    }
+
+
+def summarize_risk_budget(status_rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not status_rows:
+        return {
+            "status": "unavailable",
+            "daily_loss_used_dollars": None,
+            "daily_loss_limit_dollars": None,
+            "daily_loss_remaining_dollars": None,
+            "daily_loss_usage_fraction": None,
+            "market_exposure_used_dollars": None,
+            "market_exposure_limit_dollars": None,
+            "market_exposure_usage_fraction": None,
+        }
+    latest = status_rows[0]
+    daily_used = _float(latest.get("daily_loss_used_dollars"))
+    daily_limit = _float(latest.get("daily_loss_limit_dollars"))
+    market_used = _float(latest.get("market_exposure_used_dollars"))
+    market_limit = _float(latest.get("market_exposure_limit_dollars"))
+    return {
+        "status": "ok",
+        "daily_loss_used_dollars": _money(daily_used),
+        "daily_loss_limit_dollars": _money(daily_limit),
+        "daily_loss_remaining_dollars": _money(_remaining(daily_limit, daily_used)),
+        "daily_loss_usage_fraction": _fraction(daily_used, daily_limit),
+        "market_exposure_used_dollars": _money(market_used),
+        "market_exposure_limit_dollars": _money(market_limit),
+        "market_exposure_usage_fraction": _fraction(market_used, market_limit),
+    }
+
+
+def _active_config_row(
+    cursor: psycopg.Cursor,
+    *,
+    strategy: str,
+) -> Mapping[str, Any] | None:
+    cursor.execute(
+        """
+        select
+            config_id,
+            strategy,
+            version,
+            is_active,
+            max_order_dollars,
+            max_market_exposure_dollars,
+            max_daily_loss_dollars,
+            min_edge,
+            min_contract_price,
+            max_markets,
+            created_at
+        from live_runtime_configs
+        where strategy = %s
+        order by is_active desc, version desc
+        limit 1
+        """,
+        (strategy,),
+    )
+    return cursor.fetchone()
+
+
+def _recent_status_rows(
+    cursor: psycopg.Cursor,
+    *,
+    strategy: str,
+    limit: int,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        select
+            run_id,
+            strategy,
+            generated_at,
+            config_id,
+            config_version,
+            current_market_ticker,
+            decision_outcome,
+            selected_side,
+            skip_reason,
+            latest_attempt_status,
+            latest_attempt_reason,
+            fill_status,
+            daily_loss_used_dollars,
+            daily_loss_limit_dollars,
+            market_exposure_used_dollars,
+            market_exposure_limit_dollars,
+            recent_attempt_count,
+            recent_submitted_count,
+            recent_skipped_count,
+            recent_no_fill_count,
+            recent_filled_count
+        from live_run_statuses
+        where strategy = %s
+        order by generated_at desc, run_id desc
+        limit %s
+        """,
+        (strategy, limit),
+    )
+    return cursor.fetchall()
+
+
+def _paper_order_rows(
+    cursor: psycopg.Cursor,
+    *,
+    market_series: str,
+    limit: int,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        select
+            po.paper_order_id,
+            po.market_ticker,
+            po.status,
+            po.limit_price,
+            po.quantity,
+            po.filled_quantity,
+            po.submitted_at,
+            pr.status as reconciliation_status,
+            pr.expected_quantity as reconciliation_expected_quantity,
+            pr.filled_quantity as reconciliation_filled_quantity,
+            pr.open_quantity as reconciliation_open_quantity,
+            pr.realized_pnl_dollars as reconciliation_realized_pnl_dollars,
+            pr.unrealized_pnl_dollars as reconciliation_unrealized_pnl_dollars,
+            pr.created_at as reconciliation_created_at
+        from paper_orders po
+        left join paper_reconciliations pr on pr.paper_order_id = po.paper_order_id
+        where po.market_ticker = %s or po.market_ticker like %s
+        order by po.submitted_at desc, po.paper_order_id desc
+        limit %s
+        """,
+        (market_series, f"{market_series}-%", limit),
+    )
+    return cursor.fetchall()
+
+
+def _paper_fill_rows(
+    cursor: psycopg.Cursor,
+    *,
+    market_series: str,
+    limit: int,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        select
+            paper_fill_id,
+            market_ticker,
+            quantity,
+            fill_price,
+            fee_dollars,
+            filled_at
+        from paper_fills
+        where market_ticker = %s or market_ticker like %s
+        order by filled_at desc, paper_fill_id desc
+        limit %s
+        """,
+        (market_series, f"{market_series}-%", limit),
+    )
+    return cursor.fetchall()
+
+
+def _paper_position_rows(
+    cursor: psycopg.Cursor,
+    *,
+    market_series: str,
+    limit: int,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        select
+            position_id,
+            market_ticker,
+            side,
+            quantity,
+            avg_price,
+            realized_pnl_dollars,
+            unrealized_pnl_dollars,
+            updated_at
+        from paper_positions
+        where market_ticker = %s or market_ticker like %s
+        order by updated_at desc, position_id desc
+        limit %s
+        """,
+        (market_series, f"{market_series}-%", limit),
+    )
+    return cursor.fetchall()
+
+
+def _config_payload(row: Mapping[str, Any] | None) -> dict[str, Any]:
+    if row is None:
+        return {
+            "status": "missing",
+            "config_id": None,
+            "version": None,
+            "is_active": False,
+            "created_at_utc": None,
+            "limits": {},
+        }
+    return {
+        "status": "ok" if bool(row.get("is_active")) else "inactive_latest",
+        "config_id": _text(row.get("config_id")),
+        "version": _int_or_none(row.get("version")),
+        "is_active": bool(row.get("is_active")),
+        "created_at_utc": _iso(_datetime(row.get("created_at"))),
+        "limits": {
+            "max_order_dollars": _money(_float(row.get("max_order_dollars"))),
+            "max_market_exposure_dollars": _money(
+                _float(row.get("max_market_exposure_dollars"))
+            ),
+            "max_daily_loss_dollars": _money(_float(row.get("max_daily_loss_dollars"))),
+            "min_edge": _float(row.get("min_edge")),
+            "min_contract_price": _float(row.get("min_contract_price")),
+            "max_markets": _int_or_none(row.get("max_markets")),
+        },
+    }
+
+
+def _add_single_run_execution_count(counts: dict[str, int], row: Mapping[str, Any]) -> None:
+    outcome = _text(row.get("decision_outcome"))
+    attempt_status = _text(row.get("latest_attempt_status"))
+    fill_status = _text(row.get("fill_status"))
+    if outcome == "skipped" or attempt_status == "skipped":
+        counts["skipped"] += 1
+        return
+    if outcome in {"rejected", "error"} or attempt_status in {"rejected", "error"}:
+        counts["rejected"] += 1
+        return
+    if outcome == "submitted" or attempt_status == "submitted":
+        counts["submitted"] += 1
+        if fill_status == "filled":
+            counts["filled"] += 1
+        elif fill_status == "no_fill":
+            counts["no_fill"] += 1
+        elif fill_status in {None, "submitted_fill_unknown"}:
+            counts["unknown"] += 1
+        return
+    if outcome not in {None, "no_recent_run"}:
+        counts["unknown"] += 1
+
+
+def _recent_run_payload(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "run_id": _text(row.get("run_id")),
+        "generated_at_utc": _iso(_datetime(row.get("generated_at"))),
+        "market_ticker": _text(row.get("current_market_ticker")),
+        "decision_outcome": _text(row.get("decision_outcome")),
+        "selected_side": _text(row.get("selected_side")),
+        "skip_reason": _text(row.get("skip_reason")),
+        "attempt_status": _text(row.get("latest_attempt_status")),
+        "attempt_reason": _text(row.get("latest_attempt_reason")),
+        "fill_status": _text(row.get("fill_status")),
+        "config_version": _int_or_none(row.get("config_version")),
+        "daily_loss_used_dollars": _money(_float(row.get("daily_loss_used_dollars"))),
+        "market_exposure_used_dollars": _money(
+            _float(row.get("market_exposure_used_dollars"))
+        ),
+    }
+
+
+def _skip_reason(row: Mapping[str, Any]) -> str | None:
+    outcome = _text(row.get("decision_outcome"))
+    attempt_status = _text(row.get("latest_attempt_status"))
+    if outcome != "skipped" and attempt_status != "skipped":
+        return None
+    return _text(row.get("skip_reason")) or _text(row.get("latest_attempt_reason"))
+
+
+def _settlement_state(
+    *,
+    orders: Sequence[Mapping[str, Any]],
+    positions: Sequence[Mapping[str, Any]],
+) -> str:
+    if not orders:
+        return "unknown" if positions else "unavailable"
+    statuses = {_order_reconciliation_status(row) for row in orders}
+    if "unknown" in statuses:
+        return "unknown"
+    if any(
+        _order_reconciliation_status(row) == "partial"
+        or (
+            _order_reconciliation_status(row) not in {"unfilled", "no_fill"}
+            and _int(row.get("reconciliation_open_quantity")) > 0
+        )
+        for row in orders
+    ):
+        return "partial"
+    return "complete"
+
+
+def _order_reconciliation_status(row: Mapping[str, Any]) -> str:
+    status = _text(row.get("reconciliation_status")) or _text(row.get("status"))
+    if status in {"unfilled", "no_fill"}:
+        return "unfilled"
+    if status in {"filled", "settled", "complete"}:
+        return "filled"
+    if status == "partial":
+        return "partial"
+    return "unknown"
+
+
+def _filled_contracts(
+    *,
+    orders: Sequence[Mapping[str, Any]],
+    fills: Sequence[Mapping[str, Any]],
+) -> int:
+    if fills:
+        return sum(_int(row.get("quantity")) for row in fills)
+    return sum(
+        _int(row.get("reconciliation_filled_quantity") or row.get("filled_quantity"))
+        for row in orders
+    )
+
+
+def _unsettled_exposure(
+    *,
+    orders: Sequence[Mapping[str, Any]],
+    positions: Sequence[Mapping[str, Any]],
+) -> float | None:
+    exposure_parts: list[float] = []
+    position_exposure = sum(
+        max(0, _int(row.get("quantity"))) * (_float(row.get("avg_price")) or 0.0)
+        for row in positions
+    )
+    if positions:
+        exposure_parts.append(position_exposure)
+    partial_open_exposure = sum(
+        _int(row.get("reconciliation_open_quantity")) * (_float(row.get("limit_price")) or 0.0)
+        for row in orders
+        if _order_reconciliation_status(row) == "partial"
+    )
+    if partial_open_exposure:
+        exposure_parts.append(partial_open_exposure)
+    if not exposure_parts:
+        return None if not orders else 0.0
+    return sum(exposure_parts)
+
+
+def _latest_observed_at(
+    orders: Sequence[Mapping[str, Any]],
+    fills: Sequence[Mapping[str, Any]],
+    positions: Sequence[Mapping[str, Any]],
+) -> datetime | None:
+    timestamps = [
+        _datetime(row.get("submitted_at")) for row in orders if row.get("submitted_at")
+    ]
+    timestamps.extend(
+        _datetime(row.get("reconciliation_created_at"))
+        for row in orders
+        if row.get("reconciliation_created_at")
+    )
+    timestamps.extend(_datetime(row.get("filled_at")) for row in fills if row.get("filled_at"))
+    timestamps.extend(
+        _datetime(row.get("updated_at")) for row in positions if row.get("updated_at")
+    )
+    parsed = [timestamp for timestamp in timestamps if timestamp is not None]
+    return max(parsed) if parsed else None
+
+
+def _overall_data_status(
+    execution: Mapping[str, Any],
+    pnl: Mapping[str, Any],
+    freshness: Mapping[str, Any],
+) -> str:
+    if execution.get("data_status") == "empty" and pnl.get("status") == "unavailable":
+        return "empty"
+    if freshness.get("status") == "stale":
+        return "stale"
+    if pnl.get("status") in {"partial", "unavailable"}:
+        return "partial"
+    return "ok"
+
+
+def _data_status_detail(
+    status: str,
+    execution: Mapping[str, Any],
+    pnl: Mapping[str, Any],
+    freshness: Mapping[str, Any],
+) -> str:
+    if status == "empty":
+        return "No live run or paper performance rows recorded."
+    if status == "stale":
+        return "Latest live run is older than the Performance freshness threshold."
+    if status == "partial":
+        if execution.get("data_status") == "empty":
+            return "Paper performance rows exist but no recent live run rows are recorded."
+        return str(pnl.get("status_detail") or "Some performance fields are unavailable.")
+    return "Performance data is current."
+
+
+def _sum_field(rows: Sequence[Mapping[str, Any]], key: str) -> float | None:
+    values = [_float(row.get(key)) for row in rows if row.get(key) is not None]
+    if not values:
+        return None
+    return sum(value for value in values if value is not None)
+
+
+def _remaining(limit: float | None, used: float | None) -> float | None:
+    if limit is None or used is None:
+        return None
+    return max(0.0, limit - used)
+
+
+def _fraction(used: float | None, limit: float | None) -> float | None:
+    if used is None or limit is None or limit <= 0:
+        return None
+    return round(used / limit, 6)
+
+
+def _money(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), 6)
+
+
+def _float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        text = value.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _iso(value: datetime | None) -> str | None:
+    return None if value is None else value.isoformat()

--- a/tests/test_dashboard_performance.py
+++ b/tests/test_dashboard_performance.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from alphadb.config import settings_from_env
+from alphadb.dashboard.app import DashboardService
+from alphadb.performance import build_performance_summary
+
+
+NOW = datetime(2026, 6, 6, 18, 30, tzinfo=UTC)
+
+
+def test_performance_summary_reports_truthful_empty_state() -> None:
+    summary = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+    )
+
+    assert summary["data_status"] == "empty"
+    assert summary["config"]["status"] == "missing"
+    assert summary["execution"]["data_status"] == "empty"
+    assert summary["execution"]["counts"] == {
+        "submitted": 0,
+        "skipped": 0,
+        "rejected": 0,
+        "filled": 0,
+        "no_fill": 0,
+        "unknown": 0,
+    }
+    assert summary["pnl"]["status"] == "unavailable"
+    assert summary["pnl"]["net_pnl_dollars"] is None
+    assert summary["freshness"]["status"] == "empty"
+
+
+def test_performance_summary_counts_execution_outcomes_and_skip_reasons() -> None:
+    summary = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+        config_row=config_row(version=4),
+        status_rows=[
+            status_row(
+                "run_unknown",
+                NOW,
+                decision_outcome="submitted",
+                latest_attempt_status="submitted",
+                fill_status="submitted_fill_unknown",
+            ),
+            status_row(
+                "run_skip",
+                NOW - timedelta(minutes=1),
+                decision_outcome="skipped",
+                latest_attempt_status="skipped",
+                skip_reason="daily_loss_cap_reached",
+                latest_attempt_reason="daily_loss_cap_reached",
+            ),
+            status_row(
+                "run_filled",
+                NOW - timedelta(minutes=2),
+                decision_outcome="submitted",
+                latest_attempt_status="submitted",
+                fill_status="filled",
+            ),
+            status_row(
+                "run_no_fill",
+                NOW - timedelta(minutes=3),
+                decision_outcome="submitted",
+                latest_attempt_status="submitted",
+                fill_status="no_fill",
+            ),
+            status_row(
+                "run_rejected",
+                NOW - timedelta(minutes=4),
+                decision_outcome="rejected",
+                latest_attempt_status="rejected",
+                latest_attempt_reason="guard_denied",
+            ),
+        ],
+    )
+
+    assert summary["data_status"] == "partial"
+    assert summary["config"]["version"] == 4
+    assert summary["execution"]["counts"] == {
+        "submitted": 3,
+        "skipped": 1,
+        "rejected": 1,
+        "filled": 1,
+        "no_fill": 1,
+        "unknown": 1,
+    }
+    assert summary["execution"]["skip_reasons"] == [
+        {"reason": "daily_loss_cap_reached", "count": 1}
+    ]
+    assert summary["recent_runs"][0]["run_id"] == "run_unknown"
+
+
+def test_performance_summary_reports_pnl_fees_exposure_and_risk_budget() -> None:
+    summary = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+        config_row=config_row(version=7),
+        status_rows=[
+            status_row(
+                "run_filled",
+                NOW,
+                decision_outcome="submitted",
+                latest_attempt_status="submitted",
+                fill_status="filled",
+                daily_loss_used_dollars=1.25,
+                daily_loss_limit_dollars=50.0,
+                market_exposure_used_dollars=0.9,
+                market_exposure_limit_dollars=5.0,
+            )
+        ],
+        order_rows=[
+            paper_order_row(
+                status="filled",
+                filled_quantity=2,
+                open_quantity=0,
+                realized_pnl_dollars=1.0,
+                unrealized_pnl_dollars=0.25,
+            )
+        ],
+        fill_rows=[
+            {
+                "quantity": 2,
+                "fee_dollars": 0.05,
+                "filled_at": NOW - timedelta(seconds=5),
+            }
+        ],
+        position_rows=[
+            {
+                "quantity": 2,
+                "avg_price": 0.45,
+                "realized_pnl_dollars": 1.0,
+                "unrealized_pnl_dollars": 0.25,
+                "updated_at": NOW - timedelta(seconds=4),
+            }
+        ],
+    )
+
+    assert summary["data_status"] == "ok"
+    assert summary["pnl"]["status"] == "ok"
+    assert summary["pnl"]["settlement_state"] == "complete"
+    assert summary["pnl"]["net_pnl_dollars"] == 1.2
+    assert summary["pnl"]["fees_dollars"] == 0.05
+    assert summary["pnl"]["unsettled_exposure_dollars"] == 0.9
+    assert summary["risk_budget"]["daily_loss_usage_fraction"] == 0.025
+    assert summary["risk_budget"]["market_exposure_usage_fraction"] == 0.18
+
+
+def test_performance_summary_distinguishes_no_fill_from_missing_pnl() -> None:
+    summary = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+        status_rows=[
+            status_row(
+                "run_no_fill",
+                NOW,
+                decision_outcome="submitted",
+                latest_attempt_status="submitted",
+                fill_status="no_fill",
+            )
+        ],
+        order_rows=[
+            paper_order_row(
+                status="unfilled",
+                filled_quantity=0,
+                open_quantity=1,
+                realized_pnl_dollars=0.0,
+                unrealized_pnl_dollars=0.0,
+            )
+        ],
+    )
+
+    assert summary["pnl"]["status"] == "ok"
+    assert summary["pnl"]["settlement_state"] == "complete"
+    assert summary["pnl"]["fees_status"] == "not_applicable"
+    assert summary["pnl"]["net_pnl_dollars"] == 0.0
+    assert summary["pnl"]["unsettled_exposure_dollars"] == 0.0
+
+
+def test_performance_summary_marks_partial_when_fees_or_settlement_are_unavailable() -> None:
+    summary = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+        status_rows=[
+            status_row(
+                "run_partial",
+                NOW,
+                decision_outcome="submitted",
+                latest_attempt_status="submitted",
+                fill_status="filled",
+            )
+        ],
+        order_rows=[
+            paper_order_row(
+                status="partial",
+                filled_quantity=1,
+                open_quantity=1,
+                realized_pnl_dollars=0.2,
+                unrealized_pnl_dollars=0.1,
+            )
+        ],
+    )
+
+    assert summary["data_status"] == "partial"
+    assert summary["pnl"]["status"] == "partial"
+    assert summary["pnl"]["settlement_state"] == "partial"
+    assert summary["pnl"]["fees_status"] == "unavailable"
+    assert summary["pnl"]["net_pnl_dollars"] is None
+    assert summary["pnl"]["unsettled_exposure_dollars"] == 0.45
+
+
+def test_dashboard_service_exposes_performance_payload() -> None:
+    payload = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+    )
+    repository = FakePerformanceRepository(payload)
+    service = DashboardService(
+        settings=settings_from_env({"DATABASE_URL": "postgresql://example.test/alphadb"}),
+        performance_repository_factory=lambda database_url: repository,
+    )
+
+    result = service.performance_payload()
+
+    assert result["schema_version"] == "alphadb_performance_summary.v1"
+    assert result["strategy"] == "fair_value_live"
+    assert repository.calls == ["fair_value_live"]
+
+
+@dataclass
+class FakePerformanceRepository:
+    payload: dict[str, Any]
+    calls: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.calls is None:
+            self.calls = []
+
+    def summary(self, *, strategy: str) -> dict[str, Any]:
+        assert self.calls is not None
+        self.calls.append(strategy)
+        return dict(self.payload)
+
+
+def config_row(*, version: int) -> dict[str, Any]:
+    return {
+        "config_id": f"cfg_{version}",
+        "strategy": "fair_value_live",
+        "version": version,
+        "is_active": True,
+        "max_order_dollars": 5.0,
+        "max_market_exposure_dollars": 5.0,
+        "max_daily_loss_dollars": 50.0,
+        "min_edge": 0.0,
+        "min_contract_price": 0.25,
+        "max_markets": 20,
+        "created_at": NOW - timedelta(minutes=10),
+    }
+
+
+def status_row(
+    run_id: str,
+    generated_at: datetime,
+    *,
+    decision_outcome: str,
+    latest_attempt_status: str,
+    fill_status: str | None = None,
+    skip_reason: str | None = None,
+    latest_attempt_reason: str | None = None,
+    daily_loss_used_dollars: float = 0.0,
+    daily_loss_limit_dollars: float = 50.0,
+    market_exposure_used_dollars: float = 0.0,
+    market_exposure_limit_dollars: float = 5.0,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "generated_at": generated_at,
+        "config_version": 1,
+        "current_market_ticker": "KXBTC15M-TEST",
+        "decision_outcome": decision_outcome,
+        "selected_side": "yes" if latest_attempt_status == "submitted" else None,
+        "skip_reason": skip_reason,
+        "latest_attempt_status": latest_attempt_status,
+        "latest_attempt_reason": latest_attempt_reason,
+        "fill_status": fill_status,
+        "daily_loss_used_dollars": daily_loss_used_dollars,
+        "daily_loss_limit_dollars": daily_loss_limit_dollars,
+        "market_exposure_used_dollars": market_exposure_used_dollars,
+        "market_exposure_limit_dollars": market_exposure_limit_dollars,
+        "recent_attempt_count": 0,
+        "recent_submitted_count": 0,
+        "recent_skipped_count": 0,
+        "recent_no_fill_count": 0,
+        "recent_filled_count": 0,
+    }
+
+
+def paper_order_row(
+    *,
+    status: str,
+    filled_quantity: int,
+    open_quantity: int,
+    realized_pnl_dollars: float,
+    unrealized_pnl_dollars: float,
+) -> dict[str, Any]:
+    return {
+        "paper_order_id": f"order_{status}",
+        "market_ticker": "KXBTC15M-TEST",
+        "status": status,
+        "limit_price": 0.45,
+        "quantity": filled_quantity + open_quantity,
+        "filled_quantity": filled_quantity,
+        "submitted_at": NOW - timedelta(seconds=10),
+        "reconciliation_status": status,
+        "reconciliation_expected_quantity": filled_quantity + open_quantity,
+        "reconciliation_filled_quantity": filled_quantity,
+        "reconciliation_open_quantity": open_quantity,
+        "reconciliation_realized_pnl_dollars": realized_pnl_dollars,
+        "reconciliation_unrealized_pnl_dollars": unrealized_pnl_dollars,
+        "reconciliation_created_at": NOW - timedelta(seconds=9),
+    }


### PR DESCRIPTION
## Summary

Implements the Performance MVP slices for ALP-221, ALP-222, and ALP-223.

- Adds a read-only AlphaDB API `/api/performance` summary backed by Operational State.
- Adds a Cockpit `/performance` route and nav item.
- Shows truthful sparse states for empty, stale, partial, and unavailable data instead of fake values.
- Summarizes execution outcomes, skip reasons, recent run trend, risk budget usage, PnL, fees, exposure, and settlement state.

## Scope

This keeps the MVP boundary intact: Cockpit renders API data only, Python owns the Operational State aggregation, and this does not add alerts, automations, runtime controls, model promotion logic, or strategy/risk behavior changes.

## Validation

- `.venv/bin/python -m pytest -q tests/test_dashboard_performance.py tests/test_dashboard_live_console.py tests/test_live_runtime.py tests/test_portfolio.py`
- `.venv/bin/python -m ruff check src/alphadb/performance.py src/alphadb/dashboard/app.py tests/test_dashboard_performance.py`
- `PATH="/Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" apps/dashboard/node_modules/.bin/tsc --noEmit --project apps/dashboard/tsconfig.json`
- `PATH="/Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" apps/dashboard/node_modules/.bin/next build apps/dashboard`
- Browser smoke on `/performance` desktop and mobile: route rendered, API returned `alphadb_performance_summary.v1`, no console errors, no mobile horizontal overflow.