### PR TITLE
fix: stop BRTI collector migration deadlocks

### DIFF
--- a/src/alphadb/collectors/brti.py
+++ b/src/alphadb/collectors/brti.py
@@ -449,7 +449,6 @@ class BRTILiveCollector:
         self.latest_contexts = BRTILatestContextRepository(database_url)
 
     def ingest_frames(self, frames: Iterable[BRTIWebSocketFrame]) -> BRTIIngestSummary:
-        OperationalStateRepository(self.database_url).apply_migrations()
         messages_seen = 0
         control_messages_seen = 0
         accepted = 0
@@ -633,6 +632,7 @@ async def run_live_collector(
 ) -> BRTIIngestSummary:
     credentials = assert_live_smoke_enabled(settings)
     websocket_url = credentials.websocket_url or DEFAULT_KALSHI_WS_URL
+    OperationalStateRepository(database_url).apply_migrations()
     collector = BRTILiveCollector(database_url=database_url, index_id=index_id)
     aggregate = _MutableIngestAggregate(index_id=index_id)
     attempts = 0

--- a/src/alphadb/state/repository.py
+++ b/src/alphadb/state/repository.py
@@ -27,9 +27,12 @@ class OperationalStateRepository:
 
     def apply_migrations(self) -> list[str]:
         applied: list[str] = []
+        applied_versions = set(self.applied_migrations())
         with self.connect() as connection:
             with connection.cursor() as cursor:
                 for migration in MIGRATIONS:
+                    if migration.version in applied_versions:
+                        continue
                     for statement in migration.statements:
                         cursor.execute(statement)
                     cursor.execute(
@@ -42,6 +45,7 @@ class OperationalStateRepository:
                     )
                     if cursor.rowcount:
                         applied.append(migration.version)
+                        applied_versions.add(migration.version)
             connection.commit()
         return applied
 

--- a/tests/test_brti_collector.py
+++ b/tests/test_brti_collector.py
@@ -164,6 +164,31 @@ def test_collector_writes_index_level_raw_event_and_latest_context() -> None:
     assert replayed[0]["raw_event_id"] == latest.context.raw_event_id
 
 
+def test_collector_ingest_does_not_apply_migrations_per_frame(monkeypatch) -> None:
+    repository, _collector = brti_repository_or_skip()
+    unique_index = f"BRTI_NO_MIGRATE_{uuid4().hex[:8]}"
+    collector = BRTILiveCollector(
+        database_url=repository.database_url,
+        index_id=unique_index,
+    )
+    received_at = datetime.now(UTC)
+    frame = fixture_brti_frame(index_id=unique_index, received_at=received_at)
+
+    def fail_apply_migrations(_self: object) -> None:
+        raise AssertionError("BRTI frame ingestion must not run migrations")
+
+    monkeypatch.setattr(
+        OperationalStateRepository,
+        "apply_migrations",
+        fail_apply_migrations,
+    )
+
+    summary = collector.ingest_frames([frame])
+
+    assert summary.accepted == 1
+    assert summary.latest_context_updates == 1
+
+
 def test_collector_rejects_invalid_message_before_raw_persistence() -> None:
     repository, collector = brti_repository_or_skip()
     received_at = datetime.now(UTC)

--- a/tests/test_operational_state.py
+++ b/tests/test_operational_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from uuid import uuid4
 
 import psycopg
 import pytest
@@ -9,6 +10,7 @@ from psycopg.types.json import Jsonb
 
 from alphadb.config import settings_from_env
 from alphadb.markets.spec import kxbtc15m_spec
+from alphadb.state.migrations import Migration
 from alphadb.state.repository import OperationalStateRepository
 
 
@@ -49,6 +51,38 @@ def test_migrations_are_idempotent_and_create_complete_tracer_run() -> None:
     assert counts.decisions >= 1
     assert counts.risk_decisions >= 1
     assert counts.order_intents >= 1
+
+
+def test_apply_migrations_skips_already_recorded_versions(monkeypatch) -> None:
+    repository = repository_or_skip()
+    repository.apply_migrations()
+    marker = f"9999_test_skip_applied_{uuid4().hex}"
+
+    with repository.connect() as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "insert into schema_migrations (version) values (%s)",
+                (marker,),
+            )
+        connection.commit()
+
+    try:
+        monkeypatch.setattr(
+            "alphadb.state.repository.MIGRATIONS",
+            (
+                Migration(
+                    version=marker,
+                    statements=("select alphadb_missing_migration_function()",),
+                ),
+            ),
+        )
+
+        assert repository.apply_migrations() == []
+    finally:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("delete from schema_migrations where version = %s", (marker,))
+            connection.commit()
 
 
 def test_decision_uniqueness_preserves_one_authoritative_outcome_per_run_instance() -> None:


### PR DESCRIPTION
## Summary
- Stop the BRTI collector from running operational-state migrations for every received WebSocket frame; the live collector applies migrations once before entering the frame loop.
- Make `OperationalStateRepository.apply_migrations()` skip versions already recorded in `schema_migrations`, so repeated runtime startup checks do not re-execute DDL.
- Add regressions covering both the per-frame collector behavior and the migration-runner skip behavior.

## Root Cause
CloudWatch around the reported 2026-06-08 12:50 PM Pacific / 19:50 UTC window showed fair-value `brti_context_stale` skips while the BRTI collector was reconnecting after Postgres `DeadlockDetected` errors. The collector was calling `apply_migrations()` on every BRTI frame, and the migration runner reissued all idempotent DDL even for already-applied migrations. Those repeated DDL locks interrupted collector updates long enough for the 5-second BRTI freshness gate to fail closed.

## Validation
- `.venv/bin/python -m pytest -q` => 319 passed, 22 warnings
- `.venv/bin/alphadb-repo-hygiene check` => pass for public Git state
- `.venv/bin/ruff check src/alphadb/collectors/brti.py src/alphadb/state/repository.py tests/test_brti_collector.py tests/test_operational_state.py`
- `git diff --check`

## Note
`pre-commit run --all-files` could not run because this repo currently has no `.pre-commit-config.yaml`.