### PR TITLE
[codex] Adopt close-inclusive KXBTC15M settlement window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ htmlcov/
 /data/
 /research/
 /artifacts/
+experiments/**/raw/
+experiments/**/normalized/
+experiments/**/derived/
+experiments/**/results/
 *.parquet
 *.joblib
 *.pkl

--- a/docs/research/cfbenchmarks-value-feed-fit.md
+++ b/docs/research/cfbenchmarks-value-feed-fit.md
@@ -1,0 +1,133 @@
+# CF Benchmarks Value Feed Research Fit
+
+Status: research assessment
+Reviewed: 2026-06-08
+Branch: `exp/cfbenchmarks-value-research-fit`
+
+## Source Summary
+
+Kalshi's `cfbenchmarks_value` WebSocket channel emits real-time CF Benchmarks
+index values. The channel requires an authenticated WebSocket connection, is
+subscribed by `index_ids`, supports `index_ids: ["all"]`, can return an
+`indexlist`, and emits ticks roughly once per second. Each value update includes
+the index id, Kalshi receive timestamp, the raw upstream frame, a trailing
+60-second average, and a final-minute quarter-hour average that is present only
+inside the final minute before `:00`, `:15`, `:30`, and `:45` quarter closes.
+Kalshi documents that final-minute field as excluding the start boundary and
+including the close tick: `(quarter_close_ts_ms - 60000, quarter_close_ts_ms]`.
+
+Primary source:
+
+- <https://docs.kalshi.com/websockets/cfbenchmarks-value>
+- <https://docs.kalshi.com/websockets>
+- <https://docs.kalshi.com/getting_started/quick_start_websockets>
+
+## Fit Verdict
+
+This feed is a strong fit for an AlphaDB experiment, but it should enter as a
+research input and future raw event source, not as immediate model-promotion,
+live-trading, or Current MVP cutover authority.
+
+The useful split is:
+
+- Settlement-state validation input: capture `BRTI` around `KXBTC15M` quarter
+  closes and compare the final-minute average to AlphaDB settlement-state
+  calculations.
+- Decision-time context feed: create no-lookahead threshold-distance,
+  current-index, short-window momentum, and final-minute-lockdown features for
+  fair-value policy replay.
+- WebSocket ingestion readiness probe: validate authenticated subscription,
+  sequencing, reconnect, and coverage behavior before serious paper or shadow
+  runtime use.
+
+## Boundary Classification
+
+For `KXBTC15M`, the feed is official-source-adjacent because the market rules
+already identify CF Benchmarks as the source agency and the settlement spec uses
+the `BRTI` index with a final 60-second average. However, AlphaDB should not
+automatically treat a Kalshi-relayed live WebSocket stream as
+`official_licensed` historical settlement input.
+
+Until licensing and retention rights are confirmed, store generated captures
+outside Git and classify derived manifests as public-safe evidence. In the
+current settlement manifest contract, promotion-grade settlement readiness still
+requires `source_status == "official_licensed"`. A feed capture with uncertain
+license status should produce an `INCONCLUSIVE` readiness verdict, not a
+`PASS`, even if the mechanics look correct.
+
+For feature research, the feed behaves like external market context. A feature
+row may use a CF Benchmarks tick only if the source timestamp and local receive
+timestamp prove it was observable at or before the decision timestamp. Historical
+backfills must preserve retrieval timing and must not pretend that later
+collection was live-observable.
+
+AlphaDB now adopts Kalshi's documented `cfbenchmarks_value` quarter-close
+average convention for `KXBTC15M` settlement-state calculations: the final
+minute excludes the start-boundary tick and includes the close tick,
+`(close - 60s, close]`. For one-second `BRTI` prints, that means `close - 59s`
+through `close`.
+
+## Proposed Research Questions
+
+1. Coverage and latency: can AlphaDB capture continuous `BRTI` values through
+   enough quarter-hour closes without missing final-window data?
+2. Settlement mechanics: does the captured final-minute quarter-hour average
+   match AlphaDB's close-inclusive final 60 one-second average over normalized
+   official settlement input or exchange-published outcomes, subject to
+   documented precision and rounding semantics?
+3. Model value: do CF Benchmarks decision-time features improve probability
+   quality and taker-policy outcomes after fees and spread stress versus the
+   Coinbase/BTC market-structure baseline?
+4. Operational readiness: can the existing `alphadb.collectors.kalshi_ws`
+   raw-event path be extended to index-level events without forcing a
+   market-ticker join in the hot path?
+
+## First Experiment Shape
+
+Start with a narrow capture probe before any runtime or model changes:
+
+- Subscribe to `cfbenchmarks_value` for `index_ids: ["BRTI"]`.
+- Call `indexlist` once per run and preserve the returned available index ids.
+- Capture raw value frames across at least several `KXBTC15M` quarter-hour
+  closes, including the full final minute before close.
+- Store raw frames under ignored `research/` or `artifacts/` paths.
+- Normalize a private table with index id, source timestamp, Kalshi receive
+  timestamp, local receive timestamp, sequence, raw upstream payload hash,
+  tick value, trailing 60-second average, and quarter-hour final-minute average.
+- Produce a public-safe manifest with counts, time range, gaps, hashes, source
+  status, index ids, websocket environment, and a readiness verdict.
+- Only after coverage is credible, run an offline feature ablation against
+  decision-time rows and settlement labels.
+
+## Schema Notes
+
+The existing raw event log can hold index-level feed events because
+`raw_events.market_ticker` is nullable. A future implementation can use:
+
+- `source`: `kalshi_ws`
+- `schema_version`: `kalshi.ws.cfbenchmarks_value.v1`
+- `source_event_id`: `cfbenchmarks_value:{index_id}:{source_ts_ms}:{seq}`
+- `market_ticker`: `null` for raw index events
+- `source_timestamp`: parsed upstream `time` from `msg.data`
+- `payload`: the complete Kalshi message plus parsed convenience fields
+
+Market-instance joins should happen in normalized research or feature-building
+steps, where a `BRTI` tick can be associated with all active `KXBTC15M` markets
+whose decision or settlement window can legally observe it.
+
+## Promotion Gates
+
+Do not promote this feed beyond research until these are resolved:
+
+- Retention and licensing status for Kalshi-relayed CF Benchmarks frames.
+- Exact timestamp semantics for upstream `time`, Kalshi `received_at`, and local
+  receive time.
+- Rounding and precision behavior for settlement comparison.
+- Behavior during missing ticks, duplicate timestamps, reconnects, and final
+  close ticks.
+- Whether the demo environment supports representative `cfbenchmarks_value`
+  payloads and index ids.
+
+Passing the first capture probe should create an edge verdict or readiness
+verdict only. It should not authorize model registry promotion, live trading,
+Current MVP changes, or target-platform cutover.

--- a/docs/settlement/kxbtc15m-rules.md
+++ b/docs/settlement/kxbtc15m-rules.md
@@ -11,6 +11,9 @@
 
 - The source agency is CF Benchmarks.
 - The underlying uses the relevant CF crypto index averaged over the 60 seconds before the listed expiration time.
+- AlphaDB models that final minute using Kalshi's `cfbenchmarks_value`
+  quarter-close average convention: exclude the start-boundary tick and include
+  the close tick, `(expiration - 60s, expiration]`.
 - Revisions to the underlying after expiration are not used to determine the expiration value.
 - If expiration-time data is unavailable or incomplete, affected strikes resolve to No.
 - `above X` is a strict greater-than comparison.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,23 @@
+# Experiments
+
+This tree holds public-safe experiment charters, configs, manifest examples,
+decision records, and high-level summaries.
+
+Do not commit raw vendor data, private generated datasets, production logs,
+model binaries, credentials, exchange account records, or live strategy
+configuration. Generated experiment artifacts belong under ignored roots such
+as `research/` or `artifacts/`, with committed manifests referring to hashes,
+counts, schemas, and stable private paths only.
+
+Recommended shape for a research branch:
+
+```text
+experiments/<experiment-id>/
+  README.md
+  configs/
+  templates/
+  decisions/
+```
+
+If a local experiment needs `raw/`, `normalized/`, `derived/`, or `results/`
+subdirectories under this tree, those paths are ignored by Git.

--- a/experiments/cfbenchmarks-value-feed/README.md
+++ b/experiments/cfbenchmarks-value-feed/README.md
@@ -1,0 +1,67 @@
+# CF Benchmarks Value Feed Experiment
+
+Status: design-only scaffold
+Related assessment: `docs/research/cfbenchmarks-value-feed-fit.md`
+
+## Hypothesis
+
+The Kalshi `cfbenchmarks_value` WebSocket feed can improve AlphaDB's
+`KXBTC15M` research foundation by providing observable, one-second `BRTI`
+index context and final-minute quarter-hour averages, as long as captures are
+manifested, no-lookahead-safe, and kept separate from promotion-grade official
+licensed settlement history until source rights are confirmed.
+
+## Non-Goals
+
+- No live trading or order submission.
+- No Current MVP integration.
+- No model registry promotion.
+- No committed raw CF Benchmarks, official BRTI, or private generated datasets.
+- No assumption that a live Kalshi relay is automatically licensed historical
+  settlement input.
+
+## Data Contract
+
+Capture runs should preserve:
+
+- WebSocket environment and URL family, without credentials.
+- Subscription command ids, assigned `sid`, requested `index_ids`, and
+  `indexlist` response.
+- Raw `cfbenchmarks_value` messages exactly as received.
+- Local receive timestamps in UTC.
+- Parsed upstream source timestamp and value from `msg.data`.
+- Kalshi `received_at`, stream `seq`, `avg_60s_data`, and
+  `last_60s_windowed_average_15min`.
+- Coverage gaps, reconnect intervals, duplicate/out-of-order drops if observed,
+  and final-window completeness.
+- File hashes and row counts for every generated artifact.
+
+## Candidate Outputs
+
+Private generated outputs:
+
+- `research/cfbenchmarks-value-feed/<dataset_id>/raw/ws_frames.jsonl`
+- `research/cfbenchmarks-value-feed/<dataset_id>/normalized/index_ticks.parquet`
+- `research/cfbenchmarks-value-feed/<dataset_id>/derived/final_windows.parquet`
+- `artifacts/cfbenchmarks-value-feed/<dataset_id>/coverage_report.md`
+
+Public-safe committed outputs:
+
+- A pull manifest based on `templates/pull_manifest.example.json`.
+- A dataset manifest based on `templates/dataset_manifest.example.json`.
+- A short decision record under `decisions/` when the probe has a verdict.
+
+## Success Criteria
+
+The first probe is useful if it can answer:
+
+- Were all intended quarter-hour final windows captured?
+- Did the feed provide 60 final-minute observations for complete closes?
+- Were source timestamps, Kalshi receive timestamps, and local receive
+  timestamps internally consistent?
+- Did captured final-window averages match AlphaDB's adopted close-inclusive
+  `(close - 60s, close]` convention?
+- Can the private capture be transformed into settlement-state or feature rows
+  without lookahead?
+- Is the licensing/source-status strong enough for settlement-state readiness,
+  or should the result stay `INCONCLUSIVE`?

--- a/experiments/cfbenchmarks-value-feed/configs/probe.example.json
+++ b/experiments/cfbenchmarks-value-feed/configs/probe.example.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "cfbenchmarks_value_probe_config.v0",
+  "experiment_id": "cfbenchmarks-value-feed",
+  "environment": "demo-or-production",
+  "channel": "cfbenchmarks_value",
+  "index_ids": ["BRTI"],
+  "capture_windows": [
+    {
+      "label": "example_quarter_close",
+      "start_utc": "2026-06-08T20:14:00Z",
+      "end_utc": "2026-06-08T20:15:10Z",
+      "expected_quarter_close_utc": "2026-06-08T20:15:00Z"
+    }
+  ],
+  "storage": {
+    "raw_root": "research/cfbenchmarks-value-feed/<dataset_id>/raw",
+    "normalized_root": "research/cfbenchmarks-value-feed/<dataset_id>/normalized",
+    "artifact_root": "artifacts/cfbenchmarks-value-feed/<dataset_id>"
+  },
+  "safety": {
+    "commit_raw_data": false,
+    "commit_credentials": false,
+    "live_trading_enabled": false
+  }
+}

--- a/experiments/cfbenchmarks-value-feed/templates/dataset_manifest.example.json
+++ b/experiments/cfbenchmarks-value-feed/templates/dataset_manifest.example.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "cfbenchmarks_value_dataset_manifest.v0",
+  "dataset_id": "cfbval_YYYYMMDD_probe",
+  "source_identity": "kalshi_ws.cfbenchmarks_value",
+  "source_status": "official_unlicensed",
+  "license_status": "unlicensed",
+  "market_series": "KXBTC15M",
+  "index_ids": ["BRTI"],
+  "tested_time_range": {
+    "start_utc": "2026-06-08T20:14:00Z",
+    "end_utc": "2026-06-08T20:15:10Z"
+  },
+  "coverage": {
+    "raw_message_count": 0,
+    "normalized_tick_count": 0,
+    "quarter_close_count": 0,
+    "complete_final_window_count": 0,
+    "incomplete_final_window_count": 0,
+    "gap_count": 0,
+    "reconnect_count": 0
+  },
+  "artifact_hashes": {
+    "raw_frames_jsonl_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "normalized_ticks_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "final_windows_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "artifact_locations": {
+    "raw_frames_jsonl": "research/cfbenchmarks-value-feed/<dataset_id>/raw/ws_frames.jsonl",
+    "normalized_ticks": "research/cfbenchmarks-value-feed/<dataset_id>/normalized/index_ticks.parquet",
+    "final_windows": "research/cfbenchmarks-value-feed/<dataset_id>/derived/final_windows.parquet",
+    "coverage_report": "artifacts/cfbenchmarks-value-feed/<dataset_id>/coverage_report.md"
+  },
+  "readiness_verdict": "INCONCLUSIVE",
+  "readiness_reasons": [
+    "source_status_requires_license_confirmation",
+    "example_manifest_contains_no_real_capture"
+  ],
+  "no_lookahead_basis": "Feature rows may use only ticks whose source timestamp and local receive timestamp are at or before the decision timestamp.",
+  "non_promotion_notice": "This manifest is research evidence only and does not authorize model promotion, live trading, Current MVP changes, or target-platform cutover."
+}

--- a/experiments/cfbenchmarks-value-feed/templates/pull_manifest.example.json
+++ b/experiments/cfbenchmarks-value-feed/templates/pull_manifest.example.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "cfbenchmarks_value_pull_manifest.v0",
+  "pull_id": "cfbval_pull_YYYYMMDDTHHMMSSZ",
+  "requested_at_utc": "2026-06-08T20:13:55Z",
+  "completed_at_utc": "2026-06-08T20:15:15Z",
+  "vendor": "Kalshi",
+  "dataset": "WebSocket cfbenchmarks_value",
+  "websocket_environment": "demo-or-production",
+  "channel": "cfbenchmarks_value",
+  "subscription": {
+    "index_ids": ["BRTI"],
+    "indexlist_requested": true,
+    "assigned_sid": 1
+  },
+  "client": {
+    "client_name": "alphadb",
+    "client_version": "0.1.0",
+    "auth_material_recorded": false
+  },
+  "capture": {
+    "started_at_utc": "2026-06-08T20:14:00Z",
+    "ended_at_utc": "2026-06-08T20:15:10Z",
+    "local_clock_source": "system_utc",
+    "messages_seen": 0,
+    "errors_seen": 0,
+    "reconnects": 0
+  },
+  "outputs": {
+    "raw_frames_jsonl": "research/cfbenchmarks-value-feed/<dataset_id>/raw/ws_frames.jsonl",
+    "pull_log": "artifacts/cfbenchmarks-value-feed/<dataset_id>/pull_log.json"
+  },
+  "checksums": {
+    "raw_frames_jsonl_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "pull_log_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "notes": [
+    "Example only. Do not commit raw frames, credentials, private keys, or live account data."
+  ]
+}

--- a/src/alphadb/settlement/fixtures.py
+++ b/src/alphadb/settlement/fixtures.py
@@ -185,7 +185,7 @@ def synthetic_official_input_payload(prints: list[dict[str, Any]]) -> dict[str, 
 
 
 def synthetic_print_payloads() -> list[dict[str, Any]]:
-    start = KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=60)
+    start = KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=59)
     return [
         synthetic_print_payload(
             effective_time_utc=start + timedelta(seconds=offset),

--- a/src/alphadb/settlement/inputs.py
+++ b/src/alphadb/settlement/inputs.py
@@ -171,7 +171,7 @@ def expected_final_window_times(
     window = settlement_spec.final_settlement_window
     start = expiration_time_utc - timedelta(seconds=window.duration_seconds)
     return tuple(
-        start + timedelta(seconds=window.cadence_seconds * offset)
+        start + timedelta(seconds=window.cadence_seconds * (offset + 1))
         for offset in range(window.expected_print_count)
     )
 

--- a/tests/test_settlement_inputs.py
+++ b/tests/test_settlement_inputs.py
@@ -97,15 +97,15 @@ def test_synthetic_fixture_validity_expectations_are_enforced() -> None:
                 )
 
 
-def test_expected_final_window_times_use_sixty_seconds_prior_to_expiration() -> None:
+def test_expected_final_window_times_use_kalshi_close_inclusive_final_minute() -> None:
     times = expected_final_window_times(
         expiration_time_utc=KXBTC15M_SYNTHETIC_EXPIRATION,
         settlement_spec=kxbtc15m_settlement_spec(),
     )
 
     assert len(times) == 60
-    assert times[0] == KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=60)
-    assert times[-1] == KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=1)
+    assert times[0] == KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=59)
+    assert times[-1] == KXBTC15M_SYNTHETIC_EXPIRATION
 
 
 def test_boundary_decision_times_are_public_fixture_data() -> None:

--- a/tests/test_settlement_state.py
+++ b/tests/test_settlement_state.py
@@ -41,14 +41,13 @@ def test_clean_rows_support_boundary_decision_times() -> None:
         for decision_time in kxbtc15m_synthetic_fixture_suite()["clean_above"].decision_times_utc
     ]
 
-    assert [row.locked_count for row in rows] == [0, 1, 31, 60, 60, 60]
-    assert [row.remaining_count for row in rows] == [60, 59, 29, 0, 0, 0]
+    assert [row.locked_count for row in rows] == [0, 0, 30, 59, 60, 60]
+    assert [row.remaining_count for row in rows] == [60, 60, 30, 1, 0, 0]
     assert all(row.row_valid for row in rows)
     assert all(row.promotion_safe for row in rows)
     assert rows[0].locked_average is None
-    assert rows[1].locked_sum == Decimal("100000.00")
-    assert rows[1].locked_average == Decimal("100000.00")
-    assert rows[-1].source_lag_seconds == 2
+    assert rows[1].locked_average is None
+    assert rows[-1].source_lag_seconds == 1
 
 
 def test_clean_final_row_has_required_audit_fields_and_hashes() -> None:
@@ -68,7 +67,7 @@ def test_clean_final_row_has_required_audit_fields_and_hashes() -> None:
     assert row.payout_comparator == "between"
     assert row.payout_thresholds == (Decimal("99990.00"), Decimal("100010.00"))
     assert row.threshold_precision == 2
-    assert row.final_window_start_utc == KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=60)
+    assert row.final_window_start_utc == KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=59)
     assert row.final_window_end_utc == KXBTC15M_SYNTHETIC_EXPIRATION
     assert row.expected_print_count == 60
     assert row.locked_count == 60
@@ -77,7 +76,7 @@ def test_clean_final_row_has_required_audit_fields_and_hashes() -> None:
     assert row.remaining_count == 0
     assert row.source_quality_flags == ()
     assert row.invalid_reason is None
-    assert row.max_source_event_timestamp_utc == KXBTC15M_SYNTHETIC_EXPIRATION - timedelta(seconds=1)
+    assert row.max_source_event_timestamp_utc == KXBTC15M_SYNTHETIC_EXPIRATION
     assert row.source_id == "synthetic.cf-brti.kxbtc15m"
     assert row.source_version == "synthetic.v1"
     assert row.source_status == "synthetic_fixture"
@@ -114,7 +113,7 @@ def test_no_lookahead_future_print_values_do_not_change_partial_row() -> None:
         decision_time_utc=decision_time,
     )
 
-    assert baseline.locked_count == 31
+    assert baseline.locked_count == 30
     assert baseline.row_hash == changed.row_hash
     assert baseline.locked_prints_hash == changed.locked_prints_hash
     assert baseline.source_event_ids == changed.source_event_ids


### PR DESCRIPTION
## Summary

- Adopt Kalshi's close-inclusive `cfbenchmarks_value` quarter-close convention for KXBTC15M settlement-state final-window timestamps: `(expiration - 60s, expiration]`.
- Update synthetic settlement fixtures and tests so the close tick is included and the start-boundary tick is excluded.
- Add public-safe CF Benchmarks feed research assessment, experiment scaffold, and manifest templates.

## Impact

Settlement-state and fair-value replay labels now use the Kalshi-sanctioned final-minute average convention. Live fair-value order selection does not directly compute settlement averages, so visible prod impact depends on settlement/replay/report paths using this helper.

## Validation

- `.venv/bin/pytest tests/test_settlement_inputs.py tests/test_settlement_state.py tests/test_settlement_dataset.py tests/test_settlement_manifest.py tests/test_settlement_synthetic_readiness.py`
- `.venv/bin/pytest tests/test_fair_value_mvp.py tests/test_model_evaluation.py tests/test_live_runtime.py tests/test_deploy.py`
- `.venv/bin/pytest`
- `PYTHONPATH=src python3 -m alphadb.repo_hygiene check --repo .`
- `git diff --check`
- `python3 -m json.tool` on the example config and manifest JSON files
