### PR TITLE
[codex] Add canonical live settlement reconciliation

### DIFF
--- a/docs/prd/live-settlement-pnl-materializer.md
+++ b/docs/prd/live-settlement-pnl-materializer.md
@@ -1,0 +1,155 @@
+# PRD: Live Settlement P&L Materializer
+
+Linear publish status: published as
+[ALP-291](https://linear.app/threadfork/issue/ALP-291/prd-live-settlement-pandl-materializer).
+
+## Problem Statement
+
+Operators can see that live strategy order attempts were submitted and filled,
+but they do not have a canonical Operational State-backed answer for final
+realized P&L once Kalshi finalizes the market. The current live artifacts can
+prove execution, but compact reconciliation may continue to label filled
+attempts as unsettled because it deliberately avoids public settlement lookup.
+That forces operators and agents to reconstruct P&L by scanning artifacts,
+querying public Kalshi market results manually, and recomputing payout, fees,
+win rate, and exposure outside the product surface.
+
+This was exposed during the BRTI-primary `fair_value_live` investigation: the
+live filled attempts were real, the market results were finalized, and manual
+inspection showed realized P&L, but AlphaDB did not have a boring canonical row
+that Cockpit, reports, and agents could read.
+
+## Solution
+
+Build a narrow Live Settlement P&L Materializer that reconciles live order
+attempts against public Kalshi finalized market outcomes and persists canonical
+reconciliation rows in Operational State.
+
+From the user's perspective, AlphaDB should be able to answer live operational
+performance questions directly:
+
+- realized P&L
+- open or unsettled exposure
+- gross cost
+- fees
+- payout
+- filled contracts
+- settled and unresolved counts
+- win rate
+- later risk/performance ratios using the same canonical rows
+
+This is an operational reconciliation feature, not an official account-audit
+system and not a settlement-state research system. It applies to all live
+strategies that write live order attempts, starting with `fair_value_live`. BRTI
+is preserved as decision provenance, but P&L calculation does not depend on
+whether the decision source was BRTI, Coinbase, fixture, or something else.
+
+## User Stories
+
+1. As a live strategy operator, I want realized P&L to appear from canonical Operational State, so that I do not have to manually scan S3 artifacts.
+2. As a live strategy operator, I want filled live attempts to settle once Kalshi finalizes their markets, so that performance reports stop showing stale unresolved rows.
+3. As a live strategy operator, I want open exposure to remain visible for filled attempts whose market result is not yet finalized, so that I understand capital still at risk.
+4. As a live strategy operator, I want no-fill attempts to be represented with zero P&L, so that skipped or unfilled activity does not pollute trade performance.
+5. As a live strategy operator, I want partial fills to compute P&L only on filled contracts, so that reported performance matches actual exposure.
+6. As a live strategy operator, I want gross cost, fees, payout, and net P&L separated, so that I can inspect why a trade won or lost money.
+7. As a live strategy operator, I want win rate to use settled live reconciliation rows, so that it reflects final market outcomes rather than submitted-order counts.
+8. As a live strategy operator, I want unresolved counts to be explicit, so that I know when a performance answer is incomplete.
+9. As a live strategy operator, I want lookup failures to be recorded per market, so that one bad public API response does not hide all other reconciliations.
+10. As a live strategy operator, I want rerunning reconciliation to update existing rows rather than creating duplicates, so that the operational ledger stays stable.
+11. As a live strategy operator, I want the reconciliation command to be safe to run manually, so that I can answer urgent P&L questions after live probes.
+12. As a live strategy operator, I want the reconciliation path to work for `fair_value_live`, so that BRTI-primary live-money probe results are reportable.
+13. As a live strategy operator, I want the reconciliation path to be strategy-scoped, so that I can inspect one strategy without mixing unrelated live probes.
+14. As a live strategy operator, I want decision source provenance preserved, so that BRTI-primary and Coinbase-primary results can be compared later.
+15. As a live strategy operator, I want settlement source provenance preserved, so that I know whether a row was settled from public Kalshi market results.
+16. As a live strategy operator, I want reconciled timestamps and observed timestamps, so that I know when AlphaDB looked and what market state it observed.
+17. As a Cockpit user, I want the Performance section to read canonical live reconciliation rows, so that the UI answers P&L questions without frontend-owned trading logic.
+18. As a Cockpit user, I want sparse or unavailable states to remain truthful, so that missing reconciliation data is not disguised as fake zero P&L.
+19. As an agent, I want one canonical Operational State view of live settlement and P&L, so that natural-language performance questions do not require ad hoc scripts.
+20. As an agent, I want settled and unresolved rows to be machine-readable, so that I can explain what evidence backs a P&L answer.
+21. As an agent, I want strategy, run, market ticker, side, fill, cost, fee, payout, and result fields available together, so that I can audit individual trades.
+22. As a runtime maintainer, I want reconciliation to stay outside the one-minute live decision hot path, so that trading authority remains fail-closed and bounded.
+23. As a runtime maintainer, I want bounded live-risk admission refresh to remain separate from P&L settlement, so that admission control is not coupled to full-history reconciliation.
+24. As a runtime maintainer, I want live order attempts to remain the execution evidence source, so that reconciliation does not create a parallel order lifecycle.
+25. As a platform engineer, I want an idempotent upsert keyed to the live order attempt, so that the schema supports repeated reconciliation jobs.
+26. As a platform engineer, I want a small pure P&L calculator interface, so that settlement arithmetic can be tested without database or network dependencies.
+27. As a platform engineer, I want the public Kalshi market-result lookup isolated behind a client interface, so that lookup failures and tests are easy to control.
+28. As a platform engineer, I want repository methods for reading candidate attempts and upserting reconciliation rows, so that Operational State ownership stays in Python.
+29. As a platform engineer, I want the AlphaDB API performance summary to prefer live reconciliation rows for live strategies, so that Cockpit does not need direct database access.
+30. As a platform engineer, I want lookup failure metadata stored in reconciliation rows, so that operational debugging does not depend on logs alone.
+31. As a platform engineer, I want historical diagnostic artifact reconciliation to remain separate from this canonical table, so that old S3 reports do not become live authority.
+32. As a researcher, I want this feature not to create an official BRTI settlement-state dataset, so that research provenance and licensed data policies remain clean.
+33. As a researcher, I want this feature not to change model evaluation replay, so that operational P&L and research replay remain separate evidence systems.
+34. As a risk reviewer, I want this feature not to change live trading policy, so that `0.999` near-settlement trading behavior can be evaluated separately.
+35. As a risk reviewer, I want unresolved filled exposure visible, so that daily risk discussions can distinguish realized losses from still-open settlement exposure.
+36. As a maintainer, I want tests for wins, losses, no-fills, unresolved markets, lookup failures, partial fills, and reruns, so that future changes do not regress basic P&L truth.
+
+## Implementation Decisions
+
+- Add a canonical `live_trade_reconciliations` Operational State table rather than expanding diagnostic artifact reports into product authority.
+- Key reconciliation rows by live order attempt, using an upsert so reruns update the same row rather than appending duplicates.
+- Include strategy, run, market ticker, side, filled contracts, cost, fees, market status, market result, settlement status, payout, net P&L, unsettled exposure, decision source, settlement source, settlement observed timestamp, reconciled timestamp, and metadata.
+- Preserve decision provenance separately from settlement provenance. Decision provenance captures sources such as `brti_primary` or `coinbase_primary`; settlement provenance captures the public Kalshi market-result lookup used for operational reconciliation.
+- Treat live order attempts as the execution evidence source. The reconciliation materializer reads attempts and does not mutate attempt lifecycle state except through explicit linking if a future implementation chooses to add a reference.
+- Compute P&L from confirmed filled contracts. Submitted-but-unfilled attempts do not count as realized exposure unless fill evidence exists.
+- Use actual cost and fee fields when available from the live attempt or order detail. If the MVP must fall back to intended price and configured fee assumptions, record that fallback in metadata.
+- Compute payout as filled contracts times one dollar when the attempted side matches the finalized market result; otherwise payout is zero.
+- Compute net P&L as payout minus cost and fees.
+- Compute unsettled exposure as cost plus fees for filled attempts whose market result is not finalized or unavailable.
+- Represent no-fill attempts with a no-fill settlement status and zero payout, zero net P&L, and zero unsettled exposure.
+- Represent finalized wins, finalized losses, and flat outcomes distinctly enough for reports to compute win rate without guessing from numeric P&L alone.
+- Represent lookup failures separately from ordinary open markets, so operators can distinguish public API problems from not-yet-finalized markets.
+- Isolate Kalshi public market lookup behind a small client interface with per-market soft failure behavior.
+- Cache or reuse market-result lookups within a run so multiple attempts in the same market do not require duplicate network calls.
+- Add a live-orders command for settlement reconciliation, strategy-scoped by default and initially supporting `fair_value_live`.
+- Keep reconciliation outside the one-minute live decision job and outside bounded live-risk admission refresh.
+- Update the AlphaDB API performance summary path so live strategies prefer canonical live reconciliation rows before falling back to sparse or unavailable states.
+- Keep Cockpit as a reader of AlphaDB API performance output only; Cockpit does not compute P&L or query Operational State directly.
+- Keep artifact-level live reconciliation as diagnostic compatibility, not the canonical answer for operational P&L.
+- Do not introduce official BRTI settlement-state reconstruction in this PRD. BRTI remains decision-time market context, not settlement truth for this operational materializer.
+- Do not use this PRD to decide whether high-price near-settlement trades are desirable. That is a separate strategy/risk policy decision.
+- Major modules to build or modify are: Operational State schema and repository methods, a pure live settlement P&L calculator, a Kalshi public market-result client, the live-orders command surface, the AlphaDB API performance summary projection, and Cockpit/reporting consumers as needed to display the new fields.
+- The deepest module should be the reconciliation calculator/materializer interface: given attempt fill facts and a market-result observation, it returns a deterministic reconciliation row. This keeps arithmetic and status decisions testable without network or database state.
+
+## Testing Decisions
+
+- Tests should assert external behavior: persisted rows, status transitions, summary fields, CLI output, and API response payloads. They should not lock tests to implementation-private helper names.
+- Add pure unit tests for the settlement P&L calculator covering settled win, settled loss, settled flat, no-fill, unresolved market, lookup failure, partial fill, fee fallback, and cost fallback.
+- Add repository tests that prove migrations create the reconciliation table, candidate live attempts can be selected by strategy, reconciliation rows can be upserted, and reruns do not create duplicates.
+- Add command tests using a fake market-result client and local Operational State so the command can prove soft failure behavior without real Kalshi network calls.
+- Add performance summary tests proving live reconciliation rows produce realized P&L, unsettled exposure, gross cost, fees, payout, filled contracts, settled count, open count, and win rate.
+- Add tests proving no live reconciliation data produces truthful unavailable or sparse performance states rather than fake zeros.
+- Add tests proving multiple live attempts in the same market can reconcile from one market-result observation without inconsistent row outcomes.
+- Add tests proving lookup failure for one market does not prevent other markets from reconciling.
+- Add tests proving no-fill attempts produce zero P&L and do not count as wins or losses.
+- Add tests proving partial fills compute cost, fees, payout, and exposure from filled quantity rather than intended quantity.
+- Add tests proving the AlphaDB API remains the boundary for Cockpit performance data.
+- Prior art in the codebase includes live order repository tests, live runtime tests around reconciliation-shaped rows, performance summary tests, model evaluation replay P&L tests, and synthetic settlement-state tests.
+
+## Out of Scope
+
+- Official BRTI settlement-state reconstruction.
+- Licensed official BRTI dataset ingestion or publication.
+- Promotion-grade research datasets.
+- Model evaluation replay changes.
+- Full exchange account reconciliation.
+- Maker-order lifecycle or resting-order state machines.
+- New trading behavior, edge thresholds, max-price caps, or live-risk authority changes.
+- Changes to bounded live-risk admission refresh.
+- Mutation of live order attempt lifecycle state beyond reading and optional explicit linkage.
+- Cockpit-owned P&L logic or direct Cockpit database access.
+- Historical S3 artifact backfill as the main MVP path.
+- Sharpe and Sortino implementation, except that future ratios should use this canonical table once present.
+
+## Further Notes
+
+The BRTI-primary investigation found 43 filled attempt rows across 16 finalized
+markets. All were `0.999` near-certain-side fills, all matched the public Kalshi
+result, and manual public-market lookup produced positive realized P&L. That
+proved the reporting gap: the compact live artifacts could still report
+unresolved or zero realized P&L even when operational P&L was knowable.
+
+This PRD addresses the canonical P&L and settlement reporting gap. It
+intentionally does not answer whether near-settlement `0.999` trades should be
+allowed. That should be handled by a separate strategy diagnosis or risk-policy
+issue covering max price, minimum edge after fees, and late-window trading
+behavior.

--- a/src/alphadb/live_orders.py
+++ b/src/alphadb/live_orders.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from alphadb.config import Settings, settings_from_env
+from alphadb.live_settlement import reconcile_live_settlements
 from alphadb.paper.ioc import ApprovedOrderIntent, PaperExecutionRepository
 from alphadb.runtime import RuntimeGuardDecision, evaluate_runtime_guard
 from alphadb.state.repository import OperationalStateRepository
@@ -778,6 +779,14 @@ def build_parser() -> argparse.ArgumentParser:
     smoke.add_argument("--order-intent-id", required=True)
     status = subparsers.add_parser("status", help="Show live adapter readiness and attempts")
     status.add_argument("--limit", type=int, default=10)
+    reconcile = subparsers.add_parser(
+        "reconcile-settlement",
+        help="Materialize canonical live settlement P&L rows",
+    )
+    reconcile.add_argument("--strategy", default="fair_value_live")
+    reconcile.add_argument("--market-ticker")
+    reconcile.add_argument("--live-risk-day")
+    reconcile.add_argument("--limit", type=int, default=500)
     return parser
 
 
@@ -807,5 +816,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                 default=str,
             )
         )
+        return 0
+    if args.command == "reconcile-settlement":
+        live_risk_day = (
+            date.fromisoformat(args.live_risk_day)
+            if getattr(args, "live_risk_day", None)
+            else None
+        )
+        summary = reconcile_live_settlements(
+            database_url=settings.database_url,
+            settings=settings,
+            strategy=args.strategy,
+            market_ticker=args.market_ticker,
+            live_risk_day=live_risk_day,
+            limit=args.limit,
+        )
+        print(json.dumps(summary, indent=2, sort_keys=True, default=str))
         return 0
     raise AssertionError(f"unhandled command: {args.command}")

--- a/src/alphadb/live_settlement.py
+++ b/src/alphadb/live_settlement.py
@@ -1,0 +1,723 @@
+"""Canonical live trade settlement and P&L materialization."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any, Protocol
+from urllib import parse, request
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from alphadb.config import Settings
+from alphadb.model_evaluation.metrics import taker_fee
+from alphadb.state.repository import OperationalStateRepository
+
+
+SETTLEMENT_SOURCE_KALSHI_PUBLIC_MARKET_API = "kalshi_public_market_api"
+LIVE_TRADE_RECONCILIATION_SCHEMA = "alphadb_live_trade_reconciliation.v1"
+LIVE_TRADE_RECONCILIATION_SUMMARY_SCHEMA = "alphadb_live_trade_reconciliation_summary.v1"
+
+SETTLED_STATUSES = {"settled_win", "settled_loss", "settled_flat"}
+UNSETTLED_FILLED_STATUSES = {"open", "settlement_unavailable", "lookup_failed"}
+
+
+class LiveSettlementError(RuntimeError):
+    """Raised when live settlement reconciliation cannot proceed safely."""
+
+
+@dataclass(frozen=True)
+class MarketResultObservation:
+    market_ticker: str
+    status: str | None
+    result: str | None
+    source: str | None = SETTLEMENT_SOURCE_KALSHI_PUBLIC_MARKET_API
+    observed_at: datetime | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "market_ticker": self.market_ticker,
+            "status": self.status,
+            "result": self.result,
+            "source": self.source,
+            "observed_at": _iso(self.observed_at),
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+class MarketResultClient(Protocol):
+    def get_market_result(
+        self,
+        *,
+        ticker: str,
+        settings: Settings,
+        observed_at: datetime,
+    ) -> MarketResultObservation:
+        """Return a public market-result observation for one Kalshi ticker."""
+
+
+class KalshiPublicMarketResultClient:
+    """Small public Kalshi market-result lookup client."""
+
+    def get_market_result(
+        self,
+        *,
+        ticker: str,
+        settings: Settings,
+        observed_at: datetime,
+    ) -> MarketResultObservation:
+        if not ticker:
+            return MarketResultObservation(
+                market_ticker=ticker,
+                status=None,
+                result=None,
+                observed_at=observed_at,
+                metadata={"error": "missing_ticker"},
+            )
+        url = f"{settings.kalshi_base_url.rstrip('/')}/markets/{parse.quote(ticker, safe='')}"
+        try:
+            http_request = request.Request(
+                url,
+                headers={"Accept": "application/json", "User-Agent": "alphadb/0.1"},
+                method="GET",
+            )
+            with request.urlopen(http_request, timeout=10) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            market = _mapping(payload.get("market")) if isinstance(payload, Mapping) else {}
+            result = _lower_text(market.get("result"))
+            return MarketResultObservation(
+                market_ticker=ticker,
+                status=_text(market.get("status")),
+                result=result if result in {"yes", "no"} else None,
+                observed_at=observed_at,
+                metadata={"http_status": getattr(response, "status", None)},
+            )
+        except Exception as exc:
+            return MarketResultObservation(
+                market_ticker=ticker,
+                status="unknown",
+                result=None,
+                observed_at=observed_at,
+                metadata={"error": f"{type(exc).__name__}: {exc}"},
+            )
+
+
+def reconcile_live_order_attempt(
+    attempt: Mapping[str, Any],
+    *,
+    market_result: MarketResultObservation | Mapping[str, Any] | None,
+    reconciled_at: datetime,
+    taker_fee_multiplier: float = 0.07,
+) -> dict[str, Any]:
+    """Build one canonical reconciliation row from attempt and market evidence."""
+
+    request_payload = _mapping(attempt.get("request_payload"))
+    response_payload = _mapping(attempt.get("response_payload"))
+    market_observation = _market_result_observation(
+        market_result,
+        ticker=_text(attempt.get("market_ticker")) or _text(request_payload.get("ticker")) or "",
+    )
+
+    filled_contracts, fill_source = _filled_contracts(attempt, response_payload)
+    side, side_source = _selected_side(attempt, request_payload)
+    price, price_source = _selected_price(attempt, request_payload, side=side)
+    cost, cost_source = _cost_dollars(
+        response_payload,
+        filled_contracts=filled_contracts,
+        price=price,
+    )
+    fees, fees_source = _fees_dollars(
+        response_payload,
+        filled_contracts=filled_contracts,
+        price=price,
+        taker_fee_multiplier=taker_fee_multiplier,
+    )
+    ticker = (
+        _text(attempt.get("market_ticker"))
+        or _text(request_payload.get("ticker"))
+        or market_observation.market_ticker
+    )
+    result = _lower_text(market_observation.result)
+    lookup_error = _lookup_error(market_observation)
+
+    if filled_contracts <= 0:
+        settlement_status = "no_fill"
+        payout = 0.0
+        net_pnl = 0.0
+        unsettled_exposure = 0.0
+    elif lookup_error:
+        settlement_status = "lookup_failed"
+        payout = 0.0
+        net_pnl = 0.0
+        unsettled_exposure = cost + fees
+    elif result in {"yes", "no"} and side in {"yes", "no"}:
+        payout = filled_contracts if result == side else 0.0
+        net_pnl = payout - cost - fees
+        unsettled_exposure = 0.0
+        if abs(net_pnl) < 0.0000005:
+            settlement_status = "settled_flat"
+        elif net_pnl > 0:
+            settlement_status = "settled_win"
+        else:
+            settlement_status = "settled_loss"
+    elif _lower_text(market_observation.status) in {"finalized", "settled", "closed"}:
+        settlement_status = "settlement_unavailable"
+        payout = 0.0
+        net_pnl = 0.0
+        unsettled_exposure = cost + fees
+    else:
+        settlement_status = "open"
+        payout = 0.0
+        net_pnl = 0.0
+        unsettled_exposure = cost + fees
+
+    metadata = {
+        "schema_version": LIVE_TRADE_RECONCILIATION_SCHEMA,
+        "attempt_status": _text(attempt.get("status")),
+        "exchange_status": _text(attempt.get("exchange_status")),
+        "fill_source": fill_source,
+        "side_source": side_source,
+        "price_source": price_source,
+        "cost_source": cost_source,
+        "fees_source": fees_source,
+        "fallbacks": [
+            source
+            for source in (cost_source, fees_source)
+            if source.startswith("fallback_")
+        ],
+        "market_result_observation": market_observation.as_dict(),
+    }
+    if lookup_error:
+        metadata["lookup_error"] = lookup_error
+
+    return {
+        "live_order_attempt_id": str(attempt.get("live_order_attempt_id") or ""),
+        "strategy": _text(attempt.get("strategy")) or "unknown",
+        "run_id": _run_id(attempt, request_payload, response_payload),
+        "live_risk_day": _date_or_none(attempt.get("live_risk_day")),
+        "market_ticker": ticker,
+        "side": side,
+        "filled_contracts": _round(filled_contracts),
+        "cost_dollars": _round(cost),
+        "fees_dollars": _round(fees),
+        "market_status": market_observation.status,
+        "market_result": result,
+        "settlement_status": settlement_status,
+        "payout_dollars": _round(payout),
+        "net_pnl_dollars": _round(net_pnl),
+        "unsettled_exposure_dollars": _round(unsettled_exposure),
+        "decision_source": _decision_source(attempt, request_payload, response_payload),
+        "settlement_source": market_observation.source if market_observation.source else None,
+        "settlement_observed_at": market_observation.observed_at,
+        "reconciled_at": reconciled_at,
+        "metadata": metadata,
+    }
+
+
+class LiveTradeReconciliationRepository:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def candidate_attempts(
+        self,
+        *,
+        strategy: str,
+        limit: int = 500,
+        market_ticker: str | None = None,
+        live_risk_day: date | None = None,
+    ) -> list[dict[str, Any]]:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        predicates = ["strategy = %s"]
+        params: list[Any] = [strategy]
+        if market_ticker:
+            predicates.append("market_ticker = %s")
+            params.append(market_ticker)
+        if live_risk_day:
+            predicates.append("live_risk_day = %s")
+            params.append(live_risk_day)
+        params.append(limit)
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    select *
+                    from live_order_attempts
+                    where {" and ".join(predicates)}
+                    order by submitted_at desc nulls last, created_at desc, live_order_attempt_id desc
+                    limit %s
+                    """,
+                    params,
+                )
+                return [_json_ready(row) for row in cursor.fetchall()]
+
+    def upsert(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        if not row.get("live_order_attempt_id"):
+            raise LiveSettlementError("reconciliation row needs live_order_attempt_id")
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into live_trade_reconciliations (
+                        live_order_attempt_id,
+                        strategy,
+                        run_id,
+                        live_risk_day,
+                        market_ticker,
+                        side,
+                        filled_contracts,
+                        cost_dollars,
+                        fees_dollars,
+                        market_status,
+                        market_result,
+                        settlement_status,
+                        payout_dollars,
+                        net_pnl_dollars,
+                        unsettled_exposure_dollars,
+                        decision_source,
+                        settlement_source,
+                        settlement_observed_at,
+                        reconciled_at,
+                        metadata,
+                        updated_at
+                    )
+                    values (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, now()
+                    )
+                    on conflict (live_order_attempt_id) do update
+                    set strategy = excluded.strategy,
+                        run_id = excluded.run_id,
+                        live_risk_day = excluded.live_risk_day,
+                        market_ticker = excluded.market_ticker,
+                        side = excluded.side,
+                        filled_contracts = excluded.filled_contracts,
+                        cost_dollars = excluded.cost_dollars,
+                        fees_dollars = excluded.fees_dollars,
+                        market_status = excluded.market_status,
+                        market_result = excluded.market_result,
+                        settlement_status = excluded.settlement_status,
+                        payout_dollars = excluded.payout_dollars,
+                        net_pnl_dollars = excluded.net_pnl_dollars,
+                        unsettled_exposure_dollars = excluded.unsettled_exposure_dollars,
+                        decision_source = excluded.decision_source,
+                        settlement_source = excluded.settlement_source,
+                        settlement_observed_at = excluded.settlement_observed_at,
+                        reconciled_at = excluded.reconciled_at,
+                        metadata = excluded.metadata,
+                        updated_at = now()
+                    returning *
+                    """,
+                    (
+                        row.get("live_order_attempt_id"),
+                        row.get("strategy"),
+                        row.get("run_id"),
+                        row.get("live_risk_day"),
+                        row.get("market_ticker"),
+                        row.get("side"),
+                        row.get("filled_contracts"),
+                        row.get("cost_dollars"),
+                        row.get("fees_dollars"),
+                        row.get("market_status"),
+                        row.get("market_result"),
+                        row.get("settlement_status"),
+                        row.get("payout_dollars"),
+                        row.get("net_pnl_dollars"),
+                        row.get("unsettled_exposure_dollars"),
+                        row.get("decision_source"),
+                        row.get("settlement_source"),
+                        row.get("settlement_observed_at"),
+                        row.get("reconciled_at"),
+                        Jsonb(dict(row.get("metadata") or {})),
+                    ),
+                )
+                saved = cursor.fetchone()
+            connection.commit()
+        if saved is None:
+            raise LiveSettlementError("live reconciliation upsert returned no row")
+        return _json_ready(saved)
+
+    def recent_rows(
+        self,
+        *,
+        strategy: str,
+        limit: int = 500,
+        market_series: str | None = None,
+    ) -> list[dict[str, Any]]:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        predicates = ["strategy = %s"]
+        params: list[Any] = [strategy]
+        if market_series:
+            predicates.append("(market_ticker = %s or market_ticker like %s)")
+            params.extend([market_series, f"{market_series}-%"])
+        params.append(limit)
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    select *
+                    from live_trade_reconciliations
+                    where {" and ".join(predicates)}
+                    order by reconciled_at desc, live_order_attempt_id desc
+                    limit %s
+                    """,
+                    params,
+                )
+                return [_json_ready(row) for row in cursor.fetchall()]
+
+
+def reconcile_live_settlements(
+    *,
+    database_url: str,
+    settings: Settings,
+    strategy: str,
+    market_client: MarketResultClient | None = None,
+    limit: int = 500,
+    market_ticker: str | None = None,
+    live_risk_day: date | None = None,
+    reconciled_at: datetime | None = None,
+) -> dict[str, Any]:
+    observed_at = reconciled_at or datetime.now(UTC)
+    repository = LiveTradeReconciliationRepository(database_url)
+    client = market_client or KalshiPublicMarketResultClient()
+    attempts = repository.candidate_attempts(
+        strategy=strategy,
+        limit=limit,
+        market_ticker=market_ticker,
+        live_risk_day=live_risk_day,
+    )
+    market_cache: dict[str, MarketResultObservation] = {}
+    rows: list[dict[str, Any]] = []
+    for attempt in attempts:
+        response_payload = _mapping(attempt.get("response_payload"))
+        filled_contracts, _source = _filled_contracts(attempt, response_payload)
+        ticker = _text(attempt.get("market_ticker")) or _text(
+            _mapping(attempt.get("request_payload")).get("ticker")
+        ) or ""
+        market_result: MarketResultObservation | None = None
+        if filled_contracts > 0:
+            if ticker not in market_cache:
+                market_cache[ticker] = client.get_market_result(
+                    ticker=ticker,
+                    settings=settings,
+                    observed_at=observed_at,
+                )
+            market_result = market_cache[ticker]
+        row = reconcile_live_order_attempt(
+            attempt,
+            market_result=market_result,
+            reconciled_at=observed_at,
+        )
+        rows.append(repository.upsert(row))
+    summary = summarize_live_trade_reconciliations(rows, generated_at=observed_at)
+    summary["lookup_count"] = len(market_cache)
+    return summary
+
+
+def summarize_live_trade_reconciliations(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    normalized = [dict(row) for row in rows]
+    filled = [row for row in normalized if _float(row.get("filled_contracts")) > 0]
+    settled = [row for row in filled if _text(row.get("settlement_status")) in SETTLED_STATUSES]
+    unsettled = [
+        row
+        for row in filled
+        if _text(row.get("settlement_status")) in UNSETTLED_FILLED_STATUSES
+    ]
+    wins = [row for row in settled if _text(row.get("settlement_status")) == "settled_win"]
+    losses = [row for row in settled if _text(row.get("settlement_status")) == "settled_loss"]
+    counts = Counter(_text(row.get("settlement_status")) or "unknown" for row in normalized)
+    return {
+        "schema_version": LIVE_TRADE_RECONCILIATION_SUMMARY_SCHEMA,
+        "generated_at": _iso(generated_at or datetime.now(UTC)),
+        "counts": dict(sorted(counts.items())),
+        "pnl": {
+            "realized_pnl_dollars": _round(
+                sum(_float(row.get("net_pnl_dollars")) for row in settled)
+            ),
+            "net_pnl_dollars": _round(
+                sum(_float(row.get("net_pnl_dollars")) for row in settled)
+            ),
+            "gross_cost_dollars": _round(
+                sum(_float(row.get("cost_dollars")) for row in filled)
+            ),
+            "fees_dollars": _round(sum(_float(row.get("fees_dollars")) for row in filled)),
+            "payout_dollars": _round(
+                sum(_float(row.get("payout_dollars")) for row in settled)
+            ),
+            "unsettled_exposure_dollars": _round(
+                sum(_float(row.get("unsettled_exposure_dollars")) for row in unsettled)
+            ),
+            "filled_contracts": _round(
+                sum(_float(row.get("filled_contracts")) for row in filled)
+            ),
+            "settled_trade_count": len(settled),
+            "open_trade_count": len(unsettled),
+            "no_fill_count": counts.get("no_fill", 0),
+            "lookup_failed_count": counts.get("lookup_failed", 0),
+            "win_rate": _round(len(wins) / len(settled)) if settled else None,
+            "loss_count": len(losses),
+        },
+        "settlement": {
+            "state": _live_settlement_state(normalized),
+            "settled_rows": len(settled),
+            "unsettled_rows": len(unsettled),
+            "default_reporting": "canonical_live_trade_reconciliations",
+        },
+        "rows": normalized,
+    }
+
+
+def _live_settlement_state(rows: Sequence[Mapping[str, Any]]) -> str:
+    if not rows:
+        return "unavailable"
+    filled = [row for row in rows if _float(row.get("filled_contracts")) > 0]
+    if not filled:
+        return "complete"
+    statuses = {_text(row.get("settlement_status")) for row in filled}
+    if statuses <= SETTLED_STATUSES:
+        return "complete"
+    if statuses & SETTLED_STATUSES:
+        return "partial"
+    return "unresolved"
+
+
+def _market_result_observation(
+    market_result: MarketResultObservation | Mapping[str, Any] | None,
+    *,
+    ticker: str,
+) -> MarketResultObservation:
+    if isinstance(market_result, MarketResultObservation):
+        return market_result
+    if isinstance(market_result, Mapping):
+        metadata = _mapping(market_result.get("metadata"))
+        return MarketResultObservation(
+            market_ticker=_text(market_result.get("market_ticker")) or ticker,
+            status=_text(market_result.get("status")),
+            result=_lower_text(market_result.get("result")),
+            source=_text(market_result.get("source")) or SETTLEMENT_SOURCE_KALSHI_PUBLIC_MARKET_API,
+            observed_at=_datetime(market_result.get("observed_at")),
+            metadata=metadata,
+        )
+    return MarketResultObservation(
+        market_ticker=ticker,
+        status=None,
+        result=None,
+        source=None,
+        observed_at=None,
+        metadata={},
+    )
+
+
+def _filled_contracts(
+    attempt: Mapping[str, Any],
+    response_payload: Mapping[str, Any],
+) -> tuple[float, str]:
+    value = _float_or_none(attempt.get("fill_count"))
+    if value is not None:
+        return max(0.0, value), "live_order_attempt.fill_count"
+    value = _numeric_response_value(
+        response_payload,
+        ("fill_count", "fill_count_fp", "filled_quantity"),
+    )
+    if value is not None:
+        return max(0.0, value), "response_payload.fill_count"
+    return 0.0, "missing_fill_count"
+
+
+def _selected_side(
+    attempt: Mapping[str, Any],
+    request_payload: Mapping[str, Any],
+) -> tuple[str, str]:
+    side = _text(attempt.get("intended_side"))
+    side = _lower_text(side)
+    if side in {"yes", "no"}:
+        return side, "live_order_attempt.intended_side"
+    request_side = _lower_text(request_payload.get("side"))
+    if request_side == "bid":
+        return "yes", "request_payload.side"
+    if request_side == "ask":
+        return "no", "request_payload.side"
+    return "", "missing_side"
+
+
+def _selected_price(
+    attempt: Mapping[str, Any],
+    request_payload: Mapping[str, Any],
+    *,
+    side: str,
+) -> tuple[float, str]:
+    value = _float_or_none(attempt.get("intended_price_dollars"))
+    if value is not None:
+        return max(0.0, value), "live_order_attempt.intended_price_dollars"
+    request_price = _float_or_none(request_payload.get("price"))
+    request_side = _lower_text(request_payload.get("side"))
+    if request_price is not None:
+        if side == "no" or request_side == "ask":
+            return max(0.0, 1.0 - request_price), "fallback_request_payload.price_complement"
+        return max(0.0, request_price), "fallback_request_payload.price"
+    return 0.0, "missing_price"
+
+
+def _cost_dollars(
+    response_payload: Mapping[str, Any],
+    *,
+    filled_contracts: float,
+    price: float,
+) -> tuple[float, str]:
+    actual = _numeric_response_value(
+        response_payload,
+        (
+            "taker_fill_cost_dollars",
+            "maker_fill_cost_dollars",
+            "fill_cost_dollars",
+            "filled_cost_dollars",
+            "cost_dollars",
+        ),
+    )
+    if actual is not None:
+        return max(0.0, actual), "response_payload.actual_cost"
+    value = max(0.0, price * filled_contracts)
+    return value, "fallback_intended_price_times_fill"
+
+
+def _fees_dollars(
+    response_payload: Mapping[str, Any],
+    *,
+    filled_contracts: float,
+    price: float,
+    taker_fee_multiplier: float,
+) -> tuple[float, str]:
+    actual = _numeric_response_value(
+        response_payload,
+        (
+            "taker_fees_dollars",
+            "maker_fees_dollars",
+            "fees_dollars",
+            "fee_dollars",
+        ),
+    )
+    if actual is not None:
+        return max(0.0, actual), "response_payload.actual_fees"
+    value = max(0.0, taker_fee(price, taker_fee_multiplier) * filled_contracts)
+    return value, "fallback_taker_fee_assumption"
+
+
+def _numeric_response_value(payload: Mapping[str, Any], keys: Sequence[str]) -> float | None:
+    order = _mapping(payload.get("order"))
+    for source in (payload, order):
+        for key in keys:
+            value = _float_or_none(source.get(key))
+            if value is not None:
+                return value
+    return None
+
+
+def _decision_source(
+    attempt: Mapping[str, Any],
+    request_payload: Mapping[str, Any],
+    response_payload: Mapping[str, Any],
+) -> str | None:
+    for source in (attempt, request_payload, _mapping(request_payload.get("metadata")), response_payload):
+        value = _text(source.get("decision_source")) or _text(source.get("market_context_source"))
+        if value:
+            return value
+    return None
+
+
+def _run_id(
+    attempt: Mapping[str, Any],
+    request_payload: Mapping[str, Any],
+    response_payload: Mapping[str, Any],
+) -> str | None:
+    for source in (attempt, request_payload, _mapping(request_payload.get("metadata")), response_payload):
+        value = _text(source.get("run_id"))
+        if value:
+            return value
+    return None
+
+
+def _lookup_error(observation: MarketResultObservation) -> str | None:
+    metadata = dict(observation.metadata or {})
+    return _text(metadata.get("error"))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _lower_text(value: Any) -> str | None:
+    text = _text(value)
+    return text.lower() if text else None
+
+
+def _float(value: Any) -> float:
+    parsed = _float_or_none(value)
+    return parsed if parsed is not None else 0.0
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _round(value: float | int | Decimal) -> float:
+    return round(float(value), 6)
+
+
+def _datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str) and value:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _date_or_none(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str) and value:
+        return date.fromisoformat(value)
+    return None
+
+
+def _iso(value: datetime | None) -> str | None:
+    return None if value is None else value.isoformat()
+
+
+def _json_ready(row: Mapping[str, Any]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for key, value in row.items():
+        if isinstance(value, datetime):
+            output[key] = value.isoformat()
+        elif isinstance(value, date) and not isinstance(value, datetime):
+            output[key] = value.isoformat()
+        elif isinstance(value, Decimal):
+            output[key] = float(value)
+        else:
+            output[key] = value
+    return output

--- a/src/alphadb/performance.py
+++ b/src/alphadb/performance.py
@@ -13,6 +13,7 @@ from psycopg.rows import dict_row
 
 from alphadb.live_runtime import FAIR_VALUE_LIVE_STRATEGY
 from alphadb.live_edge_attribution import summarize_live_edge_attribution_buckets
+from alphadb.live_settlement import summarize_live_trade_reconciliations
 from alphadb.state.repository import OperationalStateRepository
 
 
@@ -21,6 +22,7 @@ DEFAULT_MARKET_SERIES = "KXBTC15M"
 PERFORMANCE_STALE_AFTER_SECONDS = 300
 DEFAULT_RECENT_RUN_LIMIT = 25
 DEFAULT_PAPER_ROW_LIMIT = 500
+DEFAULT_LIVE_RECONCILIATION_LIMIT = 500
 
 
 class PerformanceSummaryRepository:
@@ -44,6 +46,12 @@ class PerformanceSummaryRepository:
                     cursor,
                     strategy=strategy,
                     limit=recent_limit,
+                )
+                live_reconciliation_rows = _live_reconciliation_rows(
+                    cursor,
+                    strategy=strategy,
+                    market_series=market_series,
+                    limit=DEFAULT_LIVE_RECONCILIATION_LIMIT,
                 )
                 if strategy == FAIR_VALUE_LIVE_STRATEGY:
                     order_rows = _paper_order_rows(
@@ -71,6 +79,7 @@ class PerformanceSummaryRepository:
             generated_at=datetime.now(UTC),
             config_row=config_row,
             status_rows=status_rows,
+            live_reconciliation_rows=live_reconciliation_rows,
             order_rows=order_rows,
             fill_rows=fill_rows,
             position_rows=position_rows,
@@ -84,6 +93,7 @@ def build_performance_summary(
     generated_at: datetime,
     config_row: Mapping[str, Any] | None = None,
     status_rows: Sequence[Mapping[str, Any]] = (),
+    live_reconciliation_rows: Sequence[Mapping[str, Any]] = (),
     order_rows: Sequence[Mapping[str, Any]] = (),
     fill_rows: Sequence[Mapping[str, Any]] = (),
     position_rows: Sequence[Mapping[str, Any]] = (),
@@ -92,6 +102,7 @@ def build_performance_summary(
     rows = [dict(row) for row in status_rows]
     execution = summarize_execution(rows)
     pnl = summarize_pnl(
+        live_reconciliation_rows=live_reconciliation_rows,
         order_rows=order_rows,
         fill_rows=fill_rows,
         position_rows=position_rows,
@@ -182,10 +193,15 @@ def summarize_execution(status_rows: Sequence[Mapping[str, Any]]) -> dict[str, A
 
 def summarize_pnl(
     *,
+    live_reconciliation_rows: Sequence[Mapping[str, Any]] = (),
     order_rows: Sequence[Mapping[str, Any]] = (),
     fill_rows: Sequence[Mapping[str, Any]] = (),
     position_rows: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
+    live_reconciliations = [dict(row) for row in live_reconciliation_rows]
+    if live_reconciliations:
+        return summarize_live_reconciliation_pnl(live_reconciliations)
+
     orders = [dict(row) for row in order_rows]
     fills = [dict(row) for row in fill_rows]
     positions = [dict(row) for row in position_rows]
@@ -199,9 +215,14 @@ def summarize_pnl(
             "net_pnl_dollars": None,
             "realized_pnl_dollars": None,
             "unrealized_pnl_dollars": None,
+            "gross_cost_dollars": None,
             "fees_dollars": None,
+            "payout_dollars": None,
             "unsettled_exposure_dollars": None,
             "filled_contracts": 0,
+            "settled_trade_count": 0,
+            "open_trade_count": 0,
+            "win_rate": None,
             "order_count": 0,
             "fill_count": 0,
             "position_count": 0,
@@ -246,9 +267,14 @@ def summarize_pnl(
         "net_pnl_dollars": _money(net_pnl),
         "realized_pnl_dollars": _money(realized),
         "unrealized_pnl_dollars": _money(unrealized),
+        "gross_cost_dollars": None,
         "fees_dollars": _money(fees),
+        "payout_dollars": None,
         "unsettled_exposure_dollars": _money(unsettled_exposure),
         "filled_contracts": filled_contracts,
+        "settled_trade_count": 0,
+        "open_trade_count": 0,
+        "win_rate": None,
         "order_count": len(orders),
         "fill_count": len(fills),
         "position_count": len(positions),
@@ -259,6 +285,41 @@ def summarize_pnl(
                 key=lambda item: item[0],
             )
         ),
+    }
+
+
+def summarize_live_reconciliation_pnl(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    summary = summarize_live_trade_reconciliations(rows)
+    pnl = dict(summary["pnl"])
+    settlement = dict(summary["settlement"])
+    settlement_state = str(settlement.get("state") or "unavailable")
+    status = "ok" if settlement_state == "complete" else "partial"
+    filled_contracts = _float(pnl.get("filled_contracts")) or 0.0
+    fees_status = "available" if filled_contracts > 0 else "not_applicable"
+    latest = _latest_live_reconciliation_observed_at(rows)
+    return {
+        "status": status,
+        "status_detail": "Canonical live trade reconciliation rows are available."
+        if status == "ok"
+        else "Some live trade settlement rows remain unresolved.",
+        "settlement_state": settlement_state,
+        "fees_status": fees_status,
+        "net_pnl_dollars": _money(_float(pnl.get("net_pnl_dollars"))),
+        "realized_pnl_dollars": _money(_float(pnl.get("realized_pnl_dollars"))),
+        "unrealized_pnl_dollars": None,
+        "gross_cost_dollars": _money(_float(pnl.get("gross_cost_dollars"))),
+        "fees_dollars": _money(_float(pnl.get("fees_dollars"))),
+        "payout_dollars": _money(_float(pnl.get("payout_dollars"))),
+        "unsettled_exposure_dollars": _money(_float(pnl.get("unsettled_exposure_dollars"))),
+        "filled_contracts": filled_contracts,
+        "settled_trade_count": int(pnl.get("settled_trade_count") or 0),
+        "open_trade_count": int(pnl.get("open_trade_count") or 0),
+        "win_rate": _float(pnl.get("win_rate")) if pnl.get("win_rate") is not None else None,
+        "order_count": len(rows),
+        "fill_count": len([row for row in rows if (_float(row.get("filled_contracts")) or 0) > 0]),
+        "position_count": 0,
+        "latest_observed_at_utc": _iso(latest),
+        "reconciliation_counts": dict(summary["counts"]),
     }
 
 
@@ -384,6 +445,47 @@ def _recent_status_rows(
         limit %s
         """,
         (strategy, limit),
+    )
+    return cursor.fetchall()
+
+
+def _live_reconciliation_rows(
+    cursor: psycopg.Cursor,
+    *,
+    strategy: str,
+    market_series: str,
+    limit: int,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        select
+            live_order_attempt_id,
+            strategy,
+            run_id,
+            live_risk_day,
+            market_ticker,
+            side,
+            filled_contracts,
+            cost_dollars,
+            fees_dollars,
+            market_status,
+            market_result,
+            settlement_status,
+            payout_dollars,
+            net_pnl_dollars,
+            unsettled_exposure_dollars,
+            decision_source,
+            settlement_source,
+            settlement_observed_at,
+            reconciled_at,
+            metadata
+        from live_trade_reconciliations
+        where strategy = %s
+          and (market_ticker = %s or market_ticker like %s)
+        order by reconciled_at desc, live_order_attempt_id desc
+        limit %s
+        """,
+        (strategy, market_series, f"{market_series}-%", limit),
     )
     return cursor.fetchall()
 
@@ -680,6 +782,19 @@ def _latest_observed_at(
     return max(parsed) if parsed else None
 
 
+def _latest_live_reconciliation_observed_at(rows: Sequence[Mapping[str, Any]]) -> datetime | None:
+    timestamps = [
+        _datetime(row.get("reconciled_at")) for row in rows if row.get("reconciled_at")
+    ]
+    timestamps.extend(
+        _datetime(row.get("settlement_observed_at"))
+        for row in rows
+        if row.get("settlement_observed_at")
+    )
+    parsed = [timestamp for timestamp in timestamps if timestamp is not None]
+    return max(parsed) if parsed else None
+
+
 def _overall_data_status(
     execution: Mapping[str, Any],
     pnl: Mapping[str, Any],
@@ -706,7 +821,7 @@ def _data_status_detail(
         return "Latest live run is older than the Performance freshness threshold."
     if status == "partial":
         if execution.get("data_status") == "empty":
-            return "Paper performance rows exist but no recent live run rows are recorded."
+            return "Performance rows exist but no recent live run rows are recorded."
         return str(pnl.get("status_detail") or "Some performance fields are unavailable.")
     return "Performance data is current."
 

--- a/src/alphadb/state/migrations.py
+++ b/src/alphadb/state/migrations.py
@@ -816,6 +816,64 @@ LIVE_RUNTIME_MARKET_CONTEXT_SOURCE = Migration(
 )
 
 
+LIVE_TRADE_RECONCILIATIONS = Migration(
+    version="0018_live_trade_reconciliations",
+    statements=(
+        """
+        create table if not exists live_trade_reconciliations (
+            live_order_attempt_id text primary key references live_order_attempts(live_order_attempt_id),
+            strategy text not null,
+            run_id text,
+            live_risk_day date,
+            market_ticker text not null,
+            side text check (side in ('yes', 'no') or side is null or side = ''),
+            filled_contracts numeric not null default 0 check (filled_contracts >= 0),
+            cost_dollars numeric not null default 0 check (cost_dollars >= 0),
+            fees_dollars numeric not null default 0 check (fees_dollars >= 0),
+            market_status text,
+            market_result text check (
+                market_result in ('yes', 'no') or market_result is null
+            ),
+            settlement_status text not null check (
+                settlement_status in (
+                    'no_fill',
+                    'open',
+                    'settled_win',
+                    'settled_loss',
+                    'settled_flat',
+                    'settlement_unavailable',
+                    'lookup_failed'
+                )
+            ),
+            payout_dollars numeric not null default 0 check (payout_dollars >= 0),
+            net_pnl_dollars numeric not null default 0,
+            unsettled_exposure_dollars numeric not null default 0
+                check (unsettled_exposure_dollars >= 0),
+            decision_source text,
+            settlement_source text,
+            settlement_observed_at timestamptz,
+            reconciled_at timestamptz not null,
+            metadata jsonb not null default '{}'::jsonb,
+            created_at timestamptz not null default now(),
+            updated_at timestamptz not null default now()
+        )
+        """,
+        """
+        create index if not exists live_trade_reconciliations_strategy_reconciled_idx
+        on live_trade_reconciliations(strategy, reconciled_at desc)
+        """,
+        """
+        create index if not exists live_trade_reconciliations_market_idx
+        on live_trade_reconciliations(market_ticker)
+        """,
+        """
+        create index if not exists live_trade_reconciliations_status_idx
+        on live_trade_reconciliations(strategy, settlement_status, reconciled_at desc)
+        """,
+    ),
+)
+
+
 MIGRATIONS: tuple[Migration, ...] = (
     INITIAL_OPERATIONAL_STATE,
     RAW_EVENT_LOG,
@@ -834,4 +892,5 @@ MIGRATIONS: tuple[Migration, ...] = (
     LIVE_ORDER_ATTEMPT_REFRESH_EVIDENCE,
     BRTI_LATEST_CONTEXT,
     LIVE_RUNTIME_MARKET_CONTEXT_SOURCE,
+    LIVE_TRADE_RECONCILIATIONS,
 )

--- a/tests/test_kalshi_rest_collector.py
+++ b/tests/test_kalshi_rest_collector.py
@@ -75,7 +75,7 @@ def test_collector_persists_status_and_recent_errors() -> None:
     summary = collector.collect(
         series="KXBTC15M",
         max_markets=1,
-        now=datetime(2026, 5, 31, 21, 12, tzinfo=UTC),
+        now=datetime.now(UTC),
     )
     recent_runs = collector.run_store.recent_runs(limit=1000)
     current_run = next(

--- a/tests/test_live_settlement.py
+++ b/tests/test_live_settlement.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from alphadb.config import settings_from_env
+from alphadb.live_orders import LiveOrderAttempt, LiveOrderRepository
+from alphadb.live_settlement import (
+    MarketResultObservation,
+    LiveTradeReconciliationRepository,
+    reconcile_live_order_attempt,
+    reconcile_live_settlements,
+    summarize_live_trade_reconciliations,
+)
+from alphadb.performance import build_performance_summary
+from alphadb.state.repository import OperationalStateRepository
+
+
+NOW = datetime(2026, 6, 9, 17, 30, tzinfo=UTC)
+
+
+class FakeMarketResultClient:
+    def __init__(self, observations: dict[str, MarketResultObservation]):
+        self.observations = observations
+        self.calls: list[str] = []
+
+    def get_market_result(self, *, ticker, settings, observed_at):
+        self.calls.append(ticker)
+        observation = self.observations[ticker]
+        return MarketResultObservation(
+            market_ticker=observation.market_ticker,
+            status=observation.status,
+            result=observation.result,
+            source=observation.source,
+            observed_at=observed_at,
+            metadata=observation.metadata,
+        )
+
+
+def repository_or_skip() -> OperationalStateRepository:
+    repository = OperationalStateRepository(settings_from_env().database_url)
+    try:
+        with repository.connect() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("select 1")
+                cursor.fetchone()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    repository.apply_migrations()
+    return repository
+
+
+def test_reconcile_live_order_attempt_settles_public_win_with_actual_economics() -> None:
+    row = reconcile_live_order_attempt(
+        {
+            "live_order_attempt_id": "live_order_win",
+            "strategy": "fair_value_live",
+            "market_ticker": "KXBTC15M-WIN",
+            "intended_side": "yes",
+            "intended_price_dollars": 0.91,
+            "fill_count": 2,
+            "request_payload": {
+                "metadata": {
+                    "run_id": "fv_live_20260609T173000Z",
+                    "market_context_source": "brti_primary",
+                }
+            },
+            "response_payload": {
+                "order": {
+                    "taker_fill_cost_dollars": 1.80,
+                    "taker_fees_dollars": 0.02,
+                }
+            },
+            "status": "accepted",
+        },
+        market_result=MarketResultObservation(
+            market_ticker="KXBTC15M-WIN",
+            status="finalized",
+            result="yes",
+            observed_at=NOW,
+        ),
+        reconciled_at=NOW,
+    )
+
+    assert row["settlement_status"] == "settled_win"
+    assert row["payout_dollars"] == 2.0
+    assert row["net_pnl_dollars"] == pytest.approx(0.18)
+    assert row["decision_source"] == "brti_primary"
+    assert row["settlement_source"] == "kalshi_public_market_api"
+    assert row["metadata"]["cost_source"] == "response_payload.actual_cost"
+    assert row["metadata"]["fees_source"] == "response_payload.actual_fees"
+
+
+def test_reconcile_live_order_attempt_covers_loss_no_fill_open_and_lookup_failure() -> None:
+    loss = reconcile_live_order_attempt(
+        attempt("loss", side="yes", fill_count=1, price=0.4),
+        market_result=MarketResultObservation(
+            market_ticker="KXBTC15M-LOSS",
+            status="finalized",
+            result="no",
+            observed_at=NOW,
+        ),
+        reconciled_at=NOW,
+    )
+    no_fill = reconcile_live_order_attempt(
+        attempt("none", side="no", fill_count=0, price=0.7),
+        market_result=None,
+        reconciled_at=NOW,
+    )
+    open_row = reconcile_live_order_attempt(
+        attempt("open", side="yes", fill_count=1, price=0.4),
+        market_result=MarketResultObservation(
+            market_ticker="KXBTC15M-OPEN",
+            status="active",
+            result=None,
+            observed_at=NOW,
+        ),
+        reconciled_at=NOW,
+    )
+    failed = reconcile_live_order_attempt(
+        attempt("failed", side="yes", fill_count=1, price=0.4),
+        market_result=MarketResultObservation(
+            market_ticker="KXBTC15M-FAILED",
+            status="unknown",
+            result=None,
+            observed_at=NOW,
+            metadata={"error": "HTTPError: 502"},
+        ),
+        reconciled_at=NOW,
+    )
+
+    assert loss["settlement_status"] == "settled_loss"
+    assert loss["payout_dollars"] == 0.0
+    assert loss["net_pnl_dollars"] < 0
+    assert no_fill["settlement_status"] == "no_fill"
+    assert no_fill["net_pnl_dollars"] == 0.0
+    assert no_fill["unsettled_exposure_dollars"] == 0.0
+    assert open_row["settlement_status"] == "open"
+    assert open_row["unsettled_exposure_dollars"] > 0
+    assert failed["settlement_status"] == "lookup_failed"
+    assert failed["metadata"]["lookup_error"] == "HTTPError: 502"
+
+
+def test_reconcile_live_order_attempt_uses_partial_fill_and_records_fallbacks() -> None:
+    row = reconcile_live_order_attempt(
+        {
+            **attempt("partial", side="no", fill_count=0.5, price=0.6),
+            "intended_quantity": 10,
+        },
+        market_result=MarketResultObservation(
+            market_ticker="KXBTC15M-PARTIAL",
+            status="active",
+            result=None,
+            observed_at=NOW,
+        ),
+        reconciled_at=NOW,
+    )
+
+    assert row["filled_contracts"] == 0.5
+    assert row["cost_dollars"] == pytest.approx(0.3)
+    assert row["fees_dollars"] == pytest.approx(0.0084)
+    assert row["unsettled_exposure_dollars"] == pytest.approx(0.3084)
+    assert row["metadata"]["cost_source"] == "fallback_intended_price_times_fill"
+    assert row["metadata"]["fees_source"] == "fallback_taker_fee_assumption"
+
+
+def test_live_reconciliation_summary_and_performance_prefer_canonical_rows() -> None:
+    rows = [
+        reconcile_live_order_attempt(
+            attempt("win", side="yes", fill_count=2, price=0.9),
+            market_result=MarketResultObservation(
+                market_ticker="KXBTC15M-WIN",
+                status="finalized",
+                result="yes",
+                observed_at=NOW,
+            ),
+            reconciled_at=NOW,
+        ),
+        reconcile_live_order_attempt(
+            attempt("open", side="no", fill_count=1, price=0.4),
+            market_result=MarketResultObservation(
+                market_ticker="KXBTC15M-OPEN",
+                status="active",
+                result=None,
+                observed_at=NOW,
+            ),
+            reconciled_at=NOW,
+        ),
+        reconcile_live_order_attempt(
+            attempt("none", side="yes", fill_count=0, price=0.5),
+            market_result=None,
+            reconciled_at=NOW,
+        ),
+    ]
+
+    summary = summarize_live_trade_reconciliations(rows, generated_at=NOW)
+    performance = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+        live_reconciliation_rows=rows,
+    )
+
+    assert summary["pnl"]["settled_trade_count"] == 1
+    assert summary["pnl"]["open_trade_count"] == 1
+    assert summary["pnl"]["no_fill_count"] == 1
+    assert summary["settlement"]["state"] == "partial"
+    assert performance["pnl"]["status"] == "partial"
+    assert performance["pnl"]["settlement_state"] == "partial"
+    assert performance["pnl"]["gross_cost_dollars"] > 0
+    assert performance["pnl"]["payout_dollars"] == 2.0
+    assert performance["pnl"]["win_rate"] == 1.0
+
+
+def test_brti_primary_live_smoke_needs_no_manual_lookup_after_reconciliation() -> None:
+    row = reconcile_live_order_attempt(
+        {
+            **attempt("brti", side="no", fill_count=10, price=0.999),
+            "request_payload": {
+                "metadata": {
+                    "run_id": "fv_live_20260609T173000Z",
+                    "market_context_source": "brti_primary",
+                }
+            },
+        },
+        market_result=MarketResultObservation(
+            market_ticker="KXBTC15M-BRTI",
+            status="finalized",
+            result="no",
+            observed_at=NOW,
+        ),
+        reconciled_at=NOW,
+    )
+    performance = build_performance_summary(
+        strategy="fair_value_live",
+        market_series="KXBTC15M",
+        generated_at=NOW,
+        live_reconciliation_rows=[row],
+    )
+
+    assert row["decision_source"] == "brti_primary"
+    assert row["settlement_status"] == "settled_win"
+    assert row["metadata"]["market_result_observation"]["source"] == "kalshi_public_market_api"
+    assert performance["pnl"]["status"] == "ok"
+    assert performance["pnl"]["realized_pnl_dollars"] > 0
+    assert performance["pnl"]["unsettled_exposure_dollars"] == 0.0
+
+
+def test_reconcile_live_settlements_is_idempotent_scoped_and_caches_market_results() -> None:
+    repository = repository_or_skip()
+    strategy = f"settlement_test_{uuid4().hex[:8]}"
+    other_strategy = f"settlement_other_{uuid4().hex[:8]}"
+    risk_day = date(2026, 6, 9)
+    live_orders = LiveOrderRepository(repository.database_url)
+    first = live_orders.persist(
+        live_attempt("first", strategy=strategy, ticker="KXBTC15M-BATCH", risk_day=risk_day)
+    )
+    second = live_orders.persist(
+        live_attempt("second", strategy=strategy, ticker="KXBTC15M-BATCH", risk_day=risk_day)
+    )
+    failed = live_orders.persist(
+        live_attempt("failed", strategy=strategy, ticker="KXBTC15M-FAIL", risk_day=risk_day)
+    )
+    live_orders.persist(
+        live_attempt("other", strategy=other_strategy, ticker="KXBTC15M-BATCH", risk_day=risk_day)
+    )
+    client = FakeMarketResultClient(
+        {
+            "KXBTC15M-BATCH": MarketResultObservation(
+                market_ticker="KXBTC15M-BATCH",
+                status="finalized",
+                result="yes",
+            ),
+            "KXBTC15M-FAIL": MarketResultObservation(
+                market_ticker="KXBTC15M-FAIL",
+                status="unknown",
+                result=None,
+                metadata={"error": "timeout"},
+            ),
+        }
+    )
+
+    first_summary = reconcile_live_settlements(
+        database_url=repository.database_url,
+        settings=settings_from_env(),
+        strategy=strategy,
+        live_risk_day=risk_day,
+        market_client=client,
+        reconciled_at=NOW,
+    )
+    second_summary = reconcile_live_settlements(
+        database_url=repository.database_url,
+        settings=settings_from_env(),
+        strategy=strategy,
+        live_risk_day=risk_day,
+        market_client=client,
+        reconciled_at=NOW,
+    )
+    rows = LiveTradeReconciliationRepository(repository.database_url).recent_rows(
+        strategy=strategy,
+        limit=10,
+    )
+
+    assert first.live_order_attempt_id in {row["live_order_attempt_id"] for row in rows}
+    assert second.live_order_attempt_id in {row["live_order_attempt_id"] for row in rows}
+    assert failed.live_order_attempt_id in {row["live_order_attempt_id"] for row in rows}
+    assert len(rows) == 3
+    assert first_summary["lookup_count"] == 2
+    assert second_summary["lookup_count"] == 2
+    assert client.calls.count("KXBTC15M-BATCH") == 2
+    assert client.calls.count("KXBTC15M-FAIL") == 2
+    assert first_summary["counts"]["settled_win"] == 2
+    assert first_summary["counts"]["lookup_failed"] == 1
+
+
+def attempt(
+    suffix: str,
+    *,
+    side: str,
+    fill_count: float,
+    price: float,
+) -> dict:
+    ticker = f"KXBTC15M-{suffix.upper()}"
+    return {
+        "live_order_attempt_id": f"live_order_{suffix}",
+        "strategy": "fair_value_live",
+        "market_ticker": ticker,
+        "intended_side": side,
+        "intended_price_dollars": price,
+        "fill_count": fill_count,
+        "runtime_mode": "gated-live",
+        "status": "accepted",
+        "request_payload": {
+            "ticker": ticker,
+            "side": "bid" if side == "yes" else "ask",
+            "price": price if side == "yes" else 1.0 - price,
+        },
+        "response_payload": {"fill_count": str(fill_count)},
+    }
+
+
+def live_attempt(
+    suffix: str,
+    *,
+    strategy: str,
+    ticker: str,
+    risk_day: date,
+) -> LiveOrderAttempt:
+    return LiveOrderAttempt(
+        live_order_attempt_id=f"live_order_{suffix}_{uuid4().hex[:8]}",
+        order_intent_id=None,
+        risk_decision_id=None,
+        strategy=strategy,
+        live_risk_day=risk_day,
+        reservation_id=f"res_{suffix}_{uuid4().hex[:8]}",
+        market_ticker=ticker,
+        client_order_id=f"client_{suffix}_{uuid4().hex[:8]}",
+        intended_side="yes",
+        intended_price_dollars=0.9,
+        intended_quantity=1,
+        intended_max_loss_dollars=0.91,
+        runtime_mode="gated-live",
+        status="accepted",
+        guard_reason=None,
+        request_payload={
+            "ticker": ticker,
+            "side": "bid",
+            "price": "0.9000",
+            "metadata": {"market_context_source": "brti_primary"},
+        },
+        response_payload={"fill_count": "1.00"},
+        submitted_at=NOW,
+        exchange_order_id=f"ord_{suffix}",
+        exchange_status="accepted",
+        exchange_response_at=NOW,
+        fill_count=1,
+        remaining_count=0,
+    )


### PR DESCRIPTION
## Summary

Adds the Live Settlement P&L Materializer from ALP-291:

- Creates canonical `live_trade_reconciliations` Operational State rows keyed by live order attempt.
- Adds deterministic live settlement/P&L calculation for wins, losses, no-fills, open markets, lookup failures, partial fills, and cost/fee fallbacks.
- Adds `alphadb-live-orders reconcile-settlement` for strategy-scoped reconciliation.
- Updates the performance summary path to prefer canonical live reconciliation rows for live P&L, exposure, fees, payout, filled contracts, settlement counts, and win rate.
- Includes the ALP-291 PRD in `docs/prd/` for implementation context.

## Notes

BRTI remains decision provenance only. Settlement P&L is source-agnostic and uses public Kalshi market-result observations through an isolated client interface.

I also made one small collector test robustness fix: the test now uses a current timestamp so `recent_runs(limit=1000)` does not depend on stale rows accumulated in a persistent local test database.

## Validation

- `.venv/bin/pytest` - 345 passed, 22 warnings
- `.venv/bin/ruff check src/alphadb/live_settlement.py src/alphadb/live_orders.py src/alphadb/performance.py src/alphadb/state/migrations.py tests/test_live_settlement.py tests/test_kalshi_rest_collector.py`
- `git diff --check`
- `.venv/bin/alphadb-repo-hygiene` - pass for public Git state; local ignored/untracked warnings remain

`pre-commit` is installed, but this checkout does not have `.pre-commit-config.yaml`, so there was no hook config to run.