### PR TITLE
[codex] Fail closed on Postgres authority denial

### DIFF
--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -204,11 +204,15 @@ class FairValueLiveTradingJob:
                     "status_materialization",
                     "artifact_write",
                 )
+                authority_denial_reason = live_run_lock.reason or "live_run_lock_held"
                 return self._materialize_one_cycle_run(
                     run_dir=run_dir,
                     run_id=run_id,
                     generated_at=generated_at,
-                    runtime_config=runtime_config_snapshot(original_config),
+                    runtime_config=runtime_config_snapshot(
+                        original_config,
+                        reason=authority_denial_reason,
+                    ),
                     collected=None,
                     selected_decision=None,
                     selected_row=None,
@@ -221,12 +225,12 @@ class FairValueLiveTradingJob:
                     admission_daily_loss_accounting=empty_live_risk_accounting(
                         generated_at=generated_at,
                         live_risk_timezone=original_config.live_risk_timezone,
-                        reason="live_run_lock_held",
+                        reason=authority_denial_reason,
                     ),
                     daily_loss_accounting=empty_live_risk_accounting(
                         generated_at=generated_at,
                         live_risk_timezone=original_config.live_risk_timezone,
-                        reason="live_run_lock_held",
+                        reason=authority_denial_reason,
                     ),
                     runtime_guard=runtime_guard_with_credential_materialization(
                         settings=settings,
@@ -235,7 +239,7 @@ class FairValueLiveTradingJob:
                     live_run_lock=live_run_lock,
                     timer=timer,
                     require_postgres=False,
-                    materialize_status=False,
+                    materialize_status=should_materialize_live_run_status(live_run_lock),
                 )
 
             with timer.phase("runtime_config"):
@@ -1178,9 +1182,19 @@ class PhaseTimer:
         }
 
 
-def runtime_config_snapshot(config: FairValueLiveTradingJobConfig) -> dict[str, Any]:
+def runtime_config_snapshot(
+    config: FairValueLiveTradingJobConfig,
+    *,
+    reason: str = "live_run_lock_held",
+) -> dict[str, Any]:
+    source = (
+        "not_read_authority_denied"
+        if reason.startswith("live_decision_authority_")
+        else "not_read_lock_held"
+    )
     return {
-        "source": "not_read_lock_held",
+        "source": source,
+        "not_read_reason": reason,
         "strategy": config.strategy,
         "config_id": None,
         "version": None,
@@ -1250,6 +1264,7 @@ def lock_held_attempt(
     live_run_lock: "LiveRunLock",
     strategy: str = FAIR_VALUE_LIVE_STRATEGY,
 ) -> dict[str, Any]:
+    reason = live_run_lock.reason or "live_run_lock_held"
     attempt = {
         "attempt_id": f"{live_run_id_prefix(strategy)}_order_{uuid4().hex[:12]}",
         "run_id": run_id,
@@ -1257,8 +1272,8 @@ def lock_held_attempt(
         "submitted_at": generated_at.isoformat(),
         "market_ticker": "",
         "side": None,
-        "decision": {"decision": "skip", "reason": "live_run_lock_held"},
-        "original_decision": {"decision": "skip", "reason": "live_run_lock_held"},
+        "decision": {"decision": "skip", "reason": reason},
+        "original_decision": {"decision": "skip", "reason": reason},
         "request_payload": {},
         "max_loss_dollars": 0.0,
         "daily_loss_used_before_dollars": 0.0,
@@ -1268,7 +1283,7 @@ def lock_held_attempt(
         "live_run_lock": live_run_lock.as_dict(),
         "attempt_index": 0,
         "status": "skipped",
-        "reason": live_run_lock.reason or "live_run_lock_held",
+        "reason": reason,
     }
     if live_run_lock.backend == "postgres":
         attempt["live_decision_authority_lease"] = live_run_lock.as_dict()
@@ -2017,6 +2032,8 @@ class LiveRunLock:
 
 
 def should_materialize_live_run_status(live_run_lock: LiveRunLock) -> bool:
+    if live_run_lock.backend == "postgres":
+        return True
     return live_run_lock.acquired or live_run_lock.reason != "live_run_lock_held"
 
 
@@ -2090,17 +2107,32 @@ def acquire_postgres_live_decision_authority(
 ) -> LiveRunLock:
     repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
     owner_id = f"{run_id}:{uuid4().hex[:12]}"
-    result = repository.acquire(
-        strategy=strategy,
-        run_id=run_id,
-        owner_id=owner_id,
-        now=generated_at,
-        ttl_seconds=ttl_seconds,
-        metadata={
-            "source": "fair_value_live_report_only",
-            "submit_live_orders": False,
-        },
-    )
+    try:
+        result = repository.acquire(
+            strategy=strategy,
+            run_id=run_id,
+            owner_id=owner_id,
+            now=generated_at,
+            ttl_seconds=ttl_seconds,
+            metadata={
+                "source": "fair_value_live_report_only",
+                "submit_live_orders": False,
+            },
+        )
+    except Exception as exc:
+        return LiveRunLock(
+            backend="postgres",
+            acquired=False,
+            token="",
+            strategy=strategy,
+            run_id=run_id,
+            reason="live_decision_authority_unavailable",
+            existing={
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            },
+            owner_id=owner_id,
+        )
     lease = result.lease or result.current_lease
     if result.acquired and lease is not None:
         return live_run_lock_from_authority_lease(

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -1970,6 +1970,162 @@ def test_report_only_postgres_runtime_records_authority_lease_manifest(
     assert persisted.released_at is not None
 
 
+def test_postgres_authority_held_fails_closed_before_collection(
+    tmp_path: Path,
+    monkeypatch,
+    request,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    strategy = f"test_authority_held_{uuid4().hex[:10]}"
+    repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
+    held = repository.acquire(
+        strategy=strategy,
+        run_id="fv_live_existing_authority",
+        owner_id="existing_worker",
+        now=now,
+        ttl_seconds=300,
+    )
+    assert held.acquired is True
+    assert held.lease is not None
+    request.addfinalizer(
+        lambda: repository.release(
+            strategy=strategy,
+            owner_id=held.lease.owner_id,
+            fencing_token=held.lease.fencing_token,
+        )
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_kalshi_client",
+        lambda source, settings: pytest.fail("authority-held run must not collect market data"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_coinbase_client",
+        lambda source: pytest.fail("authority-held run must not collect market data"),
+    )
+    client = SequencedOrderClient([])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            submit_live_orders=False,
+            runtime_config_source="postgres",
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now + timedelta(seconds=10))
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    status = LiveRunStatusRepository(settings.database_url).latest_status(strategy=strategy)
+
+    assert client.requests == []
+    assert manifest["runtime_config"]["source"] == "not_read_authority_denied"
+    assert manifest["runtime_config"]["not_read_reason"] == "live_decision_authority_held"
+    assert manifest["runtime_controls"]["orders_placed"] == 0
+    assert manifest["runtime_controls"]["live_status_materialized"] is True
+    assert manifest["runtime_controls"]["live_run_lock"]["backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_run_lock"]["acquired"] is False
+    assert manifest["runtime_controls"]["live_run_lock"]["reason"] == (
+        "live_decision_authority_held"
+    )
+    assert manifest["runtime_controls"]["live_decision_authority_lease"]["existing"][
+        "run_id"
+    ] == "fv_live_existing_authority"
+    assert manifest["counts"]["collected_rows"] == 0
+    assert manifest["timing"]["phase_seconds"]["collection"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["risk_admission"] == 0.0
+    assert attempts["attempts"][0]["status"] == "skipped"
+    assert attempts["attempts"][0]["reason"] == "live_decision_authority_held"
+    assert attempts["attempts"][0]["decision"]["reason"] == "live_decision_authority_held"
+    assert attempts["skip_reasons"] == [
+        {"reason": "live_decision_authority_held", "count": 1}
+    ]
+    assert status.run_id == manifest["run_id"]
+    assert status.decision_outcome == "skipped"
+    assert status.latest_attempt_reason == "live_decision_authority_held"
+    assert status.skip_reason == "live_decision_authority_held"
+
+
+def test_postgres_authority_unavailable_fails_closed_before_collection(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    strategy = f"test_authority_unavailable_{uuid4().hex[:10]}"
+
+    def raise_authority_unavailable(self, **kwargs):
+        raise psycopg.OperationalError("authority database unavailable")
+
+    monkeypatch.setattr(
+        LiveDecisionAuthorityLeaseRepository,
+        "acquire",
+        raise_authority_unavailable,
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_kalshi_client",
+        lambda source, settings: pytest.fail("authority-error run must not collect market data"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_coinbase_client",
+        lambda source: pytest.fail("authority-error run must not collect market data"),
+    )
+    client = SequencedOrderClient([])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            submit_live_orders=False,
+            runtime_config_source="postgres",
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now)
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    status = LiveRunStatusRepository(settings.database_url).latest_status(strategy=strategy)
+
+    assert client.requests == []
+    assert manifest["runtime_config"]["source"] == "not_read_authority_denied"
+    assert manifest["runtime_config"]["not_read_reason"] == (
+        "live_decision_authority_unavailable"
+    )
+    assert manifest["runtime_controls"]["orders_placed"] == 0
+    assert manifest["runtime_controls"]["live_status_materialized"] is True
+    assert manifest["runtime_controls"]["live_run_lock"]["backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_run_lock"]["acquired"] is False
+    assert manifest["runtime_controls"]["live_run_lock"]["reason"] == (
+        "live_decision_authority_unavailable"
+    )
+    assert manifest["runtime_controls"]["live_decision_authority_lease"]["existing"][
+        "error_type"
+    ] == "OperationalError"
+    assert manifest["counts"]["collected_rows"] == 0
+    assert manifest["timing"]["phase_seconds"]["collection"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["submit"] == 0.0
+    assert attempts["attempts"][0]["status"] == "skipped"
+    assert attempts["attempts"][0]["reason"] == "live_decision_authority_unavailable"
+    assert attempts["skip_reasons"] == [
+        {"reason": "live_decision_authority_unavailable", "count": 1}
+    ]
+    assert status.run_id == manifest["run_id"]
+    assert status.decision_outcome == "skipped"
+    assert status.latest_attempt_reason == "live_decision_authority_unavailable"
+    assert status.skip_reason == "live_decision_authority_unavailable"
+
+
 def test_live_trading_job_uses_dashboard_config_for_exposure_and_daily_caps(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

Implements ADB-318 for the Postgres live-decision authority path.

- Treats Postgres authority-held and authority-unavailable outcomes as explicit clean skips before market collection.
- Catches authority acquisition errors and records `live_decision_authority_unavailable` evidence instead of letting the live worker crash into the hot path.
- Materializes sparse live status for Postgres authority denial while preserving the old duplicate `live_run_lock_held` suppression behavior.
- Adds focused worker tests proving held and unavailable authority do not collect market data or call the order client.

## Validation

- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_live_authority.py tests/test_fair_value_mvp.py::test_postgres_authority_held_fails_closed_before_collection tests/test_fair_value_mvp.py::test_postgres_authority_unavailable_fails_closed_before_collection tests/test_fair_value_mvp.py::test_report_only_postgres_runtime_records_authority_lease_manifest tests/test_fair_value_mvp.py::test_live_trading_job_submits_capped_order_and_reports_settled_pnl tests/test_fair_value_mvp.py::test_live_trading_job_skips_order_when_live_run_lock_is_held tests/test_fair_value_mvp.py::test_lock_held_duplicate_does_not_replace_latest_dashboard_status tests/test_fair_value_mvp.py::test_live_trading_job_uses_dashboard_brti_market_context_source tests/test_operational_state.py::test_migrations_are_idempotent_and_create_complete_tracer_run`
- `git diff --check`
- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile src/alphadb/model_evaluation/fair_value_live_job.py tests/test_fair_value_mvp.py`