### PR TITLE
[codex] docs: update agent operating docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,123 @@
 # AGENTS.md
 
-## Context
+## Purpose
 
-Read `CONTEXT.md` before making product or architecture changes. This repo is the fresh AlphaDB target-platform workspace, separate from the current Kalshi MVP repo.
+This file is the default operating guide for coding agents working in AlphaDB.
 
-## Agent skills
+AlphaDB is the target-platform repo for a reusable Kalshi prediction-market trading platform. It is separate from the current live Kalshi MVP repo. Preserve that boundary unless the user explicitly scopes a cutover or integration task.
 
-### Issue tracker
+## Read first
 
-Issues and PRDs live in Linear under the ThreadFork `ALP` team. See `docs/agents/issue-tracker.md`.
+Before product, architecture, strategy, model, risk, runtime, or data-model changes, read:
 
-### Triage labels
+- `CONTEXT.md`
+- `docs/adr/`
+- relevant docs under `docs/architecture/`, `docs/strategy/`, `docs/deployment/`, or `docs/settlement/`
 
-Use the default five-role triage vocabulary. See `docs/agents/triage-labels.md`.
+For small repo-structure, docs, hygiene, or template changes, read this file first and use `CONTEXT.md` only as needed.
 
-### Domain docs
+## Default working rules
 
-Single-context repo: read `CONTEXT.md` and root `docs/adr/`. See `docs/agents/domain.md`.
+- Prefer small, reviewable, independently testable changes.
+- Do not reorganize existing platform modules unless explicitly requested.
+- Preserve the target-platform / Current MVP boundary.
+- Keep secrets, credentials, private datasets, production logs, model binaries, generated data, and live account/order/fill artifacts out of Git.
+- Prefer truthful sparse states over fake demo data.
+- Do not introduce heavy frameworks unless explicitly requested.
+- Do not expand MVP security scope unless explicitly requested.
+- Run the lightest relevant validation before handing off.
 
-## Working rules
+## Branch taxonomy
 
-- Preserve the target-platform/MVP boundary: this repo may define the future platform, but it must not assume control of the current live MVP.
-- Prefer small, independently testable modules.
-- Keep secrets and generated data out of Git.
-- Use normal engineering branch prefixes such as `feat/`, `fix/`, `chore/`, and `docs/`.
-- Before changing strategy, model, or risk logic, create a short strategy diagnosis note unless the user explicitly asks for a direct implementation-only change. Emergency live-risk actions such as pause, stop, disabling live orders, or reducing exposure are exempt; see `docs/agents/strategy-diagnosis.md`.
+Use the branch prefix that matches the intent of the work:
+
+- `feat/...` for platform or product features.
+- `fix/...` for bug fixes.
+- `chore/...` for maintenance, dependencies, repo hygiene, or structure.
+- `docs/...` for documentation-only work.
+- `analysis/...` for exploratory data or system understanding without a formal hypothesis.
+- `spike/...` for technical feasibility tests.
+- `exp/...` for hypothesis-driven research experiments.
+
+Examples:
+
+- `chore/research-operating-structure`
+- `exp/fill-probability-baseline`
+- `analysis/aws-training-costs`
+- `spike/vectorized-replay`
+- `feat/aws-training-runner`
+- `fix/db-connection-pooling`
+
+## Research artifact policy
+
+The public repo may include:
+
+- templates
+- synthetic fixtures
+- sanitized examples
+- artifact manifests
+- public-safe reference notebooks
+- high-level experiment summaries that do not reveal proprietary edge
+
+The public repo must not include:
+
+- credentials or `.env` files
+- private keys or exchange secrets
+- raw licensed market data
+- raw official BRTI data
+- private generated research datasets
+- production database dumps
+- live account, order, fill, or strategy logs
+- model binaries
+- proprietary thresholds or live strategy configs
+
+When unsure, commit a manifest, schema, or synthetic fixture instead of the raw artifact.
+
+## Research workflow
+
+Use:
+
+- `experiments/` for hypothesis, config, manifest, result, and decision records.
+- `notebooks/` for curated public-safe notebooks.
+- `notebooks/00_scratch/` for local disposable exploration; do not commit scratch notebooks by default.
+- `db/queries/research/` for reusable research SQL.
+- `db/queries/app/` for SQL used by app/platform paths.
+- `src/alphadb/research/` for reusable research helpers that have not yet graduated into platform modules.
+
+Promotion path:
+
+```text
+scratch notebook
+  -> curated notebook
+  -> experiment record
+  -> research helper
+  -> platform module
+```
+
+Promote reusable code out of notebooks and into Python modules when it becomes repeated or important.
+
+## Strategy, model, and risk changes
+
+Before changing strategy, model, or risk logic, create or update a short strategy diagnosis note unless the user explicitly asks for a direct implementation-only change.
+
+Emergency live-risk actions such as pause, stop, disabling live orders, or reducing exposure are exempt. See:
+
+- `docs/agents/strategy-diagnosis.md`
+
+## Agent skills and docs
+
+- Issues and PRDs live in Linear under the ThreadFork `ALP` team. See `docs/agents/issue-tracker.md`.
+- Use the default five-role triage vocabulary. See `docs/agents/triage-labels.md`.
+- For domain vocabulary, read `CONTEXT.md` and `docs/agents/domain.md`.
+
+## Validation expectations
+
+For most small PRs, run the smallest relevant set of checks:
+
+```bash
+pytest
+alphadb-repo-hygiene
+pre-commit run --all-files
+```
+
+If a command is unavailable or too broad for the scoped change, say so in the handoff and explain what was run instead.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,5 +1,14 @@
 # Context
 
+## How to use this file
+
+This file is AlphaDB's domain glossary and architecture context. It is not a task list.
+
+Agents should use it to preserve vocabulary, boundaries, and invariants. For day-to-day coding rules, read `AGENTS.md` first.
+
+Stable terms and invariants should remain here. Short-lived task plans, PR-specific goals, and temporary implementation notes should live in issues, PRDs, or docs under `docs/`.
+
+
 ## Project
 
 AlphaDB is the target-platform repo for a reusable Kalshi prediction-market trading platform. It starts with `KXBTC15M`, but the architecture should support future crypto market families through explicit market specifications.


### PR DESCRIPTION
## Summary

Updated the repo-level agent operating docs from the supplied updated versions:

- Replaced `AGENTS.md` with `AGENTS.updated.md`.
- Replaced `CONTEXT.md` with `CONTEXT.updated.md`.

## What changed

- Clarified the target-platform / Current MVP boundary for coding agents.
- Added branch taxonomy for engineering and research work.
- Documented public/private research artifact rules.
- Clarified where experiments, notebooks, database queries, and reusable research helpers belong.
- Added guidance for using `CONTEXT.md` as domain context without making every small task depend on the full glossary.

## Scope

This PR intentionally updates only:

- `AGENTS.md`
- `CONTEXT.md`

The supplied `.updated.md` files were used as source inputs and are not included in the commit.

## Validation

- `cmp -s AGENTS.md AGENTS.updated.md`: matched before commit.
- `cmp -s CONTEXT.md CONTEXT.updated.md`: matched before commit.
- `git diff --check -- AGENTS.md CONTEXT.md`: passed.