### PR TITLE
[codex] Improve live operations panel UI

### DIFF
--- a/apps/dashboard/components/live/live-operations.tsx
+++ b/apps/dashboard/components/live/live-operations.tsx
@@ -1,11 +1,11 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { apiGet, apiPost } from "@/lib/alphadb-api"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useSelectedStrategy } from "@/components/strategy/strategy-context"
-import { Activity, CircleHelp, RefreshCw, Save, ShieldAlert, Square } from "lucide-react"
+import { Activity, ChevronDown, ChevronRight, CircleHelp, GripVertical, RefreshCw, RotateCcw, Save, ShieldAlert, Square } from "lucide-react"
 
 interface LivePayload {
   strategy?: string
@@ -64,6 +64,7 @@ const MARKET_CONTEXT_OPTIONS = [
 ] as const
 
 const TABLE_TOOLTIPS = {
+  details: "Expand a row to inspect order, sizing, risk, and config details.",
   time: "When this order attempt was created or submitted.",
   market: "Kalshi market ticker for the attempted live decision.",
   status: "Recorded attempt status, such as submitted, skipped, or failed.",
@@ -104,6 +105,51 @@ const RISK_TOOLTIPS = {
   market_limit: "Configured per-market exposure cap for this strategy.",
 } as const
 
+const ACTIVITY_FEED_LIMIT = 50
+const PANEL_LAYOUT_VERSION = 1
+
+const PANEL_IDS = [
+  "market",
+  "decision",
+  "risk-summary",
+  "execution",
+  "activity-feed",
+  "runtime-config",
+  "market-context",
+  "risk",
+  "recent-runs",
+] as const
+
+type PanelId = (typeof PANEL_IDS)[number]
+
+interface PanelDefinition {
+  label: string
+  defaultWidth: number
+  defaultHeight: number
+  minWidth: number
+  minHeight: number
+}
+
+interface PanelLayoutItem {
+  id: PanelId
+  width: number
+  height: number
+}
+
+const PANEL_DEFINITIONS: Record<PanelId, PanelDefinition> = {
+  market: { label: "Market", defaultWidth: 280, defaultHeight: 112, minWidth: 220, minHeight: 96 },
+  decision: { label: "Decision", defaultWidth: 280, defaultHeight: 112, minWidth: 220, minHeight: 96 },
+  "risk-summary": { label: "Risk summary", defaultWidth: 320, defaultHeight: 112, minWidth: 260, minHeight: 96 },
+  execution: { label: "Execution", defaultWidth: 300, defaultHeight: 112, minWidth: 240, minHeight: 96 },
+  "activity-feed": { label: "Activity Feed", defaultWidth: 920, defaultHeight: 520, minWidth: 420, minHeight: 260 },
+  "runtime-config": { label: "Runtime Config", defaultWidth: 360, defaultHeight: 420, minWidth: 320, minHeight: 320 },
+  "market-context": { label: "Market Context", defaultWidth: 360, defaultHeight: 260, minWidth: 320, minHeight: 220 },
+  risk: { label: "Risk", defaultWidth: 360, defaultHeight: 170, minWidth: 280, minHeight: 140 },
+  "recent-runs": { label: "Recent Runs", defaultWidth: 360, defaultHeight: 260, minWidth: 300, minHeight: 180 },
+}
+
+const PANEL_ID_SET = new Set<PanelId>(PANEL_IDS)
+
 type ConfigFieldKey = (typeof CONFIG_FIELDS)[number]["key"]
 type ConfigFormKey = ConfigFieldKey | "market_context_source"
 type ConfigFormValues = Record<ConfigFormKey, string>
@@ -115,6 +161,68 @@ const EMPTY_CONFIG_FORM = {
     return values
   }, {} as Record<ConfigFieldKey, string>),
   market_context_source: "coinbase_primary",
+}
+
+function isPanelId(value: unknown): value is PanelId {
+  return typeof value === "string" && PANEL_ID_SET.has(value as PanelId)
+}
+
+function defaultPanelLayout(): PanelLayoutItem[] {
+  return PANEL_IDS.map((id) => {
+    const definition = PANEL_DEFINITIONS[id]
+    return {
+      id,
+      width: definition.defaultWidth,
+      height: definition.defaultHeight,
+    }
+  })
+}
+
+function normalizePanelSize(id: PanelId, width: unknown, height: unknown): PanelLayoutItem {
+  const definition = PANEL_DEFINITIONS[id]
+  const parsedWidth = Number(width)
+  const parsedHeight = Number(height)
+  return {
+    id,
+    width: Math.max(
+      definition.minWidth,
+      Math.min(1600, Number.isFinite(parsedWidth) ? Math.round(parsedWidth) : definition.defaultWidth),
+    ),
+    height: Math.max(
+      definition.minHeight,
+      Math.min(1200, Number.isFinite(parsedHeight) ? Math.round(parsedHeight) : definition.defaultHeight),
+    ),
+  }
+}
+
+function normalizePanelLayout(value: unknown): PanelLayoutItem[] {
+  const rawItems = Array.isArray(value)
+    ? value
+    : Array.isArray(asRecord(value).items)
+      ? asRecord(value).items
+      : []
+  const ordered: PanelLayoutItem[] = []
+  const seen = new Set<PanelId>()
+
+  for (const rawItem of rawItems) {
+    const item = asRecord(rawItem)
+    if (!isPanelId(item.id) || seen.has(item.id)) continue
+    ordered.push(normalizePanelSize(item.id, item.width, item.height))
+    seen.add(item.id)
+  }
+
+  for (const id of PANEL_IDS) {
+    if (!seen.has(id)) {
+      const definition = PANEL_DEFINITIONS[id]
+      ordered.push({
+        id,
+        width: definition.defaultWidth,
+        height: definition.defaultHeight,
+      })
+    }
+  }
+
+  return ordered
 }
 
 function text(value: unknown, fallback = "--") {
@@ -231,6 +339,30 @@ function shortTime(value: unknown) {
   })
 }
 
+function attemptKey(attempt: Record<string, unknown>, index: number) {
+  return [
+    text(attempt.submitted_at || attempt.created_at, "no-time"),
+    text(attempt.market_ticker, "no-market"),
+    text(attempt.order_id || attempt.client_order_id || attempt.reservation_id, String(index)),
+  ].join(":")
+}
+
+function reorderPanels(
+  layout: PanelLayoutItem[],
+  draggedId: PanelId,
+  targetId: PanelId,
+) {
+  if (draggedId === targetId) return layout
+  const dragged = layout.find((item) => item.id === draggedId)
+  if (!dragged) return layout
+  const withoutDragged = layout.filter((item) => item.id !== draggedId)
+  const targetIndex = withoutDragged.findIndex((item) => item.id === targetId)
+  if (targetIndex < 0) return layout
+  const next = [...withoutDragged]
+  next.splice(targetIndex, 0, dragged)
+  return next
+}
+
 function configFormFrom(config?: Record<string, unknown>): ConfigFormValues {
   const values = CONFIG_FIELDS.reduce((current, field) => {
     current[field.key] = text(config?.[field.key], "")
@@ -286,6 +418,14 @@ export function LiveOperations() {
   const [configErrors, setConfigErrors] = useState<ConfigErrors>({})
   const [configSaving, setConfigSaving] = useState(false)
   const [configSaveMessage, setConfigSaveMessage] = useState<string | null>(null)
+  const [expandedAttempts, setExpandedAttempts] = useState<Record<string, boolean>>({})
+  const [panelLayout, setPanelLayout] = useState<PanelLayoutItem[]>(defaultPanelLayout)
+  const [layoutLoaded, setLayoutLoaded] = useState(false)
+  const [draggingPanelId, setDraggingPanelId] = useState<PanelId | null>(null)
+  const panelElements = useRef(new Map<PanelId, HTMLDivElement>())
+  const resizeObserverRef = useRef<ResizeObserver | null>(null)
+  const layoutLoadedRef = useRef(false)
+  const layoutStorageKey = `alphadb.liveOperations.homeLayout.v${PANEL_LAYOUT_VERSION}.${selectedStrategy}`
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -320,12 +460,75 @@ export function LiveOperations() {
   const recentRuns = useMemo(() => payload?.recent_runs || [], [payload?.recent_runs])
   const attempts = useMemo(() => {
     const raw = status.recent_attempts
-    return Array.isArray(raw) ? raw.map(asRecord).slice().reverse() : []
+    return Array.isArray(raw) ? raw.map(asRecord).slice().reverse().slice(0, ACTIVITY_FEED_LIMIT) : []
   }, [status.recent_attempts])
+  const totalAttemptCount = Number(status.recent_attempt_count)
+  const activityCountLabel = Number.isFinite(totalAttemptCount) && totalAttemptCount > attempts.length
+    ? `Last ${attempts.length} of ${totalAttemptCount}`
+    : `Last ${attempts.length}`
   const recentBrtiSkips = useMemo(
     () => brtiSkipReasons(status, attempts, recentRuns.map(asRecord)),
     [attempts, recentRuns, status],
   )
+
+  useEffect(() => {
+    setLayoutLoaded(false)
+    try {
+      const saved = window.localStorage.getItem(layoutStorageKey)
+      setPanelLayout(normalizePanelLayout(saved ? JSON.parse(saved) : null))
+    } catch {
+      setPanelLayout(defaultPanelLayout())
+    }
+    setLayoutLoaded(true)
+  }, [layoutStorageKey])
+
+  useEffect(() => {
+    layoutLoadedRef.current = layoutLoaded
+  }, [layoutLoaded])
+
+  useEffect(() => {
+    if (!layoutLoaded) return
+    try {
+      window.localStorage.setItem(layoutStorageKey, JSON.stringify({ items: panelLayout }))
+    } catch {
+      // Layout persistence is a convenience; the operator view should still render.
+    }
+  }, [layoutLoaded, layoutStorageKey, panelLayout])
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver((entries) => {
+      if (!layoutLoadedRef.current) return
+      const sizes = new Map<PanelId, { width: number; height: number }>()
+      for (const entry of entries) {
+        const id = (entry.target as HTMLElement).dataset.panelId
+        if (!isPanelId(id)) continue
+        const rect = entry.contentRect
+        sizes.set(id, { width: rect.width, height: rect.height })
+      }
+      if (!sizes.size) return
+      setPanelLayout((current) => {
+        let changed = false
+        const next = current.map((item) => {
+          const size = sizes.get(item.id)
+          if (!size) return item
+          const normalized = normalizePanelSize(item.id, size.width, size.height)
+          if (Math.abs(normalized.width - item.width) < 2 && Math.abs(normalized.height - item.height) < 2) {
+            return item
+          }
+          changed = true
+          return normalized
+        })
+        return changed ? next : current
+      })
+    })
+    resizeObserverRef.current = observer
+    for (const element of panelElements.current.values()) observer.observe(element)
+    return () => {
+      observer.disconnect()
+      resizeObserverRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     if (!configDirty) {
@@ -333,44 +536,32 @@ export function LiveOperations() {
     }
   }, [config, configDirty])
 
-  const liveOrdersStatus = (() => {
-    if (typeof status.live_orders_enabled === "boolean") {
-      return status.live_orders_enabled
-        ? { value: "Enabled", tone: "good" as Tone }
-        : { value: "Disabled", tone: "warn" as Tone }
+  const registerPanelElement = useCallback((id: PanelId) => (node: HTMLDivElement | null) => {
+    const previous = panelElements.current.get(id)
+    if (previous && resizeObserverRef.current) resizeObserverRef.current.unobserve(previous)
+    if (!node) {
+      panelElements.current.delete(id)
+      return
     }
-    if (loading) return { value: "Checking", tone: "warn" as Tone }
-    return {
-      value: "Unknown",
-      tone: error ? "bad" as Tone : "muted" as Tone,
-      detail: error ? "API unavailable" : "No live status",
-    }
-  })()
-  const healthStatus = (() => {
-    if (payload?.health?.ok === true) return { value: "OK", tone: "good" as Tone }
-    if (payload?.health?.ok === false) return { value: "Error", tone: "bad" as Tone }
-    if (loading) return { value: "Checking", tone: "warn" as Tone }
-    return { value: "Unknown", tone: error ? "bad" as Tone : "warn" as Tone }
-  })()
-  const portfolioStatus = (() => {
-    const balance = payload?.portfolio_balance
-    if (!balance) {
-      return { value: "--", tone: loading ? "warn" as Tone : "bad" as Tone, detail: "Checking balance" }
-    }
-    const detail = `Cash ${optionalMoney(balance.cash_dollars)} · Assets ${optionalMoney(balance.assets_dollars)}`
-    if (balance.status === "ok") {
-      return {
-        value: optionalMoney(balance.portfolio_balance_dollars),
-        tone: balance.stale ? "warn" as Tone : "good" as Tone,
-        detail: balance.stale ? `${detail} · stale` : detail,
-      }
-    }
-    return {
-      value: "--",
-      tone: "bad" as Tone,
-      detail: balance.detail ? `Unavailable: ${balance.detail}` : "Unavailable",
-    }
-  })()
+    panelElements.current.set(id, node)
+    if (resizeObserverRef.current) resizeObserverRef.current.observe(node)
+  }, [])
+
+  const resetPanelLayout = () => {
+    setPanelLayout(defaultPanelLayout())
+    setExpandedAttempts({})
+  }
+
+  const movePanel = (draggedId: PanelId, targetId: PanelId) => {
+    setPanelLayout((current) => reorderPanels(current, draggedId, targetId))
+  }
+
+  const toggleAttempt = (key: string) => {
+    setExpandedAttempts((current) => ({
+      ...current,
+      [key]: !current[key],
+    }))
+  }
 
   const handleConfigChange = (key: ConfigFormKey, value: string) => {
     setConfigForm((current) => ({ ...current, [key]: value }))
@@ -419,6 +610,205 @@ export function LiveOperations() {
     }
   }
 
+  const panelContent: Record<PanelId, ReactNode> = {
+    market: (
+      <Metric label="Market" value={text(status.current_market_ticker, "No recent run")} detail={text(status.run_id, "")} />
+    ),
+    decision: (
+      <Metric label="Decision" value={text(status.decision_outcome)} detail={text(status.selected_side || status.skip_reason, "")} />
+    ),
+    "risk-summary": (
+      <Metric label="Risk" value={money(status.daily_loss_used_dollars)} detail={`limit ${money(status.daily_loss_limit_dollars)} · market ${money(status.market_exposure_used_dollars)} / ${money(status.market_exposure_limit_dollars)}`} />
+    ),
+    execution: (
+      <Metric label="Execution" value={text(status.latest_attempt_status || status.fill_status, "No attempt")} detail={text(status.latest_attempt_reason || status.fill_status, "")} />
+    ),
+    "activity-feed": (
+      <ActivityFeed
+        attempts={attempts}
+        countLabel={activityCountLabel}
+        expandedAttempts={expandedAttempts}
+        onToggleAttempt={toggleAttempt}
+      />
+    ),
+    "runtime-config": (
+      <Panel title="Runtime Config">
+        <form
+          className="space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void saveConfig()
+          }}
+        >
+          <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+            <TooltipLabel label="Version" tooltip={CONFIG_TOOLTIPS.version} />
+            <span className="font-mono">{text(config?.version)}</span>
+          </div>
+          <div className="space-y-1 text-sm">
+            <TooltipLabel
+              className="text-xs text-muted-foreground"
+              label="Market context source"
+              tooltip={CONFIG_TOOLTIPS.market_context_source}
+            />
+            <select
+              aria-label="Market context source"
+              className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/30"
+              name="market_context_source"
+              onChange={(event) => handleConfigChange("market_context_source", event.target.value)}
+              value={configForm.market_context_source}
+            >
+              {MARKET_CONTEXT_OPTIONS.map((option) => (
+                <option key={option.key} value={option.key}>{option.label}</option>
+              ))}
+            </select>
+            {configErrors.market_context_source && (
+              <span className="block text-xs text-destructive">{configErrors.market_context_source}</span>
+            )}
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {CONFIG_FIELDS.map((field) => (
+              <div key={field.key} className="space-y-1 text-sm">
+                <TooltipLabel
+                  className="text-xs text-muted-foreground"
+                  label={field.key === "min_contract_price" ? thresholdLabel : field.label}
+                  tooltip={CONFIG_TOOLTIPS[field.key]}
+                />
+                <input
+                  aria-label={field.key === "min_contract_price" ? thresholdLabel : field.label}
+                  className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/30"
+                  inputMode="decimal"
+                  max={field.max}
+                  min={field.min}
+                  name={field.key}
+                  onChange={(event) => handleConfigChange(field.key, event.target.value)}
+                  step={field.step}
+                  type="number"
+                  value={configForm[field.key]}
+                />
+                {configErrors[field.key] && (
+                  <span className="block text-xs text-destructive">{configErrors[field.key]}</span>
+                )}
+              </div>
+            ))}
+          </div>
+          <div className="flex min-h-7 items-center justify-between gap-3">
+            <span className={`text-xs ${configSaveMessage === "Saved" || configSaveMessage?.startsWith("Saved v") ? "text-success" : "text-muted-foreground"}`}>
+              {configSaveMessage}
+            </span>
+            <Button type="submit" size="sm" disabled={!config || configSaving}>
+              <Save className="h-4 w-4" />
+              {configSaving ? "Saving" : "Save"}
+            </Button>
+          </div>
+        </form>
+      </Panel>
+    ),
+    "market-context": (
+      <Panel title="Market Context">
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <Value
+            label="Active source"
+            tooltip={MARKET_CONTEXT_TOOLTIPS.active_source}
+            value={sourceLabel(marketContext.active_source || config?.market_context_source)}
+          />
+          <Value
+            label="Run source"
+            tooltip={MARKET_CONTEXT_TOOLTIPS.run_source}
+            value={sourceLabel(latestRunContext.market_context_source)}
+          />
+          <Value label="BRTI value" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_value} value={optionalNumber(brtiLatest.value)} />
+          <Value label="BRTI age" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_age} value={seconds(brtiLatest.age_seconds)} />
+          <Value label="BRTI health" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_health} value={text(brtiLatest.status)} />
+          <Value label="Freshness" tooltip={MARKET_CONTEXT_TOOLTIPS.freshness} value={seconds(brtiLatest.freshness_limit_seconds)} />
+          <Value label="Basis" tooltip={MARKET_CONTEXT_TOOLTIPS.basis} value={basisText(coinbaseDiagnostics.basis_dollars, coinbaseDiagnostics.basis_pct)} />
+          <Value label="Coinbase diag" tooltip={MARKET_CONTEXT_TOOLTIPS.coinbase_diag} value={text(coinbaseDiagnostics.status)} />
+        </div>
+        <div className="mt-3 border-t border-border pt-3">
+          <TooltipLabel
+            className="text-xs text-muted-foreground"
+            label="Recent BRTI skips"
+            tooltip={MARKET_CONTEXT_TOOLTIPS.recent_brti_skips}
+          />
+          <div className="mt-2 flex flex-wrap gap-2">
+            {recentBrtiSkips.length ? recentBrtiSkips.map((reason) => (
+              <span key={reason} className="rounded-md border border-border bg-background px-2 py-1 font-mono text-xs">
+                {reason}
+              </span>
+            )) : (
+              <span className="text-sm text-muted-foreground">--</span>
+            )}
+          </div>
+        </div>
+      </Panel>
+    ),
+    risk: (
+      <Panel title="Risk">
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <Value label="Daily used" tooltip={RISK_TOOLTIPS.daily_used} value={money(status.daily_loss_used_dollars)} />
+          <Value label="Daily limit" tooltip={RISK_TOOLTIPS.daily_limit} value={money(status.daily_loss_limit_dollars)} />
+          <Value label="Market used" tooltip={RISK_TOOLTIPS.market_used} value={money(status.market_exposure_used_dollars)} />
+          <Value label="Market limit" tooltip={RISK_TOOLTIPS.market_limit} value={money(status.market_exposure_limit_dollars)} />
+        </div>
+      </Panel>
+    ),
+    "recent-runs": (
+      <Panel title="Recent Runs">
+        <div className="space-y-2">
+          {recentRuns.length ? recentRuns.map((run, index) => (
+            <div key={index} className="text-sm border-t border-border first:border-0 pt-2 first:pt-0">
+              <div className="font-mono text-xs">{text(run.run_id)}</div>
+              <div className="text-muted-foreground">{text(run.decision_outcome)} · {text(run.latest_attempt_reason, "")} · {shortTime(run.generated_at)}</div>
+            </div>
+          )) : (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <ShieldAlert className="h-4 w-4" />
+              No recent runs.
+            </div>
+          )}
+        </div>
+      </Panel>
+    ),
+  }
+
+  const liveOrdersStatus = (() => {
+    if (typeof status.live_orders_enabled === "boolean") {
+      return status.live_orders_enabled
+        ? { value: "Enabled", tone: "good" as Tone }
+        : { value: "Disabled", tone: "warn" as Tone }
+    }
+    if (loading) return { value: "Checking", tone: "warn" as Tone }
+    return {
+      value: "Unknown",
+      tone: error ? "bad" as Tone : "muted" as Tone,
+      detail: error ? "API unavailable" : "No live status",
+    }
+  })()
+  const healthStatus = (() => {
+    if (payload?.health?.ok === true) return { value: "OK", tone: "good" as Tone }
+    if (payload?.health?.ok === false) return { value: "Error", tone: "bad" as Tone }
+    if (loading) return { value: "Checking", tone: "warn" as Tone }
+    return { value: "Unknown", tone: error ? "bad" as Tone : "warn" as Tone }
+  })()
+  const portfolioStatus = (() => {
+    const balance = payload?.portfolio_balance
+    if (!balance) {
+      return { value: "--", tone: loading ? "warn" as Tone : "bad" as Tone, detail: "Checking balance" }
+    }
+    const detail = `Cash ${optionalMoney(balance.cash_dollars)} · Assets ${optionalMoney(balance.assets_dollars)}`
+    if (balance.status === "ok") {
+      return {
+        value: optionalMoney(balance.portfolio_balance_dollars),
+        tone: balance.stale ? "warn" as Tone : "good" as Tone,
+        detail: balance.stale ? `${detail} · stale` : detail,
+      }
+    }
+    return {
+      value: "--",
+      tone: "bad" as Tone,
+      detail: balance.detail ? `Unavailable: ${balance.detail}` : "Unavailable",
+    }
+  })()
+
   return (
     <div className="p-6 space-y-5">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -432,6 +822,10 @@ export function LiveOperations() {
           <PortfolioStatus value={portfolioStatus.value} tone={portfolioStatus.tone} detail={portfolioStatus.detail} />
           <HeaderStatus label="Live Orders" value={liveOrdersStatus.value} tone={liveOrdersStatus.tone} detail={liveOrdersStatus.detail} />
           <HeaderStatus label="Health" value={healthStatus.value} tone={healthStatus.tone} />
+          <Button variant="outline" size="sm" onClick={resetPanelLayout} title="Reset saved panel layout">
+            <RotateCcw className="h-4 w-4" />
+            Reset layout
+          </Button>
           <Button variant="outline" size="sm" onClick={load} disabled={loading}>
             <RefreshCw className="h-4 w-4" />
             Refresh
@@ -449,208 +843,220 @@ export function LiveOperations() {
         </div>
       )}
 
-      <section className="grid gap-3 md:grid-cols-4">
-        <Metric label="Market" value={text(status.current_market_ticker, "No recent run")} detail={text(status.run_id, "")} />
-        <Metric label="Decision" value={text(status.decision_outcome)} detail={text(status.selected_side || status.skip_reason, "")} />
-        <Metric label="Risk" value={money(status.daily_loss_used_dollars)} detail={`limit ${money(status.daily_loss_limit_dollars)} · market ${money(status.market_exposure_used_dollars)} / ${money(status.market_exposure_limit_dollars)}`} />
-        <Metric label="Execution" value={text(status.latest_attempt_status || status.fill_status, "No attempt")} detail={text(status.latest_attempt_reason || status.fill_status, "")} />
+      <section className="flex flex-wrap items-start gap-3">
+        {panelLayout.map((item) => (
+          <ResizableDraggablePanel
+            draggingPanelId={draggingPanelId}
+            item={item}
+            key={item.id}
+            onDragEnd={() => setDraggingPanelId(null)}
+            onDragStart={(id) => setDraggingPanelId(id)}
+            onDropPanel={movePanel}
+            registerPanelElement={registerPanelElement}
+          >
+            {panelContent[item.id]}
+          </ResizableDraggablePanel>
+        ))}
       </section>
+    </div>
+  )
+}
 
-      <section className="grid gap-3 lg:grid-cols-[1fr_360px]">
-        <div className="border border-border rounded-lg overflow-hidden">
-          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
-            <Activity className="h-4 w-4 text-muted-foreground" />
-            <h2 className="text-sm font-medium">Recent Attempts</h2>
-          </div>
-          <div className="overflow-auto">
-            <table className="min-w-[920px] w-full text-sm">
-              <thead className="bg-muted/40 text-muted-foreground">
-                <tr>
-                  <th className="text-left px-4 py-2 font-medium">
-                    <TooltipLabel label="Time" tooltip={TABLE_TOOLTIPS.time} />
-                  </th>
-                  <th className="text-left px-4 py-2 font-medium">
-                    <TooltipLabel label="Market" tooltip={TABLE_TOOLTIPS.market} />
-                  </th>
-                  <th className="text-left px-4 py-2 font-medium">
-                    <TooltipLabel label="Status" tooltip={TABLE_TOOLTIPS.status} />
-                  </th>
-                  <th className="text-left px-4 py-2 font-medium">
-                    <TooltipLabel label="Reason" tooltip={TABLE_TOOLTIPS.reason} />
-                  </th>
-                  <th className="text-right px-4 py-2 font-medium">
-                    <TooltipLabel label="Edge" tooltip={TABLE_TOOLTIPS.edge} className="ml-auto" />
-                  </th>
-                  <th className="text-right px-4 py-2 font-medium">
-                    <TooltipLabel label="Min" tooltip={TABLE_TOOLTIPS.min} className="ml-auto" />
-                  </th>
-                  <th className="text-right px-4 py-2 font-medium">
-                    <TooltipLabel label="Gap" tooltip={TABLE_TOOLTIPS.gap} className="ml-auto" />
-                  </th>
-                  <th className="text-left px-4 py-2 font-medium">
-                    <TooltipLabel label="Fill" tooltip={TABLE_TOOLTIPS.fill} />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {attempts.length ? attempts.map((attempt, index) => {
-                  const attribution = edgeAttribution(attempt)
-                  return (
-                    <tr key={index} className="border-t border-border">
-                      <td className="px-4 py-2 text-muted-foreground">{shortTime(attempt.submitted_at || attempt.created_at)}</td>
-                      <td className="px-4 py-2 font-mono text-xs">{text(attempt.market_ticker)}</td>
-                      <td className="px-4 py-2">{text(attempt.status)}</td>
-                      <td className="px-4 py-2 text-muted-foreground">{text(attempt.reason || attempt.guard_reason, "")}</td>
-                      <td className="px-4 py-2 text-right font-mono text-xs">{optionalPercent(attribution.edge)}</td>
-                      <td className="px-4 py-2 text-right font-mono text-xs">{optionalPercent(attribution.min_edge)}</td>
-                      <td className="px-4 py-2 text-right font-mono text-xs">{edgeGapText(attribution)}</td>
-                      <td className="px-4 py-2">{text(attempt.fill_status, "")}</td>
-                    </tr>
-                  )
-                }) : (
-                  <tr>
-                    <td colSpan={8} className="px-4 py-8 text-center text-muted-foreground">
-                      No live attempts recorded.
+function ResizableDraggablePanel({
+  children,
+  draggingPanelId,
+  item,
+  onDragEnd,
+  onDragStart,
+  onDropPanel,
+  registerPanelElement,
+}: {
+  children: ReactNode
+  draggingPanelId: PanelId | null
+  item: PanelLayoutItem
+  onDragEnd: () => void
+  onDragStart: (id: PanelId) => void
+  onDropPanel: (draggedId: PanelId, targetId: PanelId) => void
+  registerPanelElement: (id: PanelId) => (node: HTMLDivElement | null) => void
+}) {
+  const definition = PANEL_DEFINITIONS[item.id]
+  const dragging = draggingPanelId === item.id
+  return (
+    <div
+      className={`relative rounded-lg ${dragging ? "opacity-70" : ""}`}
+      data-panel-id={item.id}
+      onDragOver={(event) => {
+        if (!draggingPanelId || draggingPanelId === item.id) return
+        event.preventDefault()
+        event.dataTransfer.dropEffect = "move"
+      }}
+      onDrop={(event) => {
+        event.preventDefault()
+        const draggedId = event.dataTransfer.getData("text/plain")
+        if (isPanelId(draggedId)) onDropPanel(draggedId, item.id)
+      }}
+      ref={registerPanelElement(item.id)}
+      style={{
+        flex: "0 0 auto",
+        height: item.height,
+        maxWidth: "100%",
+        minHeight: definition.minHeight,
+        minWidth: `min(${definition.minWidth}px, 100%)`,
+        overflow: "hidden",
+        resize: "both",
+        width: item.width,
+      }}
+    >
+      <button
+        aria-label={`Move ${definition.label} panel`}
+        className="absolute right-2 top-2 z-10 inline-flex size-6 cursor-grab items-center justify-center rounded-md border border-border bg-background/90 text-muted-foreground shadow-sm transition hover:text-foreground active:cursor-grabbing"
+        draggable
+        onDragEnd={onDragEnd}
+        onDragStart={(event) => {
+          event.dataTransfer.effectAllowed = "move"
+          event.dataTransfer.setData("text/plain", item.id)
+          onDragStart(item.id)
+        }}
+        title={`Drag ${definition.label}`}
+        type="button"
+      >
+        <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      <div className="h-full min-h-0">{children}</div>
+    </div>
+  )
+}
+
+function ActivityFeed({
+  attempts,
+  countLabel,
+  expandedAttempts,
+  onToggleAttempt,
+}: {
+  attempts: Array<Record<string, unknown>>
+  countLabel: string
+  expandedAttempts: Record<string, boolean>
+  onToggleAttempt: (key: string) => void
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3 pr-10">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-medium">Activity Feed</h2>
+        </div>
+        <span className="rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground">
+          {countLabel}
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="min-w-[980px] w-full text-sm">
+          <thead className="sticky top-0 z-[1] bg-muted text-muted-foreground">
+            <tr>
+              <th className="w-10 px-3 py-2 font-medium">
+                <TooltipLabel label="Details" tooltip={TABLE_TOOLTIPS.details} />
+              </th>
+              <th className="text-left px-4 py-2 font-medium">
+                <TooltipLabel label="Time" tooltip={TABLE_TOOLTIPS.time} />
+              </th>
+              <th className="text-left px-4 py-2 font-medium">
+                <TooltipLabel label="Market" tooltip={TABLE_TOOLTIPS.market} />
+              </th>
+              <th className="text-left px-4 py-2 font-medium">
+                <TooltipLabel label="Status" tooltip={TABLE_TOOLTIPS.status} />
+              </th>
+              <th className="text-left px-4 py-2 font-medium">
+                <TooltipLabel label="Reason" tooltip={TABLE_TOOLTIPS.reason} />
+              </th>
+              <th className="text-right px-4 py-2 font-medium">
+                <TooltipLabel label="Edge" tooltip={TABLE_TOOLTIPS.edge} className="ml-auto" />
+              </th>
+              <th className="text-right px-4 py-2 font-medium">
+                <TooltipLabel label="Min" tooltip={TABLE_TOOLTIPS.min} className="ml-auto" />
+              </th>
+              <th className="text-right px-4 py-2 font-medium">
+                <TooltipLabel label="Gap" tooltip={TABLE_TOOLTIPS.gap} className="ml-auto" />
+              </th>
+              <th className="text-left px-4 py-2 font-medium">
+                <TooltipLabel label="Fill" tooltip={TABLE_TOOLTIPS.fill} />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {attempts.length ? attempts.map((attempt, index) => {
+              const key = attemptKey(attempt, index)
+              const attribution = edgeAttribution(attempt)
+              const expanded = Boolean(expandedAttempts[key])
+              return (
+                <Fragment key={key}>
+                  <tr key={key} className="border-t border-border">
+                    <td className="px-3 py-2 align-top">
+                      <Button
+                        aria-expanded={expanded}
+                        aria-label={`${expanded ? "Collapse" : "Expand"} attempt details`}
+                        onClick={() => onToggleAttempt(key)}
+                        size="icon-xs"
+                        title={`${expanded ? "Collapse" : "Expand"} attempt details`}
+                        type="button"
+                        variant="ghost"
+                      >
+                        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                      </Button>
                     </td>
+                    <td className="px-4 py-2 text-muted-foreground">{shortTime(attempt.submitted_at || attempt.created_at)}</td>
+                    <td className="px-4 py-2 font-mono text-xs">{text(attempt.market_ticker)}</td>
+                    <td className="px-4 py-2">{text(attempt.status)}</td>
+                    <td className="px-4 py-2 text-muted-foreground">{text(attempt.reason || attempt.guard_reason, "")}</td>
+                    <td className="px-4 py-2 text-right font-mono text-xs">{optionalPercent(attribution.edge)}</td>
+                    <td className="px-4 py-2 text-right font-mono text-xs">{optionalPercent(attribution.min_edge)}</td>
+                    <td className="px-4 py-2 text-right font-mono text-xs">{edgeGapText(attribution)}</td>
+                    <td className="px-4 py-2">{text(attempt.fill_status, "")}</td>
                   </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
+                  {expanded && (
+                    <tr key={`${key}:details`} className="border-t border-border bg-background/60">
+                      <td colSpan={9} className="px-4 py-3">
+                        <AttemptDetails attempt={attempt} />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              )
+            }) : (
+              <tr>
+                <td colSpan={9} className="px-4 py-8 text-center text-muted-foreground">
+                  No live attempts recorded.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
 
-        <div className="space-y-3">
-          <Panel title="Runtime Config">
-            <form
-              className="space-y-3"
-              onSubmit={(event) => {
-                event.preventDefault()
-                void saveConfig()
-              }}
-            >
-              <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                <TooltipLabel label="Version" tooltip={CONFIG_TOOLTIPS.version} />
-                <span className="font-mono">{text(config?.version)}</span>
-              </div>
-              <div className="space-y-1 text-sm">
-                <TooltipLabel
-                  className="text-xs text-muted-foreground"
-                  label="Market context source"
-                  tooltip={CONFIG_TOOLTIPS.market_context_source}
-                />
-                <select
-                  aria-label="Market context source"
-                  className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/30"
-                  name="market_context_source"
-                  onChange={(event) => handleConfigChange("market_context_source", event.target.value)}
-                  value={configForm.market_context_source}
-                >
-                  {MARKET_CONTEXT_OPTIONS.map((option) => (
-                    <option key={option.key} value={option.key}>{option.label}</option>
-                  ))}
-                </select>
-                {configErrors.market_context_source && (
-                  <span className="block text-xs text-destructive">{configErrors.market_context_source}</span>
-                )}
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                {CONFIG_FIELDS.map((field) => (
-                  <div key={field.key} className="space-y-1 text-sm">
-                    <TooltipLabel
-                      className="text-xs text-muted-foreground"
-                      label={field.key === "min_contract_price" ? thresholdLabel : field.label}
-                      tooltip={CONFIG_TOOLTIPS[field.key]}
-                    />
-                    <input
-                      aria-label={field.key === "min_contract_price" ? thresholdLabel : field.label}
-                      className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/30"
-                      inputMode="decimal"
-                      max={field.max}
-                      min={field.min}
-                      name={field.key}
-                      onChange={(event) => handleConfigChange(field.key, event.target.value)}
-                      step={field.step}
-                      type="number"
-                      value={configForm[field.key]}
-                    />
-                    {configErrors[field.key] && (
-                      <span className="block text-xs text-destructive">{configErrors[field.key]}</span>
-                    )}
-                  </div>
-                ))}
-              </div>
-              <div className="flex min-h-7 items-center justify-between gap-3">
-                <span className={`text-xs ${configSaveMessage === "Saved" || configSaveMessage?.startsWith("Saved v") ? "text-success" : "text-muted-foreground"}`}>
-                  {configSaveMessage}
-                </span>
-                <Button type="submit" size="sm" disabled={!config || configSaving}>
-                  <Save className="h-4 w-4" />
-                  {configSaving ? "Saving" : "Save"}
-                </Button>
-              </div>
-            </form>
-          </Panel>
-          <Panel title="Market Context">
-            <div className="grid grid-cols-2 gap-3 text-sm">
-              <Value
-                label="Active source"
-                tooltip={MARKET_CONTEXT_TOOLTIPS.active_source}
-                value={sourceLabel(marketContext.active_source || config?.market_context_source)}
-              />
-              <Value
-                label="Run source"
-                tooltip={MARKET_CONTEXT_TOOLTIPS.run_source}
-                value={sourceLabel(latestRunContext.market_context_source)}
-              />
-              <Value label="BRTI value" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_value} value={optionalNumber(brtiLatest.value)} />
-              <Value label="BRTI age" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_age} value={seconds(brtiLatest.age_seconds)} />
-              <Value label="BRTI health" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_health} value={text(brtiLatest.status)} />
-              <Value label="Freshness" tooltip={MARKET_CONTEXT_TOOLTIPS.freshness} value={seconds(brtiLatest.freshness_limit_seconds)} />
-              <Value label="Basis" tooltip={MARKET_CONTEXT_TOOLTIPS.basis} value={basisText(coinbaseDiagnostics.basis_dollars, coinbaseDiagnostics.basis_pct)} />
-              <Value label="Coinbase diag" tooltip={MARKET_CONTEXT_TOOLTIPS.coinbase_diag} value={text(coinbaseDiagnostics.status)} />
-            </div>
-            <div className="mt-3 border-t border-border pt-3">
-              <TooltipLabel
-                className="text-xs text-muted-foreground"
-                label="Recent BRTI skips"
-                tooltip={MARKET_CONTEXT_TOOLTIPS.recent_brti_skips}
-              />
-              <div className="mt-2 flex flex-wrap gap-2">
-                {recentBrtiSkips.length ? recentBrtiSkips.map((reason) => (
-                  <span key={reason} className="rounded-md border border-border bg-background px-2 py-1 font-mono text-xs">
-                    {reason}
-                  </span>
-                )) : (
-                  <span className="text-sm text-muted-foreground">--</span>
-                )}
-              </div>
-            </div>
-          </Panel>
-          <Panel title="Risk">
-            <div className="grid grid-cols-2 gap-3 text-sm">
-              <Value label="Daily used" tooltip={RISK_TOOLTIPS.daily_used} value={money(status.daily_loss_used_dollars)} />
-              <Value label="Daily limit" tooltip={RISK_TOOLTIPS.daily_limit} value={money(status.daily_loss_limit_dollars)} />
-              <Value label="Market used" tooltip={RISK_TOOLTIPS.market_used} value={money(status.market_exposure_used_dollars)} />
-              <Value label="Market limit" tooltip={RISK_TOOLTIPS.market_limit} value={money(status.market_exposure_limit_dollars)} />
-            </div>
-          </Panel>
-          <Panel title="Recent Runs">
-            <div className="space-y-2">
-              {recentRuns.length ? recentRuns.map((run, index) => (
-                <div key={index} className="text-sm border-t border-border first:border-0 pt-2 first:pt-0">
-                  <div className="font-mono text-xs">{text(run.run_id)}</div>
-                  <div className="text-muted-foreground">{text(run.decision_outcome)} · {text(run.latest_attempt_reason, "")} · {shortTime(run.generated_at)}</div>
-                </div>
-              )) : (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <ShieldAlert className="h-4 w-4" />
-                  No recent runs.
-                </div>
-              )}
-            </div>
-          </Panel>
-        </div>
-      </section>
+function AttemptDetails({ attempt }: { attempt: Record<string, unknown> }) {
+  const riskAdmission = asRecord(attempt.risk_admission)
+  const configVersion = text(attempt.config_version, "")
+  return (
+    <div className="grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
+      <ActivityDetail label="Side" value={text(attempt.side)} />
+      <ActivityDetail label="Order ID" value={text(attempt.order_id || attempt.client_order_id)} />
+      <ActivityDetail label="Contracts" value={text(attempt.sized_contracts || attempt.intended_contracts)} />
+      <ActivityDetail label="Ask" value={optionalPercent(attempt.observed_yes_ask)} />
+      <ActivityDetail label="Threshold" value={optionalPercent(attempt.yes_ask_threshold)} />
+      <ActivityDetail label="Max loss" value={optionalMoney(attempt.max_loss_dollars)} />
+      <ActivityDetail label="Risk admission" value={text(riskAdmission.status || riskAdmission.reason)} />
+      <ActivityDetail label="Config" value={configVersion ? `v${configVersion}` : text(attempt.config_id)} />
+    </div>
+  )
+}
+
+function ActivityDetail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md border border-border bg-card px-2 py-1.5">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="mt-1 truncate font-mono text-foreground">{value}</div>
     </div>
   )
 }
@@ -685,7 +1091,7 @@ function HeaderStatus({ label, value, detail, tone }: { label: string; value: st
 function Metric({ label, value, detail, tone = "muted" }: { label: string; value: string; detail?: string; tone?: Tone }) {
   const toneClass = toneTextClass(tone)
   return (
-    <div className="border border-border rounded-lg bg-card p-4 min-h-24">
+    <div className="h-full min-h-24 overflow-hidden rounded-lg border border-border bg-card p-4">
       <div className="text-xs text-muted-foreground">{label}</div>
       <div className={`mt-2 text-xl font-semibold ${toneClass}`}>{value}</div>
       {detail && <div className="mt-1 text-xs text-muted-foreground truncate">{detail}</div>}
@@ -709,9 +1115,11 @@ function toneDotClass(tone: Tone) {
 
 function Panel({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <div className="border border-border rounded-lg bg-card p-4">
-      <h2 className="text-sm font-medium mb-3">{title}</h2>
-      {children}
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card p-4">
+      <h2 className="mb-3 shrink-0 text-sm font-medium">{title}</h2>
+      <div className="min-h-0 flex-1 overflow-auto pr-2">
+        {children}
+      </div>
     </div>
   )
 }

--- a/apps/dashboard/components/live/live-operations.tsx
+++ b/apps/dashboard/components/live/live-operations.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react"
 import { apiGet, apiPost } from "@/lib/alphadb-api"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -363,6 +363,12 @@ function reorderPanels(
   return next
 }
 
+function isInteractiveDragTarget(target: EventTarget | null) {
+  return target instanceof Element
+    ? Boolean(target.closest("button,input,select,textarea,a,[role='button'],[data-no-panel-drag='true']"))
+    : false
+}
+
 function configFormFrom(config?: Record<string, unknown>): ConfigFormValues {
   const values = CONFIG_FIELDS.reduce((current, field) => {
     current[field.key] = text(config?.[field.key], "")
@@ -425,6 +431,7 @@ export function LiveOperations() {
   const panelElements = useRef(new Map<PanelId, HTMLDivElement>())
   const resizeObserverRef = useRef<ResizeObserver | null>(null)
   const layoutLoadedRef = useRef(false)
+  const dragCleanupRef = useRef<(() => void) | null>(null)
   const layoutStorageKey = `alphadb.liveOperations.homeLayout.v${PANEL_LAYOUT_VERSION}.${selectedStrategy}`
 
   const load = useCallback(async () => {
@@ -485,6 +492,10 @@ export function LiveOperations() {
   useEffect(() => {
     layoutLoadedRef.current = layoutLoaded
   }, [layoutLoaded])
+
+  useEffect(() => () => {
+    dragCleanupRef.current?.()
+  }, [])
 
   useEffect(() => {
     if (!layoutLoaded) return
@@ -552,8 +563,44 @@ export function LiveOperations() {
     setExpandedAttempts({})
   }
 
-  const movePanel = (draggedId: PanelId, targetId: PanelId) => {
-    setPanelLayout((current) => reorderPanels(current, draggedId, targetId))
+  const beginPanelDrag = (event: ReactMouseEvent<HTMLElement>, id: PanelId) => {
+    if (event.button !== 0) return
+    const rect = event.currentTarget.getBoundingClientRect()
+    const explicitHandle = event.currentTarget instanceof HTMLElement && event.currentTarget.dataset.panelDragHandle
+    const inResizeCorner = !explicitHandle && event.clientX >= rect.right - 28 && event.clientY >= rect.bottom - 28
+    if (inResizeCorner) return
+    event.preventDefault()
+    event.stopPropagation()
+    dragCleanupRef.current?.()
+    setDraggingPanelId(id)
+
+    const originalCursor = document.body.style.cursor
+    const originalUserSelect = document.body.style.userSelect
+    document.body.style.cursor = "grabbing"
+    document.body.style.userSelect = "none"
+
+    const handleMouseMove = (mouseEvent: MouseEvent) => {
+      const target = document
+        .elementFromPoint(mouseEvent.clientX, mouseEvent.clientY)
+        ?.closest("[data-panel-id]")
+      const targetId = target?.getAttribute("data-panel-id")
+      if (isPanelId(targetId)) {
+        setPanelLayout((current) => reorderPanels(current, id, targetId))
+      }
+    }
+
+    const cleanup = () => {
+      window.removeEventListener("mousemove", handleMouseMove)
+      window.removeEventListener("mouseup", cleanup)
+      document.body.style.cursor = originalCursor
+      document.body.style.userSelect = originalUserSelect
+      dragCleanupRef.current = null
+      setDraggingPanelId(null)
+    }
+
+    dragCleanupRef.current = cleanup
+    window.addEventListener("mousemove", handleMouseMove)
+    window.addEventListener("mouseup", cleanup, { once: true })
   }
 
   const toggleAttempt = (key: string) => {
@@ -849,9 +896,7 @@ export function LiveOperations() {
             draggingPanelId={draggingPanelId}
             item={item}
             key={item.id}
-            onDragEnd={() => setDraggingPanelId(null)}
-            onDragStart={(id) => setDraggingPanelId(id)}
-            onDropPanel={movePanel}
+            onDragStart={beginPanelDrag}
             registerPanelElement={registerPanelElement}
           >
             {panelContent[item.id]}
@@ -866,34 +911,24 @@ function ResizableDraggablePanel({
   children,
   draggingPanelId,
   item,
-  onDragEnd,
   onDragStart,
-  onDropPanel,
   registerPanelElement,
 }: {
   children: ReactNode
   draggingPanelId: PanelId | null
   item: PanelLayoutItem
-  onDragEnd: () => void
-  onDragStart: (id: PanelId) => void
-  onDropPanel: (draggedId: PanelId, targetId: PanelId) => void
+  onDragStart: (event: ReactMouseEvent<HTMLElement>, id: PanelId) => void
   registerPanelElement: (id: PanelId) => (node: HTMLDivElement | null) => void
 }) {
   const definition = PANEL_DEFINITIONS[item.id]
   const dragging = draggingPanelId === item.id
   return (
     <div
-      className={`relative rounded-lg ${dragging ? "opacity-70" : ""}`}
+      className={`relative cursor-grab rounded-lg transition active:cursor-grabbing ${dragging ? "scale-[0.99] opacity-70 ring-2 ring-ring/50" : ""}`}
       data-panel-id={item.id}
-      onDragOver={(event) => {
-        if (!draggingPanelId || draggingPanelId === item.id) return
-        event.preventDefault()
-        event.dataTransfer.dropEffect = "move"
-      }}
-      onDrop={(event) => {
-        event.preventDefault()
-        const draggedId = event.dataTransfer.getData("text/plain")
-        if (isPanelId(draggedId)) onDropPanel(draggedId, item.id)
+      onMouseDown={(event) => {
+        if (isInteractiveDragTarget(event.target)) return
+        onDragStart(event, item.id)
       }}
       ref={registerPanelElement(item.id)}
       style={{
@@ -909,18 +944,13 @@ function ResizableDraggablePanel({
     >
       <button
         aria-label={`Move ${definition.label} panel`}
-        className="absolute right-2 top-2 z-10 inline-flex size-6 cursor-grab items-center justify-center rounded-md border border-border bg-background/90 text-muted-foreground shadow-sm transition hover:text-foreground active:cursor-grabbing"
-        draggable
-        onDragEnd={onDragEnd}
-        onDragStart={(event) => {
-          event.dataTransfer.effectAllowed = "move"
-          event.dataTransfer.setData("text/plain", item.id)
-          onDragStart(item.id)
-        }}
+        className="absolute right-2 top-2 z-10 inline-flex size-8 touch-none cursor-grab items-center justify-center rounded-md border border-border bg-background/95 text-muted-foreground shadow-sm transition hover:border-ring/60 hover:text-foreground active:cursor-grabbing"
+        data-panel-drag-handle={item.id}
+        onMouseDown={(event) => onDragStart(event, item.id)}
         title={`Drag ${definition.label}`}
         type="button"
       >
-        <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
+        <GripVertical className="h-4 w-4" aria-hidden="true" />
       </button>
       <div className="h-full min-h-0">{children}</div>
     </div>

--- a/apps/dashboard/components/live/live-operations.tsx
+++ b/apps/dashboard/components/live/live-operations.tsx
@@ -5,7 +5,7 @@ import { apiGet, apiPost } from "@/lib/alphadb-api"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useSelectedStrategy } from "@/components/strategy/strategy-context"
-import { Activity, ChevronDown, ChevronRight, CircleHelp, GripVertical, RefreshCw, RotateCcw, Save, ShieldAlert, Square } from "lucide-react"
+import { Activity, ChevronDown, ChevronRight, CircleHelp, Eye, EyeOff, GripVertical, RefreshCw, RotateCcw, Save, ShieldAlert, Square } from "lucide-react"
 
 interface LivePayload {
   strategy?: string
@@ -225,6 +225,21 @@ function normalizePanelLayout(value: unknown): PanelLayoutItem[] {
   return ordered
 }
 
+function normalizeHiddenPanels(value: unknown): PanelId[] {
+  const rawHidden = asRecord(value).hidden
+  if (!Array.isArray(rawHidden)) return []
+  const hidden: PanelId[] = []
+  const seen = new Set<PanelId>()
+
+  for (const id of rawHidden) {
+    if (!isPanelId(id) || seen.has(id)) continue
+    hidden.push(id)
+    seen.add(id)
+  }
+
+  return hidden
+}
+
 function text(value: unknown, fallback = "--") {
   if (value === null || value === undefined || value === "") return fallback
   return String(value)
@@ -426,7 +441,9 @@ export function LiveOperations() {
   const [configSaveMessage, setConfigSaveMessage] = useState<string | null>(null)
   const [expandedAttempts, setExpandedAttempts] = useState<Record<string, boolean>>({})
   const [panelLayout, setPanelLayout] = useState<PanelLayoutItem[]>(defaultPanelLayout)
+  const [hiddenPanelIds, setHiddenPanelIds] = useState<PanelId[]>([])
   const [layoutLoaded, setLayoutLoaded] = useState(false)
+  const [panelMenuOpen, setPanelMenuOpen] = useState(false)
   const [draggingPanelId, setDraggingPanelId] = useState<PanelId | null>(null)
   const panelElements = useRef(new Map<PanelId, HTMLDivElement>())
   const resizeObserverRef = useRef<ResizeObserver | null>(null)
@@ -477,15 +494,24 @@ export function LiveOperations() {
     () => brtiSkipReasons(status, attempts, recentRuns.map(asRecord)),
     [attempts, recentRuns, status],
   )
+  const hiddenPanelSet = useMemo(() => new Set(hiddenPanelIds), [hiddenPanelIds])
+  const visiblePanelLayout = useMemo(
+    () => panelLayout.filter((item) => !hiddenPanelSet.has(item.id)),
+    [hiddenPanelSet, panelLayout],
+  )
 
   useEffect(() => {
     setLayoutLoaded(false)
     try {
       const saved = window.localStorage.getItem(layoutStorageKey)
-      setPanelLayout(normalizePanelLayout(saved ? JSON.parse(saved) : null))
+      const savedState = saved ? JSON.parse(saved) : null
+      setPanelLayout(normalizePanelLayout(savedState))
+      setHiddenPanelIds(normalizeHiddenPanels(savedState))
     } catch {
       setPanelLayout(defaultPanelLayout())
+      setHiddenPanelIds([])
     }
+    setPanelMenuOpen(false)
     setLayoutLoaded(true)
   }, [layoutStorageKey])
 
@@ -500,11 +526,11 @@ export function LiveOperations() {
   useEffect(() => {
     if (!layoutLoaded) return
     try {
-      window.localStorage.setItem(layoutStorageKey, JSON.stringify({ items: panelLayout }))
+      window.localStorage.setItem(layoutStorageKey, JSON.stringify({ items: panelLayout, hidden: hiddenPanelIds }))
     } catch {
       // Layout persistence is a convenience; the operator view should still render.
     }
-  }, [layoutLoaded, layoutStorageKey, panelLayout])
+  }, [hiddenPanelIds, layoutLoaded, layoutStorageKey, panelLayout])
 
   useEffect(() => {
     if (typeof ResizeObserver === "undefined") return
@@ -560,7 +586,20 @@ export function LiveOperations() {
 
   const resetPanelLayout = () => {
     setPanelLayout(defaultPanelLayout())
+    setHiddenPanelIds([])
     setExpandedAttempts({})
+    setPanelMenuOpen(false)
+  }
+
+  const hidePanel = (id: PanelId) => {
+    setHiddenPanelIds((current) => current.includes(id) ? current : [...current, id])
+  }
+
+  const togglePanelVisibility = (id: PanelId) => {
+    setHiddenPanelIds((current) => current.includes(id)
+      ? current.filter((hiddenId) => hiddenId !== id)
+      : [...current, id]
+    )
   }
 
   const beginPanelDrag = (event: ReactMouseEvent<HTMLElement>, id: PanelId) => {
@@ -869,6 +908,12 @@ export function LiveOperations() {
           <PortfolioStatus value={portfolioStatus.value} tone={portfolioStatus.tone} detail={portfolioStatus.detail} />
           <HeaderStatus label="Live Orders" value={liveOrdersStatus.value} tone={liveOrdersStatus.tone} detail={liveOrdersStatus.detail} />
           <HeaderStatus label="Health" value={healthStatus.value} tone={healthStatus.tone} />
+          <PanelVisibilityMenu
+            hiddenPanelIds={hiddenPanelIds}
+            onOpenChange={setPanelMenuOpen}
+            onTogglePanel={togglePanelVisibility}
+            open={panelMenuOpen}
+          />
           <Button variant="outline" size="sm" onClick={resetPanelLayout} title="Reset saved panel layout">
             <RotateCcw className="h-4 w-4" />
             Reset layout
@@ -891,18 +936,78 @@ export function LiveOperations() {
       )}
 
       <section className="flex flex-wrap items-start gap-3">
-        {panelLayout.map((item) => (
+        {visiblePanelLayout.length ? visiblePanelLayout.map((item) => (
           <ResizableDraggablePanel
             draggingPanelId={draggingPanelId}
             item={item}
             key={item.id}
             onDragStart={beginPanelDrag}
+            onHidePanel={hidePanel}
             registerPanelElement={registerPanelElement}
           >
             {panelContent[item.id]}
           </ResizableDraggablePanel>
-        ))}
+        )) : (
+          <div className="w-full rounded-lg border border-dashed border-border bg-card p-6 text-sm text-muted-foreground">
+            All panels are hidden. Use Panels to restore the view.
+          </div>
+        )}
       </section>
+    </div>
+  )
+}
+
+function PanelVisibilityMenu({
+  hiddenPanelIds,
+  onOpenChange,
+  onTogglePanel,
+  open,
+}: {
+  hiddenPanelIds: PanelId[]
+  onOpenChange: (open: boolean) => void
+  onTogglePanel: (id: PanelId) => void
+  open: boolean
+}) {
+  const hiddenSet = new Set(hiddenPanelIds)
+  const visibleCount = PANEL_IDS.length - hiddenPanelIds.length
+  return (
+    <div className="relative" data-no-panel-drag="true">
+      <Button
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => onOpenChange(!open)}
+        size="sm"
+        title="Show or hide home panels"
+        type="button"
+        variant="outline"
+      >
+        <Eye className="h-4 w-4" />
+        Panels
+        <span className="font-mono text-xs text-muted-foreground">{visibleCount}/{PANEL_IDS.length}</span>
+      </Button>
+      {open && (
+        <div className="absolute right-0 top-8 z-30 w-64 overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-xl">
+          <div className="border-b border-border px-3 py-2 text-xs font-medium text-muted-foreground">
+            Home panels
+          </div>
+          <div className="max-h-80 overflow-auto p-1">
+            {PANEL_IDS.map((id) => (
+              <label
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted"
+                key={id}
+              >
+                <input
+                  checked={!hiddenSet.has(id)}
+                  className="size-4 accent-foreground"
+                  onChange={() => onTogglePanel(id)}
+                  type="checkbox"
+                />
+                <span>{PANEL_DEFINITIONS[id].label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -912,12 +1017,14 @@ function ResizableDraggablePanel({
   draggingPanelId,
   item,
   onDragStart,
+  onHidePanel,
   registerPanelElement,
 }: {
   children: ReactNode
   draggingPanelId: PanelId | null
   item: PanelLayoutItem
   onDragStart: (event: ReactMouseEvent<HTMLElement>, id: PanelId) => void
+  onHidePanel: (id: PanelId) => void
   registerPanelElement: (id: PanelId) => (node: HTMLDivElement | null) => void
 }) {
   const definition = PANEL_DEFINITIONS[item.id]
@@ -944,13 +1051,23 @@ function ResizableDraggablePanel({
     >
       <button
         aria-label={`Move ${definition.label} panel`}
-        className="absolute right-2 top-2 z-10 inline-flex size-8 touch-none cursor-grab items-center justify-center rounded-md border border-border bg-background/95 text-muted-foreground shadow-sm transition hover:border-ring/60 hover:text-foreground active:cursor-grabbing"
+        className="absolute right-11 top-2 z-10 inline-flex size-8 touch-none cursor-grab items-center justify-center rounded-md border border-border bg-background/95 text-muted-foreground shadow-sm transition hover:border-ring/60 hover:text-foreground active:cursor-grabbing"
         data-panel-drag-handle={item.id}
         onMouseDown={(event) => onDragStart(event, item.id)}
         title={`Drag ${definition.label}`}
         type="button"
       >
         <GripVertical className="h-4 w-4" aria-hidden="true" />
+      </button>
+      <button
+        aria-label={`Hide ${definition.label} panel`}
+        className="absolute right-2 top-2 z-10 inline-flex size-8 items-center justify-center rounded-md border border-border bg-background/95 text-muted-foreground shadow-sm transition hover:border-ring/60 hover:text-foreground"
+        data-no-panel-drag="true"
+        onClick={() => onHidePanel(item.id)}
+        title={`Hide ${definition.label}`}
+        type="button"
+      >
+        <EyeOff className="h-4 w-4" aria-hidden="true" />
       </button>
       <div className="h-full min-h-0">{children}</div>
     </div>
@@ -970,7 +1087,7 @@ function ActivityFeed({
 }) {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card">
-      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3 pr-10">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3 pr-20">
         <div className="flex items-center gap-2">
           <Activity className="h-4 w-4 text-muted-foreground" />
           <h2 className="text-sm font-medium">Activity Feed</h2>
@@ -1146,7 +1263,7 @@ function toneDotClass(tone: Tone) {
 function Panel({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card p-4">
-      <h2 className="mb-3 shrink-0 text-sm font-medium">{title}</h2>
+      <h2 className="mb-3 shrink-0 pr-20 text-sm font-medium">{title}</h2>
       <div className="min-h-0 flex-1 overflow-auto pr-2">
         {children}
       </div>

--- a/apps/dashboard/components/live/live-operations.tsx
+++ b/apps/dashboard/components/live/live-operations.tsx
@@ -3,8 +3,9 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
 import { apiGet, apiPost } from "@/lib/alphadb-api"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useSelectedStrategy } from "@/components/strategy/strategy-context"
-import { Activity, RefreshCw, Save, ShieldAlert, Square } from "lucide-react"
+import { Activity, CircleHelp, RefreshCw, Save, ShieldAlert, Square } from "lucide-react"
 
 interface LivePayload {
   strategy?: string
@@ -61,6 +62,47 @@ const MARKET_CONTEXT_OPTIONS = [
   { key: "brti_primary", label: "BRTI primary" },
   { key: "fixture", label: "Fixture" },
 ] as const
+
+const TABLE_TOOLTIPS = {
+  time: "When this order attempt was created or submitted.",
+  market: "Kalshi market ticker for the attempted live decision.",
+  status: "Recorded attempt status, such as submitted, skipped, or failed.",
+  reason: "Primary skip or guard reason recorded by the live worker.",
+  edge: "After-fee edge in contract-price percentage points. Positive means fair value is above executable price plus fees.",
+  min: "Minimum required after-fee edge from runtime config. 0.00% means require break-even or better.",
+  gap: "How far the calculated edge is above or below the configured minimum edge.",
+  fill: "Exchange submission or fill lifecycle status for the attempt.",
+} as const
+
+const CONFIG_TOOLTIPS = {
+  version: "Runtime config version currently active for this strategy.",
+  market_context_source: "External price/context source the next fair_value_live run should use.",
+  max_order_dollars: "Maximum dollars the live worker may reserve for a single order.",
+  max_market_exposure_dollars: "Maximum allowed exposure in one market before new orders are skipped.",
+  max_daily_loss_dollars: "Live risk day loss cap. Skips once used amount reaches this limit.",
+  min_edge: "Minimum after-fee edge required before submitting an order. 0.02 means 2 percentage points.",
+  min_contract_price: "Lowest executable contract price this strategy is allowed to trade.",
+  max_markets: "Maximum number of markets this strategy may act on in one live sweep.",
+} as const
+
+const MARKET_CONTEXT_TOOLTIPS = {
+  active_source: "Source currently selected in runtime config. Future runs should use this value.",
+  run_source: "Source the latest displayed live run actually used. It may lag the active source until another run completes.",
+  brti_value: "Latest BRTI index value available to the runtime.",
+  brti_age: "How old the latest BRTI context is when this status was generated.",
+  brti_health: "Whether the latest BRTI context is usable for live decisions.",
+  freshness: "Maximum BRTI age allowed before fair_value_live fails closed with a stale-context skip.",
+  basis: "BRTI minus Coinbase reference price, shown in dollars and as a percent of Coinbase.",
+  coinbase_diag: "Whether Coinbase reference data is available for diagnostics and basis comparison.",
+  recent_brti_skips: "Recent skip reasons caused by missing, stale, or invalid BRTI context.",
+} as const
+
+const RISK_TOOLTIPS = {
+  daily_used: "Live risk day loss budget already consumed or reserved by this strategy.",
+  daily_limit: "Configured max daily loss cap for this strategy.",
+  market_used: "Current exposure already used or reserved in this market.",
+  market_limit: "Configured per-market exposure cap for this strategy.",
+} as const
 
 type ConfigFieldKey = (typeof CONFIG_FIELDS)[number]["key"]
 type ConfigFormKey = ConfigFieldKey | "market_context_source"
@@ -424,14 +466,30 @@ export function LiveOperations() {
             <table className="min-w-[920px] w-full text-sm">
               <thead className="bg-muted/40 text-muted-foreground">
                 <tr>
-                  <th className="text-left px-4 py-2 font-medium">Time</th>
-                  <th className="text-left px-4 py-2 font-medium">Market</th>
-                  <th className="text-left px-4 py-2 font-medium">Status</th>
-                  <th className="text-left px-4 py-2 font-medium">Reason</th>
-                  <th className="text-right px-4 py-2 font-medium">Edge</th>
-                  <th className="text-right px-4 py-2 font-medium">Min</th>
-                  <th className="text-right px-4 py-2 font-medium">Gap</th>
-                  <th className="text-left px-4 py-2 font-medium">Fill</th>
+                  <th className="text-left px-4 py-2 font-medium">
+                    <TooltipLabel label="Time" tooltip={TABLE_TOOLTIPS.time} />
+                  </th>
+                  <th className="text-left px-4 py-2 font-medium">
+                    <TooltipLabel label="Market" tooltip={TABLE_TOOLTIPS.market} />
+                  </th>
+                  <th className="text-left px-4 py-2 font-medium">
+                    <TooltipLabel label="Status" tooltip={TABLE_TOOLTIPS.status} />
+                  </th>
+                  <th className="text-left px-4 py-2 font-medium">
+                    <TooltipLabel label="Reason" tooltip={TABLE_TOOLTIPS.reason} />
+                  </th>
+                  <th className="text-right px-4 py-2 font-medium">
+                    <TooltipLabel label="Edge" tooltip={TABLE_TOOLTIPS.edge} className="ml-auto" />
+                  </th>
+                  <th className="text-right px-4 py-2 font-medium">
+                    <TooltipLabel label="Min" tooltip={TABLE_TOOLTIPS.min} className="ml-auto" />
+                  </th>
+                  <th className="text-right px-4 py-2 font-medium">
+                    <TooltipLabel label="Gap" tooltip={TABLE_TOOLTIPS.gap} className="ml-auto" />
+                  </th>
+                  <th className="text-left px-4 py-2 font-medium">
+                    <TooltipLabel label="Fill" tooltip={TABLE_TOOLTIPS.fill} />
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -471,12 +529,17 @@ export function LiveOperations() {
               }}
             >
               <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                <span>Version</span>
+                <TooltipLabel label="Version" tooltip={CONFIG_TOOLTIPS.version} />
                 <span className="font-mono">{text(config?.version)}</span>
               </div>
-              <label className="space-y-1 text-sm">
-                <span className="block text-xs text-muted-foreground">Market context source</span>
+              <div className="space-y-1 text-sm">
+                <TooltipLabel
+                  className="text-xs text-muted-foreground"
+                  label="Market context source"
+                  tooltip={CONFIG_TOOLTIPS.market_context_source}
+                />
                 <select
+                  aria-label="Market context source"
                   className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/30"
                   name="market_context_source"
                   onChange={(event) => handleConfigChange("market_context_source", event.target.value)}
@@ -489,14 +552,17 @@ export function LiveOperations() {
                 {configErrors.market_context_source && (
                   <span className="block text-xs text-destructive">{configErrors.market_context_source}</span>
                 )}
-              </label>
+              </div>
               <div className="grid grid-cols-2 gap-3">
                 {CONFIG_FIELDS.map((field) => (
-                  <label key={field.key} className="space-y-1 text-sm">
-                    <span className="block text-xs text-muted-foreground">
-                      {field.key === "min_contract_price" ? thresholdLabel : field.label}
-                    </span>
+                  <div key={field.key} className="space-y-1 text-sm">
+                    <TooltipLabel
+                      className="text-xs text-muted-foreground"
+                      label={field.key === "min_contract_price" ? thresholdLabel : field.label}
+                      tooltip={CONFIG_TOOLTIPS[field.key]}
+                    />
                     <input
+                      aria-label={field.key === "min_contract_price" ? thresholdLabel : field.label}
                       className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/30"
                       inputMode="decimal"
                       max={field.max}
@@ -510,7 +576,7 @@ export function LiveOperations() {
                     {configErrors[field.key] && (
                       <span className="block text-xs text-destructive">{configErrors[field.key]}</span>
                     )}
-                  </label>
+                  </div>
                 ))}
               </div>
               <div className="flex min-h-7 items-center justify-between gap-3">
@@ -526,17 +592,29 @@ export function LiveOperations() {
           </Panel>
           <Panel title="Market Context">
             <div className="grid grid-cols-2 gap-3 text-sm">
-              <Value label="Active source" value={sourceLabel(marketContext.active_source || config?.market_context_source)} />
-              <Value label="Run source" value={sourceLabel(latestRunContext.market_context_source)} />
-              <Value label="BRTI value" value={optionalNumber(brtiLatest.value)} />
-              <Value label="BRTI age" value={seconds(brtiLatest.age_seconds)} />
-              <Value label="BRTI health" value={text(brtiLatest.status)} />
-              <Value label="Freshness" value={seconds(brtiLatest.freshness_limit_seconds)} />
-              <Value label="Basis" value={basisText(coinbaseDiagnostics.basis_dollars, coinbaseDiagnostics.basis_pct)} />
-              <Value label="Coinbase diag" value={text(coinbaseDiagnostics.status)} />
+              <Value
+                label="Active source"
+                tooltip={MARKET_CONTEXT_TOOLTIPS.active_source}
+                value={sourceLabel(marketContext.active_source || config?.market_context_source)}
+              />
+              <Value
+                label="Run source"
+                tooltip={MARKET_CONTEXT_TOOLTIPS.run_source}
+                value={sourceLabel(latestRunContext.market_context_source)}
+              />
+              <Value label="BRTI value" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_value} value={optionalNumber(brtiLatest.value)} />
+              <Value label="BRTI age" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_age} value={seconds(brtiLatest.age_seconds)} />
+              <Value label="BRTI health" tooltip={MARKET_CONTEXT_TOOLTIPS.brti_health} value={text(brtiLatest.status)} />
+              <Value label="Freshness" tooltip={MARKET_CONTEXT_TOOLTIPS.freshness} value={seconds(brtiLatest.freshness_limit_seconds)} />
+              <Value label="Basis" tooltip={MARKET_CONTEXT_TOOLTIPS.basis} value={basisText(coinbaseDiagnostics.basis_dollars, coinbaseDiagnostics.basis_pct)} />
+              <Value label="Coinbase diag" tooltip={MARKET_CONTEXT_TOOLTIPS.coinbase_diag} value={text(coinbaseDiagnostics.status)} />
             </div>
             <div className="mt-3 border-t border-border pt-3">
-              <div className="text-xs text-muted-foreground">Recent BRTI skips</div>
+              <TooltipLabel
+                className="text-xs text-muted-foreground"
+                label="Recent BRTI skips"
+                tooltip={MARKET_CONTEXT_TOOLTIPS.recent_brti_skips}
+              />
               <div className="mt-2 flex flex-wrap gap-2">
                 {recentBrtiSkips.length ? recentBrtiSkips.map((reason) => (
                   <span key={reason} className="rounded-md border border-border bg-background px-2 py-1 font-mono text-xs">
@@ -550,10 +628,10 @@ export function LiveOperations() {
           </Panel>
           <Panel title="Risk">
             <div className="grid grid-cols-2 gap-3 text-sm">
-              <Value label="Daily used" value={money(status.daily_loss_used_dollars)} />
-              <Value label="Daily limit" value={money(status.daily_loss_limit_dollars)} />
-              <Value label="Market used" value={money(status.market_exposure_used_dollars)} />
-              <Value label="Market limit" value={money(status.market_exposure_limit_dollars)} />
+              <Value label="Daily used" tooltip={RISK_TOOLTIPS.daily_used} value={money(status.daily_loss_used_dollars)} />
+              <Value label="Daily limit" tooltip={RISK_TOOLTIPS.daily_limit} value={money(status.daily_loss_limit_dollars)} />
+              <Value label="Market used" tooltip={RISK_TOOLTIPS.market_used} value={money(status.market_exposure_used_dollars)} />
+              <Value label="Market limit" tooltip={RISK_TOOLTIPS.market_limit} value={money(status.market_exposure_limit_dollars)} />
             </div>
           </Panel>
           <Panel title="Recent Runs">
@@ -638,10 +716,33 @@ function Panel({ title, children }: { title: string; children: ReactNode }) {
   )
 }
 
-function Value({ label, value }: { label: string; value: string }) {
+function TooltipLabel({ label, tooltip, className = "" }: { label: string; tooltip: string; className?: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        aria-label={`${label}: ${tooltip}`}
+        className={`inline-flex items-center gap-1 rounded-sm text-left text-current underline decoration-dotted underline-offset-4 transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 ${className}`}
+        title={tooltip}
+        type="button"
+      >
+        <span>{label}</span>
+        <CircleHelp className="h-3 w-3 shrink-0 opacity-70" aria-hidden="true" />
+      </TooltipTrigger>
+      <TooltipContent side="top" align="start">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function Value({ label, value, tooltip }: { label: string; value: string; tooltip?: string }) {
   return (
     <div className="flex items-center justify-between gap-3">
-      <span className="text-muted-foreground">{label}</span>
+      {tooltip ? (
+        <TooltipLabel className="text-muted-foreground" label={label} tooltip={tooltip} />
+      ) : (
+        <span className="text-muted-foreground">{label}</span>
+      )}
       <span className="font-mono text-xs">{value}</span>
     </div>
   )

--- a/src/alphadb/live_runtime.py
+++ b/src/alphadb/live_runtime.py
@@ -27,6 +27,7 @@ MARKET_CONTEXT_SOURCES = (
     MARKET_CONTEXT_BRTI_PRIMARY,
     MARKET_CONTEXT_FIXTURE,
 )
+LIVE_STATUS_RECENT_ATTEMPT_LIMIT = 50
 
 
 @dataclass(frozen=True)
@@ -809,7 +810,7 @@ def _recent_attempt_rows(
 ) -> list[dict[str, Any]]:
     rows = []
     snapshot = _mapping((config or {}).get("snapshot"))
-    for attempt in attempts[-10:]:
+    for attempt in attempts[-LIVE_STATUS_RECENT_ATTEMPT_LIMIT:]:
         reconciliation = _matching_reconciliation(attempt, reconciliation_rows)
         decision = _mapping(attempt.get("decision"))
         original_decision = _mapping(attempt.get("original_decision"))

--- a/tests/test_dashboard_live_console.py
+++ b/tests/test_dashboard_live_console.py
@@ -228,6 +228,10 @@ def test_cockpit_recent_attempts_table_renders_edge_diagnostics() -> None:
     assert "short ${optionalPercent(shortfall)}" in source
     assert "colSpan={9}" in source
     assert "ResizableDraggablePanel" in source
+    assert "PanelVisibilityMenu" in source
+    assert "hiddenPanelIds" in source
+    assert "Hide ${definition.label}" in source
+    assert "hidden: hiddenPanelIds" in source
     assert "window.localStorage" in source
 
 

--- a/tests/test_dashboard_live_console.py
+++ b/tests/test_dashboard_live_console.py
@@ -217,14 +217,18 @@ def test_live_payload_preserves_recent_attempt_edge_attribution() -> None:
 def test_cockpit_recent_attempts_table_renders_edge_diagnostics() -> None:
     source = Path("apps/dashboard/components/live/live-operations.tsx").read_text()
 
-    assert ">Edge</th>" in source
-    assert ">Min</th>" in source
-    assert ">Gap</th>" in source
+    assert "Activity Feed" in source
+    assert "ACTIVITY_FEED_LIMIT = 50" in source
+    assert 'label="Edge"' in source
+    assert 'label="Min"' in source
+    assert 'label="Gap"' in source
     assert "optionalPercent(attribution.edge)" in source
     assert "optionalPercent(attribution.min_edge)" in source
     assert "edgeGapText(attribution)" in source
     assert "short ${optionalPercent(shortfall)}" in source
-    assert "colSpan={8}" in source
+    assert "colSpan={9}" in source
+    assert "ResizableDraggablePanel" in source
+    assert "window.localStorage" in source
 
 
 def test_live_payload_keeps_simulated_summary_out_of_dashboard_api() -> None:

--- a/tests/test_live_runtime.py
+++ b/tests/test_live_runtime.py
@@ -234,6 +234,35 @@ def test_live_status_summary_covers_submitted_no_fill_skipped_and_no_recent() ->
     assert no_recent.decision_outcome == "no_recent_run"
 
 
+def test_live_status_recent_attempt_rows_keep_last_50() -> None:
+    attempts = [
+        {
+            "submitted_at": f"2026-06-04T15:{minute:02d}:00+00:00",
+            "market_ticker": f"KXBTC15M-{minute:02d}",
+            "status": "skipped",
+            "reason": "edge_below_min",
+        }
+        for minute in range(60)
+    ]
+
+    status = build_fair_value_live_status(
+        manifest={
+            "run_id": "fv_live_recent_attempt_limit",
+            "generated_at": "2026-06-04T16:00:00+00:00",
+            "runtime_config": {"snapshot": {}},
+            "runtime_controls": {},
+            "counts": {"live_attempts": len(attempts)},
+        },
+        attempts_payload={"attempts": attempts},
+        reconciliation={"rows": []},
+    )
+
+    assert status.recent_attempt_count == 60
+    assert len(status.recent_attempts) == 50
+    assert status.recent_attempts[0]["market_ticker"] == "KXBTC15M-10"
+    assert status.recent_attempts[-1]["market_ticker"] == "KXBTC15M-59"
+
+
 def test_live_status_prefers_live_risk_day_accounting_over_full_history() -> None:
     status = build_fair_value_live_status(
         manifest={


### PR DESCRIPTION
## Summary

Adds the first pass of operator-facing Live Operations UI polish:

- adds tooltips for Recent Attempts/Activity Feed, Runtime Config, Market Context, and Risk fields
- renames Recent Attempts to Activity Feed
- shows the last 50 attempts with expandable details
- makes home panels resizable and reorderable
- persists panel layout per strategy in browser localStorage
- adds panel visibility controls so panels can be hidden and restored from a fixed catalog

## Notes

This keeps the MVP panel catalog code-owned: adding a genuinely new panel is still a code change, while the UI supports hiding/restoring known panels.

## Validation

- `pnpm --dir apps/dashboard lint`
- `pnpm --dir apps/dashboard build`
- `.venv/bin/python -m pytest tests/test_live_runtime.py::test_live_status_recent_attempt_rows_keep_last_50 tests/test_dashboard_live_console.py::test_cockpit_recent_attempts_table_renders_edge_diagnostics`
- local browser checks for tooltip rendering and panel visibility controls

Lint still reports two pre-existing hook dependency warnings outside this change.
