### PR TITLE
[codex] Fence live writes with authority token

### DIFF
--- a/src/alphadb/live_authority.py
+++ b/src/alphadb/live_authority.py
@@ -19,6 +19,7 @@ LIVE_DECISION_AUTHORITY_LEASE_SCHEMA = "alphadb_live_decision_authority_lease.v1
 LIVE_DECISION_AUTHORITY_RESULT_SCHEMA = "alphadb_live_decision_authority_result.v1"
 AuthorityAcquireStatus = Literal["acquired", "held"]
 AuthorityReleaseStatus = Literal["released", "stale"]
+AuthorityValidationStatus = Literal["validated", "stale"]
 
 
 @dataclass(frozen=True)
@@ -94,6 +95,29 @@ class LiveDecisionAuthorityReleaseResult:
             "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
             "backend": "postgres",
             "released": self.released,
+            "status": self.status,
+            "reason": self.reason,
+            "lease": lease.as_dict() if lease else None,
+        }
+
+
+@dataclass(frozen=True)
+class LiveDecisionAuthorityValidationResult:
+    status: AuthorityValidationStatus
+    lease: LiveDecisionAuthorityLease | None = None
+    current_lease: LiveDecisionAuthorityLease | None = None
+    reason: str | None = None
+
+    @property
+    def valid(self) -> bool:
+        return self.status == "validated"
+
+    def as_dict(self) -> dict[str, Any]:
+        lease = self.lease or self.current_lease
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": "postgres",
+            "valid": self.valid,
             "status": self.status,
             "reason": self.reason,
             "lease": lease.as_dict() if lease else None,
@@ -255,6 +279,36 @@ class LiveDecisionAuthorityLeaseRepository:
             status="stale",
             lease=None,
             current_lease=lease_from_row(current) if current else None,
+            reason="stale_live_decision_authority_token",
+        )
+
+    def validate_active(
+        self,
+        *,
+        strategy: str = FAIR_VALUE_LIVE_STRATEGY,
+        owner_id: str,
+        fencing_token: int,
+        now: datetime | None = None,
+    ) -> LiveDecisionAuthorityValidationResult:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        observed_at = ensure_utc(now or datetime.now(UTC))
+        current = self.get(strategy=strategy, apply_migrations=False)
+        if (
+            current is not None
+            and current.owner_id == owner_id
+            and current.fencing_token == fencing_token
+            and current.status == "active"
+            and current.released_at is None
+            and current.expires_at > observed_at
+        ):
+            return LiveDecisionAuthorityValidationResult(
+                status="validated",
+                lease=current,
+            )
+        return LiveDecisionAuthorityValidationResult(
+            status="stale",
+            lease=None,
+            current_lease=current,
             reason="stale_live_decision_authority_token",
         )
 

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -26,6 +26,7 @@ from alphadb.live_orders import (
 )
 from alphadb.live_authority import (
     LIVE_DECISION_AUTHORITY_LEASE_SCHEMA,
+    LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
     LiveDecisionAuthorityLease,
     LiveDecisionAuthorityLeaseRepository,
 )
@@ -309,9 +310,20 @@ class FairValueLiveTradingJob:
                 "risk_state_bootstrapped": False,
                 "risk_state_read_reason": "risk_state_not_required",
             }
+            authority_validation = validate_live_run_lock_authority(
+                live_run_lock,
+                now=generated_at,
+            )
+            if not authority_validation.get("valid", True):
+                risk_state_read = {
+                    **dict(risk_state_read),
+                    "risk_state_read_reason": "live_decision_authority_validation_failed",
+                    "live_decision_authority_validation": authority_validation,
+                }
             should_prepare_risk_state = (
                 self.config.submit_live_orders
                 and guard.can_submit_live_orders
+                and bool(authority_validation.get("valid", True))
                 and any(decision.get("decision") == "trade" for decision, _row in selected_pairs)
             )
             if should_prepare_risk_state:
@@ -537,6 +549,25 @@ class FairValueLiveTradingJob:
         if not runtime_guard.get("can_submit_live_orders"):
             reason = str(runtime_guard.get("denial_reason") or "live_orders_disabled")
             return ({**base, "status": "skipped", "reason": reason}, None, None)
+        authority_validation = validate_live_run_lock_authority(
+            live_run_lock,
+            now=generated_at,
+        )
+        if live_run_lock.backend == "postgres":
+            base["live_decision_authority_validation"] = authority_validation
+        if not authority_validation.get("valid", True):
+            return (
+                {
+                    **base,
+                    "status": "skipped",
+                    "reason": str(
+                        authority_validation.get("reason")
+                        or "stale_live_decision_authority_token"
+                    ),
+                },
+                None,
+                None,
+            )
         try:
             materialize_private_key_from_env()
         except Exception as exc:
@@ -931,6 +962,22 @@ class FairValueLiveTradingJob:
             ),
             "artifacts": artifact_records(artifacts),
         }
+        if materialize_status and live_run_lock.backend == "postgres" and live_run_lock.acquired:
+            status_authority_validation = validate_live_run_lock_authority(
+                live_run_lock,
+                now=generated_at,
+            )
+            manifest["runtime_controls"][
+                "live_decision_authority_validation"
+            ] = status_authority_validation
+            if not status_authority_validation.get("valid", True):
+                manifest["runtime_controls"][
+                    "live_status_materialization_skip_reason"
+                ] = str(
+                    status_authority_validation.get("reason")
+                    or "stale_live_decision_authority_token"
+                )
+                materialize_status = False
         if materialize_status:
             with timer.phase("status_materialization"):
                 materialize_live_run_status(
@@ -2035,6 +2082,56 @@ def should_materialize_live_run_status(live_run_lock: LiveRunLock) -> bool:
     if live_run_lock.backend == "postgres":
         return True
     return live_run_lock.acquired or live_run_lock.reason != "live_run_lock_held"
+
+
+def validate_live_run_lock_authority(
+    live_run_lock: LiveRunLock,
+    *,
+    now: datetime,
+) -> dict[str, Any]:
+    if live_run_lock.backend != "postgres":
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": live_run_lock.backend,
+            "valid": True,
+            "status": "not_required",
+            "reason": None,
+            "lease": None,
+        }
+    if (
+        not live_run_lock.acquired
+        or live_run_lock.authority_repository is None
+        or live_run_lock.owner_id is None
+        or live_run_lock.fencing_token is None
+    ):
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": "postgres",
+            "valid": False,
+            "status": "unavailable",
+            "reason": live_run_lock.reason or "live_decision_authority_unavailable",
+            "lease": live_run_lock.as_dict(),
+        }
+    try:
+        return live_run_lock.authority_repository.validate_active(
+            strategy=live_run_lock.strategy,
+            owner_id=live_run_lock.owner_id,
+            fencing_token=live_run_lock.fencing_token,
+            now=now,
+        ).as_dict()
+    except Exception as exc:
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": "postgres",
+            "valid": False,
+            "status": "unavailable",
+            "reason": "live_decision_authority_unavailable",
+            "lease": live_run_lock.as_dict(),
+            "error": {
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            },
+        }
 
 
 def acquire_live_run_lock(

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -2126,6 +2126,128 @@ def test_postgres_authority_unavailable_fails_closed_before_collection(
     assert status.skip_reason == "live_decision_authority_unavailable"
 
 
+def test_postgres_authority_stale_token_prevents_live_mutations(
+    tmp_path: Path,
+    monkeypatch,
+    request,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-STALE-AUTHORITY"
+    strategy = f"test_authority_stale_{uuid4().hex[:10]}"
+    repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
+    first = repository.acquire(
+        strategy=strategy,
+        run_id="fv_live_stale_worker",
+        owner_id="stale_worker",
+        now=now - timedelta(seconds=31),
+        ttl_seconds=30,
+    )
+    current = repository.acquire(
+        strategy=strategy,
+        run_id="fv_live_current_worker",
+        owner_id="current_worker",
+        now=now,
+        ttl_seconds=300,
+    )
+    assert first.lease is not None
+    assert current.lease is not None
+    request.addfinalizer(
+        lambda: repository.release(
+            strategy=strategy,
+            owner_id=current.lease.owner_id,
+            fencing_token=current.lease.fencing_token,
+        )
+    )
+    stale_lock = fair_value_live_job.live_run_lock_from_authority_lease(
+        first.lease,
+        acquired=True,
+        authority_repository=repository,
+    )
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    seed_live_risk_state(now=now, strategy=strategy)
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "public_market_result",
+        lambda *, settings, ticker: {"status": "active", "result": None},
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "acquire_live_run_lock",
+        lambda **kwargs: stale_lock,
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "bounded_refresh_before_admission",
+        lambda **kwargs: pytest.fail("stale token must not refresh risk state"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job.LiveRiskAdmissionRepository,
+        "admit_order",
+        lambda self, **kwargs: pytest.fail("stale token must not reserve risk"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job.LiveOrderRepository,
+        "persist",
+        lambda self, attempt: pytest.fail("stale token must not persist live attempt"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "materialize_live_run_status",
+        lambda **kwargs: pytest.fail("stale token must not materialize live status"),
+    )
+    client = SequencedOrderClient([{"fill_count": 1, "cost": 0.4, "fees": 0.01}])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+            quote_stale_seconds=120,
+            coinbase_feature_stale_seconds=180,
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now)
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    attempt = attempts["attempts"][0]
+    authority_validation = attempt["live_decision_authority_validation"]
+
+    assert client.requests == []
+    assert manifest["runtime_controls"]["orders_placed"] == 0
+    assert manifest["runtime_controls"]["live_status_materialized"] is False
+    assert manifest["runtime_controls"]["live_status_materialization_skip_reason"] == (
+        "stale_live_decision_authority_token"
+    )
+    assert manifest["runtime_controls"]["live_decision_authority_validation"]["valid"] is False
+    assert manifest["runtime_controls"]["live_decision_authority_validation"]["reason"] == (
+        "stale_live_decision_authority_token"
+    )
+    assert manifest["runtime_controls"]["admission_daily_loss_accounting"][
+        "risk_state_read_reason"
+    ] == "live_decision_authority_validation_failed"
+    assert manifest["counts"]["live_skipped"] == 1
+    assert manifest["timing"]["phase_seconds"]["risk_admission"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["submit_attempt_persist"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["submit"] == 0.0
+    assert attempt["status"] == "skipped"
+    assert attempt["reason"] == "stale_live_decision_authority_token"
+    assert authority_validation["valid"] is False
+    assert authority_validation["reason"] == "stale_live_decision_authority_token"
+    assert authority_validation["lease"]["run_id"] == "fv_live_current_worker"
+    assert attempts["skip_reasons"] == [
+        {"reason": "stale_live_decision_authority_token", "count": 1}
+    ]
+
+
 def test_live_trading_job_uses_dashboard_config_for_exposure_and_daily_caps(
     tmp_path: Path,
     monkeypatch,
@@ -2426,6 +2548,7 @@ def live_risk_repository_or_skip() -> LiveRiskAdmissionRepository:
 def seed_live_risk_state(
     *,
     now: datetime,
+    strategy: str = "fair_value_live",
     daily_loss_used_dollars: float = 0.0,
     open_exposure_dollars: float = 0.0,
     pending_exposure_dollars: float = 0.0,
@@ -2441,6 +2564,7 @@ def seed_live_risk_state(
         live_risk_timezone="America/Los_Angeles",
     )
     repository.upsert_state(
+        strategy=strategy,
         live_risk_day=live_risk_day,
         daily_loss_used_dollars=daily_loss_used_dollars,
         open_exposure_dollars=open_exposure_dollars,

--- a/tests/test_live_authority.py
+++ b/tests/test_live_authority.py
@@ -126,3 +126,52 @@ def test_live_decision_authority_expired_reclaim_denies_stale_release() -> None:
     assert current is not None
     assert current.owner_id == "worker_reclaimed"
     assert current.status == "active"
+
+
+def test_live_decision_authority_validate_active_denies_stale_token() -> None:
+    repository = repository_or_skip()
+    strategy = f"test_authority_{uuid4().hex[:10]}"
+    now = datetime(2026, 6, 9, 22, 30, tzinfo=UTC)
+
+    first = repository.acquire(
+        strategy=strategy,
+        run_id="run_first",
+        owner_id="worker_first",
+        now=now,
+        ttl_seconds=30,
+    )
+    valid_first = repository.validate_active(
+        strategy=strategy,
+        owner_id="worker_first",
+        fencing_token=first.lease.fencing_token,
+        now=now + timedelta(seconds=5),
+    )
+    reclaimed = repository.acquire(
+        strategy=strategy,
+        run_id="run_reclaimed",
+        owner_id="worker_reclaimed",
+        now=now + timedelta(seconds=31),
+        ttl_seconds=30,
+    )
+    stale_first = repository.validate_active(
+        strategy=strategy,
+        owner_id="worker_first",
+        fencing_token=first.lease.fencing_token,
+        now=now + timedelta(seconds=32),
+    )
+    valid_reclaimed = repository.validate_active(
+        strategy=strategy,
+        owner_id="worker_reclaimed",
+        fencing_token=reclaimed.lease.fencing_token,
+        now=now + timedelta(seconds=32),
+    )
+
+    assert first.lease is not None
+    assert reclaimed.lease is not None
+    assert valid_first.valid is True
+    assert valid_first.reason is None
+    assert stale_first.valid is False
+    assert stale_first.reason == "stale_live_decision_authority_token"
+    assert stale_first.current_lease is not None
+    assert stale_first.current_lease.fencing_token == reclaimed.lease.fencing_token
+    assert valid_reclaimed.valid is True


### PR DESCRIPTION
## Summary

Implements ADB-319 as a stacked PR on top of ADB-318.

- Adds an active Postgres authority-token validation primitive to the live-decision authority repository.
- Validates acquired Postgres authority before live risk preparation, immediately before live risk reservation / attempt persistence / submission, and before live status materialization.
- Fails closed with `stale_live_decision_authority_token` when a worker holds an older token than the current active lease.
- Preserves ADB-318 behavior: authority-held and authority-unavailable skips can still materialize denial status, while acquired-but-stale workers cannot materialize authoritative status.
- Adds tests proving stale workers cannot refresh risk state, reserve risk, persist live attempts, materialize live status, or call the order client.

## Validation

- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_live_authority.py tests/test_live_risk.py tests/test_live_orders.py tests/test_fair_value_mvp.py::test_postgres_authority_stale_token_prevents_live_mutations tests/test_fair_value_mvp.py::test_postgres_authority_held_fails_closed_before_collection tests/test_fair_value_mvp.py::test_postgres_authority_unavailable_fails_closed_before_collection tests/test_fair_value_mvp.py::test_report_only_postgres_runtime_records_authority_lease_manifest tests/test_fair_value_mvp.py::test_live_trading_job_submits_capped_order_and_reports_settled_pnl tests/test_fair_value_mvp.py::test_live_trading_job_skips_order_when_live_run_lock_is_held tests/test_fair_value_mvp.py::test_lock_held_duplicate_does_not_replace_latest_dashboard_status tests/test_fair_value_mvp.py::test_live_trading_job_uses_dashboard_brti_market_context_source tests/test_operational_state.py::test_migrations_are_idempotent_and_create_complete_tracer_run`
- `git diff --check`
- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile src/alphadb/live_authority.py src/alphadb/model_evaluation/fair_value_live_job.py tests/test_live_authority.py tests/test_fair_value_mvp.py`

## Stack

Base PR: https://github.com/sidmohan0/alphadb/pull/50