### PR TITLE
[codex] Add deployment intent worker tracer bullet

### DIFF
--- a/docs/agents/skills/alphadb-aws-deploy-operator/SKILL.md
+++ b/docs/agents/skills/alphadb-aws-deploy-operator/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: alphadb-aws-deploy-operator
+description: Use for AlphaDB AWS deployment management: Cockpit deploys, deployment intents, alphadb-deploy plan/apply, release-check, rollout, rollback, deployment worker evidence, and Linear deployment ticket updates.
+metadata:
+  short-description: Operate AlphaDB AWS deploys
+---
+
+# AlphaDB AWS Deploy Operator
+
+Use this repo-specific skill when working on AlphaDB AWS deployment, Cockpit
+deployment, deployment intents, release checks, rollout/rollback, or deployment
+Linear tickets.
+
+## Required Reading
+
+Before acting, read only the relevant sections of:
+
+- `CONTEXT.md`
+- `docs/deployment/aws-dashboard.md`
+- `docs/adr/0004-aws-release-discipline.md`
+- `docs/adr/0005-cockpit-deployment-authority.md`
+- `deploy/aws/deployment-profile.example.yaml`
+
+For implementation work, also inspect the current code around:
+
+- `src/alphadb/aws_deploy.py`
+- `src/alphadb/deploy.py`
+- `src/alphadb/deployment_intents.py`
+- `src/alphadb/deployment_worker.py`
+
+## Mode Selection
+
+Pick the narrowest mode that satisfies the request:
+
+- `audit`: read-only inspect docs, manifests, AWS evidence, code, or Linear state.
+- `plan`: run `alphadb-deploy aws plan`; do not mutate AWS.
+- `validate`: run focused tests, Docker builds, syntax checks, and plan dry runs.
+- `apply`: run `alphadb-deploy aws apply` only after explicit user approval.
+- `rollback`: use deployment manifests, previous task definitions, images, and
+  schedule state; ask before mutation.
+- `publish`: commit, push, open PR, and update Linear only after validation.
+
+## Operating Rules
+
+- Prefer `alphadb-deploy aws plan|apply`.
+- Treat fallback scripts under `deploy/aws/` as recovery tools, not the primary path.
+- Never invent default VPCs, subnets, AWS accounts, secret names, or raw secrets.
+- Never put AWS credentials, database URLs, private keys, or raw secret values in
+  deployment intents, manifests, PRs, issues, or docs.
+- Cockpit may be broadly permissive for the single-operator MVP per ADR 0005,
+  but AWS execution stays server-side through AlphaDB API, Operational State,
+  and a deployment worker.
+- Deploying code and enabling live authority are distinct intent fields, even
+  when the MVP requests both in one confirmed action.
+- Do not mutate real AWS unless the user explicitly asks for apply/rollback.
+- Do not mark Linear deployment tickets done without merge/deploy evidence.
+
+## Validation Defaults
+
+For release-discipline or deployment-intent changes, prefer the lightest useful
+set:
+
+```bash
+.venv/bin/pytest tests/test_aws_deploy_orchestrator.py tests/test_deploy.py -q
+.venv/bin/pytest tests/test_deployment_intents.py tests/test_deployment_worker.py -q
+.venv/bin/ruff check .
+```
+
+Add broader checks when Dockerfiles, Next.js, CloudFormation, or public Cockpit
+behavior changes:
+
+```bash
+pnpm build
+docker build --platform linux/arm64 -t alphadb-validate:runtime .
+docker build --platform linux/arm64 -t alphadb-validate:cockpit -f apps/dashboard/Dockerfile apps/dashboard
+bash -n deploy/aws/deploy-cockpit-stack.sh
+.venv/bin/alphadb-deploy aws plan --profile deploy/aws/deployment-profile.example.yaml --surfaces cockpit --skip-aws-read
+```
+
+If `pre-commit run --all-files` is unavailable or the repo has no
+`.pre-commit-config.yaml`, report that explicitly.
+
+## Handoff
+
+Always summarize:
+
+- selected mode and whether AWS was mutated
+- surfaces involved
+- deployment intent ids, manifest paths, and evidence status
+- validation commands and results
+- rollback pointers when available
+- Linear tickets or PRs updated

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -29,6 +29,10 @@ from alphadb.dashboard.skills import (
     terminal_response,
 )
 from alphadb.dashboard.strategy import DashboardStrategyRepository, compile_strategy_brief
+from alphadb.deployment_intents import (
+    DeploymentIntentRepository,
+    deployment_intent_kwargs_from_payload,
+)
 from alphadb.health import HealthReport, collect_health
 from alphadb.live_runtime import (
     EXPENSIVE_YES_LIVE_STRATEGY,
@@ -53,6 +57,7 @@ StrategyRepositoryFactory = Callable[[str], DashboardStrategyRepository]
 DataExplorerRepositoryFactory = Callable[[str], DashboardDataExplorerRepository]
 LabRepositoryFactory = Callable[[str], DashboardLabRepository]
 PerformanceRepositoryFactory = Callable[[str], PerformanceSummaryRepository]
+DeploymentIntentRepositoryFactory = Callable[[str], DeploymentIntentRepository]
 HealthCollector = Callable[[Settings], HealthReport]
 PortfolioBalanceProvider = Callable[[Settings], Mapping[str, Any]]
 LIVE_DASHBOARD_STRATEGIES = (FAIR_VALUE_LIVE_STRATEGY, EXPENSIVE_YES_LIVE_STRATEGY)
@@ -72,6 +77,9 @@ class DashboardService:
     )
     lab_repository_factory: LabRepositoryFactory = DashboardLabRepository
     performance_repository_factory: PerformanceRepositoryFactory = PerformanceSummaryRepository
+    deployment_intent_repository_factory: DeploymentIntentRepositoryFactory = (
+        DeploymentIntentRepository
+    )
     health_collector: HealthCollector = collect_health
     portfolio_balance_provider: PortfolioBalanceProvider = cached_portfolio_balance_payload
 
@@ -351,6 +359,36 @@ class DashboardService:
     def capabilities(self) -> dict[str, Any]:
         return capabilities_payload()
 
+    def create_deployment_intent(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        repository = self._deployment_intent_repository()
+        intent = repository.create_intent(**deployment_intent_kwargs_from_payload(payload))
+        return {"intent": intent.as_dict()}
+
+    def list_deployment_intents(self, *, limit: int = 50) -> dict[str, Any]:
+        repository = self._deployment_intent_repository()
+        return {
+            "intents": [intent.as_dict() for intent in repository.list_intents(limit=limit)]
+        }
+
+    def get_deployment_intent(self, deployment_intent_id: str) -> dict[str, Any]:
+        return {
+            "intent": self._deployment_intent_repository()
+            .get_intent(deployment_intent_id)
+            .as_dict()
+        }
+
+    def cancel_deployment_intent(
+        self,
+        deployment_intent_id: str,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        intent = self._deployment_intent_repository().cancel_intent(
+            deployment_intent_id,
+            actor=str(payload.get("actor") or "dashboard"),
+            reason=str(payload.get("reason") or ""),
+        )
+        return {"intent": intent.as_dict()}
+
     def ask_agent(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         skill, params = classify_terminal_request(payload)
         note = _optional_text(params.pop("note", None))
@@ -388,6 +426,9 @@ class DashboardService:
 
     def _lab_repository(self) -> DashboardLabRepository:
         return self.lab_repository_factory(self.settings.database_url)
+
+    def _deployment_intent_repository(self) -> DeploymentIntentRepository:
+        return self.deployment_intent_repository_factory(self.settings.database_url)
 
 
 def market_context_payload(
@@ -1031,6 +1072,18 @@ def make_handler(service: DashboardService) -> type[BaseHTTPRequestHandler]:
                 if path == "/api/capabilities":
                     self._json_ok(service.capabilities())
                     return
+                if path == "/api/deployment/intents":
+                    self._json_ok(
+                        service.list_deployment_intents(
+                            limit=_query_int(query, "limit", 50)
+                        )
+                    )
+                    return
+                if path.startswith("/api/deployment/intents/"):
+                    parts = _path_parts(path)
+                    if len(parts) == 4:
+                        self._json_ok(service.get_deployment_intent(parts[3]))
+                        return
                 self._json_error("not_found", status=HTTPStatus.NOT_FOUND)
             except Exception as exc:
                 self._json_error(str(exc), code=_error_code(exc), status=_error_status(exc))
@@ -1061,6 +1114,14 @@ def make_handler(service: DashboardService) -> type[BaseHTTPRequestHandler]:
             if path == "/api/live/reset-daily-limits":
                 self._json_ok(service.reset_daily_limits(payload))
                 return
+            if path == "/api/deployment/intents":
+                self._json_ok(service.create_deployment_intent(payload), status=HTTPStatus.ACCEPTED)
+                return
+            if path.startswith("/api/deployment/intents/"):
+                parts = _path_parts(path)
+                if len(parts) == 5 and parts[4] == "cancel":
+                    self._json_ok(service.cancel_deployment_intent(parts[3], payload))
+                    return
             self._json_error("not_found", status=HTTPStatus.NOT_FOUND)
 
         def _json(

--- a/src/alphadb/deploy.py
+++ b/src/alphadb/deploy.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import socket
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
 from alphadb.aws_deploy import add_aws_deploy_parser, run_aws_deployment_command
 from alphadb.config import Settings, settings_from_env
 from alphadb.dashboard.auth import DashboardAuthConfig
+from alphadb.deployment_intents import DeploymentIntentRepository
+from alphadb.deployment_worker import DeploymentIntentWorker
 from alphadb.health import HealthReport, collect_health
 from alphadb.live_runtime import LiveRuntimeConfigRepository
 from alphadb.markets.registry import default_market_registry
@@ -225,6 +229,13 @@ def build_parser() -> argparse.ArgumentParser:
     aws = subparsers.add_parser("aws", help="Plan or apply coordinated AWS deployment surfaces")
     add_aws_deploy_parser(aws)
 
+    worker = subparsers.add_parser(
+        "deployment-worker",
+        help="Claim one deployment intent and record dry-run plan evidence",
+    )
+    worker.add_argument("--worker-id", default=None)
+    worker.add_argument("--manifest-root", default="artifacts/aws-deployments")
+
     subparsers.add_parser("migrate", help="Apply operational-state migrations")
 
     release = subparsers.add_parser(
@@ -277,6 +288,15 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     settings = settings_from_env()
     repository = OperationalStateRepository(settings.database_url)
+
+    if args.command == "deployment-worker":
+        intent_repository = DeploymentIntentRepository(settings.database_url)
+        result = DeploymentIntentWorker(
+            intent_repository,
+            manifest_root=Path(args.manifest_root),
+        ).run_once(worker_id=args.worker_id or f"deployment-worker-{socket.gethostname()}")
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+        return 1 if result.status == "failed" else 0
 
     if args.command == "migrate":
         applied = repository.apply_migrations()

--- a/src/alphadb/deployment_intents.py
+++ b/src/alphadb/deployment_intents.py
@@ -1,0 +1,469 @@
+"""Deployment intent records for Cockpit-driven AWS deployment control."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from alphadb.state.repository import OperationalStateRepository
+
+DEPLOYMENT_INTENT_SCHEMA_VERSION = "alphadb.deployment_intent.v1"
+DEFAULT_DEPLOYMENT_PROFILE_PATH = "deploy/aws/deployment-profile.example.yaml"
+INTENT_STATUSES = {"pending", "planning", "planned", "failed", "canceled"}
+FINAL_INTENT_STATUSES = {"planned", "failed", "canceled"}
+CREATE_INTENT_FIELDS = {
+    "actor",
+    "source",
+    "reason",
+    "profile_path",
+    "profile_reference",
+    "surfaces",
+    "requested_surfaces",
+    "build_policy",
+    "schedule_policy",
+    "live_authority",
+    "confirmation",
+    "image_identities",
+    "rollback_pointers",
+    "metadata",
+}
+FORBIDDEN_SECRET_KEYS = {
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "database_url",
+    "kalshi_api_key_id",
+    "kalshi_private_key_pem",
+    "password",
+    "private_key",
+    "secret_value",
+}
+FORBIDDEN_SECRET_STRINGS = (
+    "-----BEGIN PRIVATE KEY-----",
+    "-----BEGIN RSA PRIVATE KEY-----",
+    "postgresql://",
+    "AWS_SECRET_ACCESS_KEY",
+)
+
+
+@dataclass(frozen=True)
+class DeploymentIntent:
+    deployment_intent_id: str
+    status: str
+    actor: str
+    source: str
+    reason: str
+    profile_path: str
+    requested_surfaces: tuple[str, ...]
+    build_policy: dict[str, Any]
+    schedule_policy: dict[str, Any]
+    live_authority: dict[str, Any]
+    confirmation: dict[str, Any]
+    image_identities: dict[str, Any]
+    evidence: dict[str, Any]
+    rollback_pointers: dict[str, Any]
+    metadata: dict[str, Any]
+    error: dict[str, Any]
+    claimed_by: str | None
+    created_at: datetime
+    updated_at: datetime
+    claimed_at: datetime | None
+    completed_at: datetime | None
+    canceled_at: datetime | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": DEPLOYMENT_INTENT_SCHEMA_VERSION,
+            "deployment_intent_id": self.deployment_intent_id,
+            "status": self.status,
+            "actor": self.actor,
+            "source": self.source,
+            "reason": self.reason,
+            "profile_path": self.profile_path,
+            "requested_surfaces": list(self.requested_surfaces),
+            "build_policy": self.build_policy,
+            "schedule_policy": self.schedule_policy,
+            "live_authority": self.live_authority,
+            "confirmation": self.confirmation,
+            "image_identities": self.image_identities,
+            "evidence": self.evidence,
+            "rollback_pointers": self.rollback_pointers,
+            "metadata": self.metadata,
+            "error": self.error,
+            "claimed_by": self.claimed_by,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "claimed_at": self.claimed_at.isoformat() if self.claimed_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "canceled_at": self.canceled_at.isoformat() if self.canceled_at else None,
+        }
+
+
+class DeploymentIntentRepository:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def apply_migrations(self) -> list[str]:
+        return OperationalStateRepository(self.database_url).apply_migrations()
+
+    def create_intent(
+        self,
+        *,
+        actor: str,
+        reason: str,
+        requested_surfaces: Sequence[str],
+        source: str = "cockpit",
+        profile_path: str = DEFAULT_DEPLOYMENT_PROFILE_PATH,
+        build_policy: Mapping[str, Any] | None = None,
+        schedule_policy: Mapping[str, Any] | None = None,
+        live_authority: Mapping[str, Any] | None = None,
+        confirmation: Mapping[str, Any] | None = None,
+        image_identities: Mapping[str, Any] | None = None,
+        rollback_pointers: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        deployment_intent_id: str | None = None,
+    ) -> DeploymentIntent:
+        actor = _required_text(actor, "actor")
+        reason = _required_text(reason, "reason")
+        source = _required_text(source, "source")
+        profile_path = _required_text(profile_path, "profile_path")
+        surfaces = _surface_tuple(requested_surfaces)
+        confirmation_payload = dict(confirmation or {})
+        if confirmation_payload.get("confirmed") is not True:
+            raise ValueError("deployment intent requires confirmation.confirmed=true")
+        payloads = {
+            "build_policy": dict(build_policy or {}),
+            "schedule_policy": dict(schedule_policy or {}),
+            "live_authority": dict(live_authority or {}),
+            "confirmation": confirmation_payload,
+            "image_identities": dict(image_identities or {}),
+            "rollback_pointers": dict(rollback_pointers or {}),
+            "metadata": dict(metadata or {}),
+        }
+        _assert_no_raw_secret_values(payloads)
+        intent_id = deployment_intent_id or f"deploy_intent_{uuid4().hex}"
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    insert into deployment_intents (
+                        deployment_intent_id,
+                        status,
+                        actor,
+                        source,
+                        reason,
+                        profile_path,
+                        requested_surfaces,
+                        build_policy,
+                        schedule_policy,
+                        live_authority,
+                        confirmation,
+                        image_identities,
+                        rollback_pointers,
+                        metadata
+                    )
+                    values (
+                        %s, 'pending', %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s
+                    )
+                    returning *
+                    """,
+                    (
+                        intent_id,
+                        actor,
+                        source,
+                        reason,
+                        profile_path,
+                        Jsonb(list(surfaces)),
+                        Jsonb(payloads["build_policy"]),
+                        Jsonb(payloads["schedule_policy"]),
+                        Jsonb(payloads["live_authority"]),
+                        Jsonb(payloads["confirmation"]),
+                        Jsonb(payloads["image_identities"]),
+                        Jsonb(payloads["rollback_pointers"]),
+                        Jsonb(payloads["metadata"]),
+                    ),
+                )
+                row = cursor.fetchone()
+            connection.commit()
+        return _intent_from_row(row)
+
+    def list_intents(self, *, limit: int = 50) -> list[DeploymentIntent]:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select *
+                    from deployment_intents
+                    order by created_at desc
+                    limit %s
+                    """,
+                    (limit,),
+                )
+                return [_intent_from_row(row) for row in cursor.fetchall()]
+
+    def get_intent(self, deployment_intent_id: str) -> DeploymentIntent:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select *
+                    from deployment_intents
+                    where deployment_intent_id = %s
+                    """,
+                    (deployment_intent_id,),
+                )
+                row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"deployment intent not found: {deployment_intent_id}")
+        return _intent_from_row(row)
+
+    def cancel_intent(
+        self,
+        deployment_intent_id: str,
+        *,
+        actor: str,
+        reason: str = "",
+    ) -> DeploymentIntent:
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    update deployment_intents
+                    set status = 'canceled',
+                        canceled_at = now(),
+                        completed_at = now(),
+                        updated_at = now(),
+                        metadata = metadata || %s::jsonb
+                    where deployment_intent_id = %s
+                        and status = 'pending'
+                    returning *
+                    """,
+                    (
+                        Jsonb(
+                            {
+                                "canceled_by": _required_text(actor, "actor"),
+                                "cancel_reason": str(reason or ""),
+                            }
+                        ),
+                        deployment_intent_id,
+                    ),
+                )
+                row = cursor.fetchone()
+            connection.commit()
+        if row is None:
+            current = self.get_intent(deployment_intent_id)
+            raise ValueError(f"cannot cancel deployment intent in status {current.status}")
+        return _intent_from_row(row)
+
+    def claim_next(self, *, worker_id: str) -> DeploymentIntent | None:
+        worker_id = _required_text(worker_id, "worker_id")
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    select deployment_intent_id
+                    from deployment_intents
+                    where status = 'pending'
+                    order by created_at
+                    for update skip locked
+                    limit 1
+                    """
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    connection.commit()
+                    return None
+                cursor.execute(
+                    """
+                    update deployment_intents
+                    set status = 'planning',
+                        claimed_by = %s,
+                        claimed_at = now(),
+                        updated_at = now()
+                    where deployment_intent_id = %s
+                    returning *
+                    """,
+                    (worker_id, row["deployment_intent_id"]),
+                )
+                claimed = cursor.fetchone()
+            connection.commit()
+        return _intent_from_row(claimed)
+
+    def mark_planned(
+        self,
+        deployment_intent_id: str,
+        *,
+        evidence: Mapping[str, Any],
+        rollback_pointers: Mapping[str, Any] | None = None,
+        image_identities: Mapping[str, Any] | None = None,
+    ) -> DeploymentIntent:
+        return self._mark_terminal(
+            deployment_intent_id,
+            status="planned",
+            evidence=evidence,
+            rollback_pointers=rollback_pointers,
+            image_identities=image_identities,
+            error={},
+        )
+
+    def mark_failed(
+        self,
+        deployment_intent_id: str,
+        *,
+        error: Mapping[str, Any],
+        evidence: Mapping[str, Any] | None = None,
+    ) -> DeploymentIntent:
+        return self._mark_terminal(
+            deployment_intent_id,
+            status="failed",
+            evidence=evidence or {},
+            rollback_pointers=None,
+            image_identities=None,
+            error=error,
+        )
+
+    def _mark_terminal(
+        self,
+        deployment_intent_id: str,
+        *,
+        status: str,
+        evidence: Mapping[str, Any],
+        rollback_pointers: Mapping[str, Any] | None,
+        image_identities: Mapping[str, Any] | None,
+        error: Mapping[str, Any],
+    ) -> DeploymentIntent:
+        if status not in FINAL_INTENT_STATUSES:
+            raise ValueError(f"unsupported terminal deployment intent status: {status}")
+        with psycopg.connect(self.database_url, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    update deployment_intents
+                    set status = %s,
+                        evidence = evidence || %s::jsonb,
+                        rollback_pointers = rollback_pointers || %s::jsonb,
+                        image_identities = image_identities || %s::jsonb,
+                        error = %s::jsonb,
+                        completed_at = now(),
+                        updated_at = now()
+                    where deployment_intent_id = %s
+                        and status = 'planning'
+                    returning *
+                    """,
+                    (
+                        status,
+                        Jsonb(dict(evidence)),
+                        Jsonb(dict(rollback_pointers or {})),
+                        Jsonb(dict(image_identities or {})),
+                        Jsonb(dict(error)),
+                        deployment_intent_id,
+                    ),
+                )
+                row = cursor.fetchone()
+            connection.commit()
+        if row is None:
+            current = self.get_intent(deployment_intent_id)
+            raise ValueError(f"cannot mark deployment intent in status {current.status}")
+        return _intent_from_row(row)
+
+
+def deployment_intent_kwargs_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    extra = set(payload) - CREATE_INTENT_FIELDS
+    if extra:
+        joined = ", ".join(sorted(extra))
+        raise ValueError(f"unsupported deployment intent field(s): {joined}")
+    _assert_no_raw_secret_values(payload)
+    profile_path = payload.get("profile_path") or payload.get("profile_reference")
+    return {
+        "actor": _required_text(payload.get("actor"), "actor"),
+        "source": str(payload.get("source") or "cockpit"),
+        "reason": _required_text(payload.get("reason"), "reason"),
+        "profile_path": str(profile_path or DEFAULT_DEPLOYMENT_PROFILE_PATH),
+        "requested_surfaces": _surface_tuple(
+            payload.get("requested_surfaces") or payload.get("surfaces") or ()
+        ),
+        "build_policy": _mapping(payload.get("build_policy"), "build_policy"),
+        "schedule_policy": _mapping(payload.get("schedule_policy"), "schedule_policy"),
+        "live_authority": _mapping(payload.get("live_authority"), "live_authority"),
+        "confirmation": _mapping(payload.get("confirmation"), "confirmation"),
+        "image_identities": _mapping(payload.get("image_identities"), "image_identities"),
+        "rollback_pointers": _mapping(payload.get("rollback_pointers"), "rollback_pointers"),
+        "metadata": _mapping(payload.get("metadata"), "metadata"),
+    }
+
+
+def _intent_from_row(row: Mapping[str, Any] | None) -> DeploymentIntent:
+    if row is None:
+        raise RuntimeError("deployment intent query did not return a row")
+    return DeploymentIntent(
+        deployment_intent_id=str(row["deployment_intent_id"]),
+        status=str(row["status"]),
+        actor=str(row["actor"]),
+        source=str(row["source"]),
+        reason=str(row["reason"]),
+        profile_path=str(row["profile_path"]),
+        requested_surfaces=tuple(str(item) for item in (row["requested_surfaces"] or [])),
+        build_policy=dict(row["build_policy"] or {}),
+        schedule_policy=dict(row["schedule_policy"] or {}),
+        live_authority=dict(row["live_authority"] or {}),
+        confirmation=dict(row["confirmation"] or {}),
+        image_identities=dict(row["image_identities"] or {}),
+        evidence=dict(row["evidence"] or {}),
+        rollback_pointers=dict(row["rollback_pointers"] or {}),
+        metadata=dict(row["metadata"] or {}),
+        error=dict(row["error"] or {}),
+        claimed_by=row["claimed_by"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        claimed_at=row["claimed_at"],
+        completed_at=row["completed_at"],
+        canceled_at=row["canceled_at"],
+    )
+
+
+def _surface_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError("deployment intent surfaces must be a list of strings")
+    surfaces = tuple(str(item).strip() for item in value if str(item).strip())
+    if not surfaces:
+        raise ValueError("deployment intent must request at least one surface")
+    return surfaces
+
+
+def _mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    return value
+
+
+def _required_text(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"deployment intent requires {name}")
+    return text
+
+
+def _assert_no_raw_secret_values(value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            normalized_key = str(key).lower()
+            if normalized_key in FORBIDDEN_SECRET_KEYS:
+                raise ValueError(f"raw secret field is not allowed in deployment intent: {key}")
+            _assert_no_raw_secret_values(child)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for child in value:
+            _assert_no_raw_secret_values(child)
+    elif isinstance(value, str):
+        for forbidden in FORBIDDEN_SECRET_STRINGS:
+            if forbidden in value:
+                raise ValueError("raw secret value is not allowed in deployment intent")

--- a/src/alphadb/deployment_worker.py
+++ b/src/alphadb/deployment_worker.py
@@ -1,0 +1,153 @@
+"""Server-side worker for backend-mediated deployment intents."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from alphadb.aws_deploy import (
+    ResolvedDeployment,
+    create_deployment_plan,
+    write_deployment_manifest,
+)
+from alphadb.deployment_intents import DeploymentIntent, DeploymentIntentRepository
+
+PlanFactory = Callable[..., ResolvedDeployment]
+ManifestWriter = Callable[..., Path]
+
+
+@dataclass(frozen=True)
+class DeploymentWorkerResult:
+    status: str
+    worker_id: str
+    deployment_intent_id: str | None
+    detail: str
+    intent: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "worker_id": self.worker_id,
+            "deployment_intent_id": self.deployment_intent_id,
+            "detail": self.detail,
+            "intent": self.intent,
+        }
+
+
+class DeploymentIntentWorker:
+    def __init__(
+        self,
+        repository: DeploymentIntentRepository,
+        *,
+        manifest_root: Path,
+        plan_factory: PlanFactory = create_deployment_plan,
+        manifest_writer: ManifestWriter = write_deployment_manifest,
+    ) -> None:
+        self.repository = repository
+        self.manifest_root = manifest_root
+        self.plan_factory = plan_factory
+        self.manifest_writer = manifest_writer
+
+    def run_once(self, *, worker_id: str) -> DeploymentWorkerResult:
+        intent = self.repository.claim_next(worker_id=worker_id)
+        if intent is None:
+            return DeploymentWorkerResult(
+                status="idle",
+                worker_id=worker_id,
+                deployment_intent_id=None,
+                detail="no pending deployment intent",
+            )
+        try:
+            planned = self._execute_plan(intent)
+        except Exception as exc:
+            failed = self.repository.mark_failed(
+                intent.deployment_intent_id,
+                error={
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                    "phase": "plan",
+                    "mutates_aws": False,
+                },
+                evidence={
+                    "mode": "plan",
+                    "mutates_aws": False,
+                    "status": "failed",
+                },
+            )
+            return DeploymentWorkerResult(
+                status="failed",
+                worker_id=worker_id,
+                deployment_intent_id=intent.deployment_intent_id,
+                detail=str(exc),
+                intent=failed.as_dict(),
+            )
+        return DeploymentWorkerResult(
+            status="planned",
+            worker_id=worker_id,
+            deployment_intent_id=planned.deployment_intent_id,
+            detail="deployment plan recorded",
+            intent=planned.as_dict(),
+        )
+
+    def _execute_plan(self, intent: DeploymentIntent) -> DeploymentIntent:
+        build_policy = dict(intent.build_policy)
+        surfaces = list(intent.requested_surfaces)
+        resolved = self.plan_factory(
+            intent.profile_path,
+            surfaces=surfaces,
+            skip_aws_read=True,
+            skip_build=bool(build_policy.get("skip_build", False)),
+            skip_push=bool(build_policy.get("skip_push", False)),
+            force_rebuild=bool(build_policy.get("force_rebuild", False)),
+            skip_migrate=bool(build_policy.get("skip_release_check", False)),
+            skip_smoke=bool(build_policy.get("skip_smoke", False)),
+            skip_service_stability=bool(build_policy.get("skip_service_stability", False)),
+            fair_value_safe_disable=_fair_value_safe_disable(intent.schedule_policy),
+        )
+        manifest_path = self.manifest_writer(
+            resolved,
+            mode="plan",
+            manifest_root=self.manifest_root,
+        )
+        plan = resolved.plan_dict()
+        rollback_pointers = _rollback_pointers_from_plan(plan)
+        evidence = {
+            "mode": "plan",
+            "status": "passed",
+            "mutates_aws": False,
+            "skip_aws_read": True,
+            "manifest_path": str(manifest_path),
+            "deployment_id": resolved.deployment_id,
+            "selected_surfaces": list(resolved.selected_surfaces),
+            "plan": plan,
+        }
+        return self.repository.mark_planned(
+            intent.deployment_intent_id,
+            evidence=evidence,
+            rollback_pointers=rollback_pointers,
+            image_identities=plan.get("images", {}),
+        )
+
+
+def _fair_value_safe_disable(schedule_policy: Mapping[str, Any]) -> bool:
+    fair_value = schedule_policy.get("fair-value") or schedule_policy.get("fair_value")
+    if isinstance(fair_value, Mapping):
+        action = str(fair_value.get("action") or fair_value.get("schedule_state") or "")
+        return action.lower() == "disable"
+    return str(fair_value or "").lower() == "disable"
+
+
+def _rollback_pointers_from_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    observed_stacks = plan.get("observed_stacks")
+    if not isinstance(observed_stacks, Mapping):
+        return {}
+    pointers: dict[str, Any] = {}
+    for surface, stack in observed_stacks.items():
+        if isinstance(stack, Mapping):
+            pointers[str(surface)] = {
+                "previous_stack_outputs": stack.get("outputs") or {},
+                "status": stack.get("status"),
+            }
+    return pointers

--- a/src/alphadb/state/migrations.py
+++ b/src/alphadb/state/migrations.py
@@ -874,6 +874,49 @@ LIVE_TRADE_RECONCILIATIONS = Migration(
 )
 
 
+DEPLOYMENT_INTENTS = Migration(
+    version="0019_deployment_intents",
+    statements=(
+        """
+        create table if not exists deployment_intents (
+            deployment_intent_id text primary key,
+            status text not null check (
+                status in ('pending', 'planning', 'planned', 'failed', 'canceled')
+            ),
+            actor text not null,
+            source text not null,
+            reason text not null,
+            profile_path text not null,
+            requested_surfaces jsonb not null default '[]'::jsonb,
+            build_policy jsonb not null default '{}'::jsonb,
+            schedule_policy jsonb not null default '{}'::jsonb,
+            live_authority jsonb not null default '{}'::jsonb,
+            confirmation jsonb not null default '{}'::jsonb,
+            image_identities jsonb not null default '{}'::jsonb,
+            evidence jsonb not null default '{}'::jsonb,
+            rollback_pointers jsonb not null default '{}'::jsonb,
+            metadata jsonb not null default '{}'::jsonb,
+            error jsonb not null default '{}'::jsonb,
+            claimed_by text,
+            claimed_at timestamptz,
+            completed_at timestamptz,
+            canceled_at timestamptz,
+            created_at timestamptz not null default now(),
+            updated_at timestamptz not null default now()
+        )
+        """,
+        """
+        create index if not exists deployment_intents_status_created_idx
+        on deployment_intents(status, created_at)
+        """,
+        """
+        create index if not exists deployment_intents_actor_created_idx
+        on deployment_intents(actor, created_at desc)
+        """,
+    ),
+)
+
+
 MIGRATIONS: tuple[Migration, ...] = (
     INITIAL_OPERATIONAL_STATE,
     RAW_EVENT_LOG,
@@ -893,4 +936,5 @@ MIGRATIONS: tuple[Migration, ...] = (
     BRTI_LATEST_CONTEXT,
     LIVE_RUNTIME_MARKET_CONTEXT_SOURCE,
     LIVE_TRADE_RECONCILIATIONS,
+    DEPLOYMENT_INTENTS,
 )

--- a/tests/test_dashboard_deployment_api.py
+++ b/tests/test_dashboard_deployment_api.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from typing import Any
+
+import pytest
+
+from alphadb.config import settings_from_env
+from alphadb.dashboard.app import DashboardService, make_handler
+from alphadb.deployment_intents import DeploymentIntent
+
+
+@dataclass
+class FakeDeploymentIntentRepository:
+    intents: dict[str, DeploymentIntent]
+
+    def create_intent(self, **kwargs: Any) -> DeploymentIntent:
+        kwargs.pop("image_identities", None)
+        kwargs.pop("rollback_pointers", None)
+        intent = fake_intent(
+            deployment_intent_id=f"deploy_intent_{len(self.intents) + 1}",
+            status="pending",
+            **kwargs,
+        )
+        self.intents[intent.deployment_intent_id] = intent
+        return intent
+
+    def list_intents(self, *, limit: int = 50) -> list[DeploymentIntent]:
+        return list(self.intents.values())[:limit]
+
+    def get_intent(self, deployment_intent_id: str) -> DeploymentIntent:
+        return self.intents[deployment_intent_id]
+
+    def cancel_intent(
+        self,
+        deployment_intent_id: str,
+        *,
+        actor: str,
+        reason: str = "",
+    ) -> DeploymentIntent:
+        current = self.intents[deployment_intent_id]
+        intent = fake_intent(
+            deployment_intent_id=deployment_intent_id,
+            status="canceled",
+            actor=current.actor,
+            source=current.source,
+            reason=current.reason,
+            profile_path=current.profile_path,
+            requested_surfaces=current.requested_surfaces,
+            build_policy=current.build_policy,
+            schedule_policy=current.schedule_policy,
+            live_authority=current.live_authority,
+            confirmation=current.confirmation,
+            metadata={**current.metadata, "canceled_by": actor, "cancel_reason": reason},
+        )
+        self.intents[deployment_intent_id] = intent
+        return intent
+
+
+def fake_intent(
+    *,
+    deployment_intent_id: str,
+    status: str,
+    actor: str = "sid",
+    source: str = "cockpit",
+    reason: str = "deploy",
+    profile_path: str = "deploy/aws/deployment-profile.example.yaml",
+    requested_surfaces: tuple[str, ...] = ("cockpit",),
+    build_policy: Mapping[str, Any] | None = None,
+    schedule_policy: Mapping[str, Any] | None = None,
+    live_authority: Mapping[str, Any] | None = None,
+    confirmation: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> DeploymentIntent:
+    now = datetime(2026, 6, 9, 12, tzinfo=UTC)
+    return DeploymentIntent(
+        deployment_intent_id=deployment_intent_id,
+        status=status,
+        actor=actor,
+        source=source,
+        reason=reason,
+        profile_path=profile_path,
+        requested_surfaces=requested_surfaces,
+        build_policy=dict(build_policy or {}),
+        schedule_policy=dict(schedule_policy or {}),
+        live_authority=dict(live_authority or {}),
+        confirmation=dict(confirmation or {"confirmed": True}),
+        image_identities={},
+        evidence={},
+        rollback_pointers={},
+        metadata=dict(metadata or {}),
+        error={},
+        claimed_by=None,
+        created_at=now,
+        updated_at=now,
+        claimed_at=None,
+        completed_at=None,
+        canceled_at=now if status == "canceled" else None,
+    )
+
+
+def test_dashboard_service_deployment_intent_methods_validate_and_delegate() -> None:
+    fake_repository = FakeDeploymentIntentRepository({})
+    service = DashboardService(
+        settings=settings_from_env({"DATABASE_URL": "postgresql://example.test/alphadb"}),
+        deployment_intent_repository_factory=lambda _: fake_repository,
+    )
+
+    created = service.create_deployment_intent(
+        {
+            "actor": "sid",
+            "reason": "deploy cockpit",
+            "surfaces": ["cockpit"],
+            "confirmation": {"confirmed": True},
+        }
+    )
+
+    intent_id = created["intent"]["deployment_intent_id"]
+    assert created["intent"]["requested_surfaces"] == ["cockpit"]
+    assert service.list_deployment_intents()["intents"][0]["deployment_intent_id"] == intent_id
+    assert service.get_deployment_intent(intent_id)["intent"]["status"] == "pending"
+    canceled = service.cancel_deployment_intent(
+        intent_id,
+        {"actor": "sid", "reason": "not now"},
+    )
+    assert canceled["intent"]["status"] == "canceled"
+    assert canceled["intent"]["metadata"]["cancel_reason"] == "not now"
+
+    with pytest.raises(ValueError, match="unsupported deployment intent field"):
+        service.create_deployment_intent(
+            {
+                "actor": "sid",
+                "reason": "bad",
+                "surfaces": ["cockpit"],
+                "confirmation": {"confirmed": True},
+                "aws_secret_access_key": "raw-secret",
+            }
+        )
+
+
+def test_dashboard_http_exposes_deployment_intent_endpoints() -> None:
+    fake_repository = FakeDeploymentIntentRepository({})
+    service = DashboardService(
+        settings=settings_from_env({"DATABASE_URL": "postgresql://example.test/alphadb"}),
+        deployment_intent_repository_factory=lambda _: fake_repository,
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(service))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        created = request_json(
+            host,
+            port,
+            "POST",
+            "/api/deployment/intents",
+            {
+                "actor": "sid",
+                "reason": "deploy cockpit",
+                "surfaces": ["cockpit"],
+                "confirmation": {"confirmed": True},
+            },
+        )
+        assert created["status"] == 202
+        intent_id = created["body"]["data"]["intent"]["deployment_intent_id"]
+
+        listed = request_json(host, port, "GET", "/api/deployment/intents")
+        assert listed["status"] == 200
+        assert listed["body"]["data"]["intents"][0]["deployment_intent_id"] == intent_id
+
+        fetched = request_json(host, port, "GET", f"/api/deployment/intents/{intent_id}")
+        assert fetched["body"]["data"]["intent"]["status"] == "pending"
+
+        canceled = request_json(
+            host,
+            port,
+            "POST",
+            f"/api/deployment/intents/{intent_id}/cancel",
+            {"actor": "sid", "reason": "pause"},
+        )
+        assert canceled["body"]["data"]["intent"]["status"] == "canceled"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def request_json(
+    host: str,
+    port: int,
+    method: str,
+    path: str,
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    connection = HTTPConnection(host, port, timeout=5)
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"} if payload is not None else {}
+    connection.request(method, path, body=body, headers=headers)
+    response = connection.getresponse()
+    response_body = json.loads(response.read().decode("utf-8"))
+    connection.close()
+    return {"status": response.status, "body": response_body}

--- a/tests/test_deployment_intents.py
+++ b/tests/test_deployment_intents.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import pytest
+
+from alphadb.config import settings_from_env
+from alphadb.deployment_intents import (
+    DeploymentIntentRepository,
+    deployment_intent_kwargs_from_payload,
+)
+
+
+def repository_or_skip() -> DeploymentIntentRepository:
+    repository = DeploymentIntentRepository(settings_from_env().database_url)
+    try:
+        repository.apply_migrations()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    return repository
+
+
+def intent_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "actor": "sid",
+        "source": "cockpit",
+        "reason": "validate deployment-intent tracer bullet",
+        "profile_path": "deploy/aws/deployment-profile.example.yaml",
+        "surfaces": ["cockpit", "fair-value"],
+        "build_policy": {"skip_build": True, "skip_push": True},
+        "schedule_policy": {"fair-value": {"action": "preserve"}},
+        "live_authority": {"action": "preserve", "strategy": "fair_value_live"},
+        "confirmation": {"confirmed": True, "confirmed_by": "sid"},
+        "rollback_pointers": {"fair-value": {"previous_schedule_state": "DISABLED"}},
+        "metadata": {"source_issue": "ADB-312"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_deployment_intent_repository_persists_lists_and_cancels_pending_intent() -> None:
+    repository = repository_or_skip()
+
+    intent = repository.create_intent(**deployment_intent_kwargs_from_payload(intent_payload()))
+
+    fetched = repository.get_intent(intent.deployment_intent_id)
+    assert fetched.status == "pending"
+    assert fetched.actor == "sid"
+    assert fetched.requested_surfaces == ("cockpit", "fair-value")
+    assert fetched.build_policy["skip_build"] is True
+    assert fetched.confirmation["confirmed"] is True
+    assert fetched.live_authority["strategy"] == "fair_value_live"
+    assert any(
+        item.deployment_intent_id == intent.deployment_intent_id
+        for item in repository.list_intents(limit=20)
+    )
+
+    canceled = repository.cancel_intent(
+        intent.deployment_intent_id,
+        actor="sid",
+        reason="operator changed mind",
+    )
+
+    assert canceled.status == "canceled"
+    assert canceled.canceled_at is not None
+    assert canceled.metadata["canceled_by"] == "sid"
+    assert canceled.metadata["cancel_reason"] == "operator changed mind"
+
+
+def test_deployment_intent_claim_skips_canceled_intents_and_marks_planned() -> None:
+    repository = repository_or_skip()
+    canceled = repository.create_intent(**deployment_intent_kwargs_from_payload(intent_payload()))
+    active = repository.create_intent(
+        **deployment_intent_kwargs_from_payload(intent_payload(actor="agent"))
+    )
+    repository.cancel_intent(canceled.deployment_intent_id, actor="sid")
+
+    claimed = repository.claim_next(worker_id="worker-a")
+    assert claimed is not None
+    assert claimed.deployment_intent_id == active.deployment_intent_id
+    assert claimed.status == "planning"
+    assert claimed.claimed_by == "worker-a"
+    assert claimed.claimed_at is not None
+
+    planned = repository.mark_planned(
+        claimed.deployment_intent_id,
+        evidence={"mode": "plan", "status": "passed"},
+        rollback_pointers={"cockpit": {"status": "unavailable"}},
+        image_identities={"runtime": {"tag": "runtime-test"}},
+    )
+    assert planned.status == "planned"
+    assert planned.evidence["status"] == "passed"
+    assert planned.rollback_pointers["cockpit"]["status"] == "unavailable"
+    assert planned.image_identities["runtime"]["tag"] == "runtime-test"
+
+
+def test_deployment_intent_payload_rejects_raw_secret_values() -> None:
+    with pytest.raises(ValueError, match="unsupported deployment intent field"):
+        deployment_intent_kwargs_from_payload(
+            intent_payload(secrets={"database_url": "postgresql://user:secret@example/db"})
+        )
+
+    with pytest.raises(ValueError, match="raw secret value"):
+        deployment_intent_kwargs_from_payload(
+            intent_payload(metadata={"debug": "postgresql://user:secret@example/db"})
+        )
+
+
+def test_deployment_intent_payload_requires_confirmation() -> None:
+    repository = repository_or_skip()
+    kwargs = deployment_intent_kwargs_from_payload(
+        intent_payload(confirmation={"confirmed": False})
+    )
+
+    with pytest.raises(ValueError, match="confirmation.confirmed=true"):
+        repository.create_intent(**kwargs)

--- a/tests/test_deployment_worker.py
+++ b/tests/test_deployment_worker.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import pytest
+
+from alphadb.config import settings_from_env
+from alphadb.deployment_intents import (
+    DeploymentIntentRepository,
+    deployment_intent_kwargs_from_payload,
+)
+from alphadb.deployment_worker import DeploymentIntentWorker
+
+
+def repository_or_skip() -> DeploymentIntentRepository:
+    repository = DeploymentIntentRepository(settings_from_env().database_url)
+    try:
+        repository.apply_migrations()
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"Postgres is not available: {exc}")
+    return repository
+
+
+def test_deployment_worker_claims_intent_and_records_dry_run_plan_evidence(
+    tmp_path: Path,
+) -> None:
+    repository = repository_or_skip()
+    profile = write_profile(tmp_path)
+    intent = repository.create_intent(
+        **deployment_intent_kwargs_from_payload(
+            {
+                "actor": "sid",
+                "reason": "plan cockpit deploy",
+                "profile_path": str(profile),
+                "surfaces": ["cockpit"],
+                "build_policy": {"skip_build": True, "skip_push": True},
+                "confirmation": {"confirmed": True},
+            }
+        )
+    )
+
+    result = DeploymentIntentWorker(
+        repository,
+        manifest_root=tmp_path / "manifests",
+    ).run_once(worker_id="worker-test")
+
+    assert result.status == "planned"
+    planned = repository.get_intent(intent.deployment_intent_id)
+    assert planned.status == "planned"
+    assert planned.claimed_by == "worker-test"
+    assert planned.evidence["mode"] == "plan"
+    assert planned.evidence["mutates_aws"] is False
+    assert planned.evidence["skip_aws_read"] is True
+    assert planned.evidence["selected_surfaces"] == ["cockpit"]
+    assert Path(planned.evidence["manifest_path"]).exists()
+    assert planned.image_identities["cockpit"]["tag"].startswith("cockpit-")
+
+
+def test_deployment_worker_does_not_claim_canceled_intent(tmp_path: Path) -> None:
+    repository = repository_or_skip()
+    profile = write_profile(tmp_path)
+    intent = repository.create_intent(
+        **deployment_intent_kwargs_from_payload(
+            {
+                "actor": "sid",
+                "reason": "plan cockpit deploy",
+                "profile_path": str(profile),
+                "surfaces": ["cockpit"],
+                "confirmation": {"confirmed": True},
+            }
+        )
+    )
+    repository.cancel_intent(intent.deployment_intent_id, actor="sid")
+
+    result = DeploymentIntentWorker(repository, manifest_root=tmp_path).run_once(
+        worker_id="worker-test"
+    )
+
+    assert result.status == "idle"
+    assert repository.get_intent(intent.deployment_intent_id).status == "canceled"
+
+
+def test_deployment_worker_records_failure_evidence(tmp_path: Path) -> None:
+    repository = repository_or_skip()
+    profile = write_profile(tmp_path)
+    intent = repository.create_intent(
+        **deployment_intent_kwargs_from_payload(
+            {
+                "actor": "sid",
+                "reason": "bad plan",
+                "profile_path": str(profile),
+                "surfaces": ["cockpit"],
+                "confirmation": {"confirmed": True},
+            }
+        )
+    )
+
+    def broken_plan_factory(*_: Any, **__: Any) -> Any:
+        raise RuntimeError("planner exploded")
+
+    result = DeploymentIntentWorker(
+        repository,
+        manifest_root=tmp_path,
+        plan_factory=broken_plan_factory,
+    ).run_once(worker_id="worker-test")
+
+    failed = repository.get_intent(intent.deployment_intent_id)
+    assert result.status == "failed"
+    assert failed.status == "failed"
+    assert failed.error["type"] == "RuntimeError"
+    assert failed.error["phase"] == "plan"
+    assert failed.evidence["mutates_aws"] is False
+
+
+def write_profile(tmp_path: Path) -> Path:
+    payload = {
+        "name": "alphadb-test",
+        "aws": {
+            "profile": "alphadb",
+            "account_id": "123456789012",
+            "region": "us-east-2",
+        },
+        "network": {
+            "vpc_id": "vpc-0123456789abcdef0",
+            "public_subnet_ids": ["subnet-0publica", "subnet-0publicb"],
+            "private_subnet_ids": ["subnet-0privatea", "subnet-0privateb"],
+            "worker_subnet_ids": ["subnet-0privatea", "subnet-0privateb"],
+            "assign_public_ip": "DISABLED",
+        },
+        "secrets": {
+            "database_url_secret_arn": (
+                "arn:aws:secretsmanager:us-east-2:123456789012:secret:database"
+            ),
+            "cockpit_pin_secret_arn": (
+                "arn:aws:secretsmanager:us-east-2:123456789012:secret:pin"
+            ),
+            "cockpit_cookie_secret_arn": (
+                "arn:aws:secretsmanager:us-east-2:123456789012:secret:cookie"
+            ),
+            "kalshi_api_key_id_secret_arn": (
+                "arn:aws:secretsmanager:us-east-2:123456789012:secret:kalshi-key-id"
+            ),
+            "kalshi_private_key_pem_secret_arn": (
+                "arn:aws:secretsmanager:us-east-2:123456789012:secret:kalshi-private-key"
+            ),
+        },
+        "images": {"repository": "alphadb-orchestrated", "platform": "linux/arm64"},
+        "surfaces": {"selected": ["cockpit"]},
+        "cockpit": {
+            "stack_name": "alphadb-cockpit",
+            "service_name": "alphadb-cockpit",
+            "template_file": "deploy/aws/ecs-fargate-dashboard.yaml",
+            "private_namespace_name": "alphadb.local",
+            "runtime_mode": "gated-live",
+            "desired_count": 1,
+        },
+    }
+    path = tmp_path / "deployment-profile.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path


### PR DESCRIPTION
## Summary

- Add Operational State persistence for deployment intents, including explicit surfaces, schedule/live-authority fields, actor/reason/confirmation, evidence, rollback pointers, and status transitions.
- Expose AlphaDB API endpoints to create, list, inspect, and cancel deployment intents.
- Add a server-side `alphadb-deploy deployment-worker` tracer bullet that claims one pending intent, runs a non-mutating dry-run plan path with `skip_aws_read=True`, and records manifest/evidence.
- Add the repo-specific `alphadb-aws-deploy-operator` Codex skill for future AlphaDB AWS deployment management.

## Linear

- ADB-312
- ADB-313

## Validation

- `.venv/bin/pytest tests/test_deployment_intents.py tests/test_dashboard_deployment_api.py tests/test_deployment_worker.py tests/test_aws_deploy_orchestrator.py tests/test_deploy.py -q` -> 37 passed
- `.venv/bin/ruff check .` -> passed
- `.venv/bin/alphadb-repo-hygiene` -> passed for public Git state; local ignored/untracked warnings remain
- `git diff --check` / `git diff --cached --check` -> passed

`pre-commit run --all-files` still cannot run because this repo does not have a `.pre-commit-config.yaml`.

## AWS Safety

No real AWS deploy/apply was run. The worker tracer path records plan evidence only and uses `skip_aws_read=True`.