### PR TITLE
[codex] Add live authority backend switch

### DIFF
--- a/deploy/aws/deploy-fair-value-live-trading-job.sh
+++ b/deploy/aws/deploy-fair-value-live-trading-job.sh
@@ -118,6 +118,7 @@ aws_cli cloudformation deploy \
     ScheduleState="${SCHEDULE_STATE:-DISABLED}" \
     MinEdgeValues="${MIN_EDGE_VALUES:-0.0,0.05,0.10}" \
     MinContractPrice="${MIN_CONTRACT_PRICE:-0.25}" \
+    LiveAuthorityBackend="${LIVE_AUTHORITY_BACKEND:-postgres}" \
     KalshiApiKeyIdSecretArn="$KALSHI_API_KEY_ID_SECRET_ARN" \
     KalshiPrivateKeyPemSecretArn="$KALSHI_PRIVATE_KEY_PEM_SECRET_ARN" \
     AwsRegionValue="$REGION"

--- a/deploy/aws/fair-value-live-trading-job.yaml
+++ b/deploy/aws/fair-value-live-trading-job.yaml
@@ -49,6 +49,13 @@ Parameters:
   MinContractPrice:
     Type: String
     Default: "0.25"
+  LiveAuthorityBackend:
+    Type: String
+    Default: postgres
+    AllowedValues:
+      - postgres
+      - s3
+    Description: Runtime authority backend; use s3 only as the temporary rollback path.
   KalshiApiKeyIdSecretArn:
     Type: String
     Description: Secrets Manager ARN whose value is KALSHI_API_KEY_ID.
@@ -178,6 +185,8 @@ Resources:
             - "60"
             - --runtime-config-source
             - postgres
+            - --live-authority-backend
+            - !Ref LiveAuthorityBackend
             - --submit-live-orders
           Environment:
             - Name: ALPHADB_ENV

--- a/src/alphadb/model_evaluation/cli.py
+++ b/src/alphadb/model_evaluation/cli.py
@@ -294,6 +294,12 @@ def build_parser() -> argparse.ArgumentParser:
         default="auto",
         help="Read dashboard-owned Postgres config, use CLI/env values, or choose by environment.",
     )
+    fair_live.add_argument(
+        "--live-authority-backend",
+        choices=("auto", "postgres", "s3", "local"),
+        default="auto",
+        help="Select live-decision authority backend; postgres keeps S3 as artifact storage only.",
+    )
     fair_live.add_argument("--output", default=None)
 
     expensive_yes_live = subparsers.add_parser(
@@ -515,6 +521,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 s3_prefix=args.s3_prefix,
                 submit_live_orders=args.submit_live_orders,
                 runtime_config_source=args.runtime_config_source,
+                live_authority_backend=args.live_authority_backend,
                 live_risk_state_stale_seconds=args.live_risk_state_stale_seconds,
                 quote_stale_seconds=args.quote_stale_seconds,
                 coinbase_feature_stale_seconds=args.coinbase_feature_stale_seconds,

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -78,6 +78,8 @@ FAIR_VALUE_LIVE_LOCK_TTL_SECONDS = 180
 DEFAULT_LIVE_RISK_TIMEZONE = "America/Los_Angeles"
 RuntimeConfigSource = Literal["auto", "postgres", "cli"]
 LiveDecisionPolicy = Literal["fair_value", "expensive_yes"]
+LiveAuthorityBackend = Literal["auto", "postgres", "s3", "local"]
+ResolvedLiveAuthorityBackend = Literal["none", "postgres", "s3", "local"]
 AWS_LIKE_ENVIRONMENTS = {"aws", "prod", "production"}
 
 
@@ -102,6 +104,7 @@ class FairValueLiveTradingJobConfig:
     s3_prefix: str | None = None
     submit_live_orders: bool = False
     runtime_config_source: RuntimeConfigSource = "auto"
+    live_authority_backend: LiveAuthorityBackend = "auto"
     live_risk_timezone: str = DEFAULT_LIVE_RISK_TIMEZONE
     live_risk_state_stale_seconds: int = DEFAULT_LIVE_RISK_STALE_SECONDS
     live_risk_refresh_max_lookup_count: int = 3
@@ -132,6 +135,7 @@ class FairValueLiveTradingJobConfig:
             "s3_prefix": self.s3_prefix,
             "submit_live_orders": self.submit_live_orders,
             "runtime_config_source": self.runtime_config_source,
+            "live_authority_backend": self.live_authority_backend,
             "live_risk_timezone": self.live_risk_timezone,
             "live_risk_state_stale_seconds": self.live_risk_state_stale_seconds,
             "live_risk_refresh_max_lookup_count": self.live_risk_refresh_max_lookup_count,
@@ -168,9 +172,10 @@ class FairValueLiveTradingJob:
         run_dir = self.config.output_root / run_id
         run_dir.mkdir(parents=True, exist_ok=True)
         timer = PhaseTimer()
+        authority_backend = resolve_live_authority_backend(self.config)
         authority_phase = (
             "postgres_authority_lease"
-            if should_use_postgres_authority_lease(self.config)
+            if authority_backend == "postgres"
             else "live_run_lock"
         )
         with timer.phase(authority_phase):
@@ -182,7 +187,8 @@ class FairValueLiveTradingJob:
                 enabled=self.config.submit_live_orders,
                 strategy=self.config.strategy,
                 settings=settings,
-                use_postgres_authority=should_use_postgres_authority_lease(self.config),
+                authority_backend=authority_backend,
+                authority_metadata=live_authority_acquire_metadata(self.config),
             )
         try:
             if not live_run_lock.acquired:
@@ -803,6 +809,8 @@ class FairValueLiveTradingJob:
             "min_contract_price": self.config.min_contract_price,
             "market_context_source": self.config.market_context_source,
             "brti_future_tolerance_seconds": self.config.brti_future_tolerance_seconds,
+            "live_authority_backend": live_run_lock.backend,
+            "live_authority_backend_requested": self.config.live_authority_backend,
             "admission_daily_loss_accounting": dict(admission_daily_loss_accounting),
             "daily_loss_accounting": dict(daily_loss_accounting),
             "runtime_guard": dict(runtime_guard),
@@ -1256,6 +1264,7 @@ def runtime_config_snapshot(
             "max_markets": config.max_markets,
             "market_context_source": config.market_context_source,
             "brti_future_tolerance_seconds": config.brti_future_tolerance_seconds,
+            "live_authority_backend": config.live_authority_backend,
         },
     }
 
@@ -2144,15 +2153,17 @@ def acquire_live_run_lock(
     strategy: str = FAIR_VALUE_LIVE_STRATEGY,
     ttl_seconds: int = FAIR_VALUE_LIVE_LOCK_TTL_SECONDS,
     settings: Settings | None = None,
-    use_postgres_authority: bool = False,
+    authority_backend: ResolvedLiveAuthorityBackend = "none",
+    authority_metadata: Mapping[str, Any] | None = None,
 ) -> LiveRunLock:
-    if use_postgres_authority:
+    if authority_backend == "postgres":
         return acquire_postgres_live_decision_authority(
             settings=settings or settings_from_env(),
             run_id=run_id,
             generated_at=generated_at,
             strategy=strategy,
             ttl_seconds=ttl_seconds,
+            metadata=authority_metadata,
         )
     if not enabled:
         return LiveRunLock(
@@ -2170,7 +2181,16 @@ def acquire_live_run_lock(
         token=token,
         ttl_seconds=ttl_seconds,
     )
-    if s3_prefix:
+    if authority_backend == "s3":
+        if not s3_prefix:
+            return LiveRunLock(
+                backend="s3",
+                acquired=False,
+                token="",
+                strategy=strategy,
+                run_id=run_id,
+                reason="live_authority_s3_prefix_missing",
+            )
         return acquire_s3_live_run_lock(
             s3_prefix=s3_prefix,
             strategy=strategy,
@@ -2178,20 +2198,44 @@ def acquire_live_run_lock(
             payload=payload,
             now=generated_at,
         )
-    return acquire_local_live_run_lock(
-        output_root=output_root,
-        strategy=strategy,
-        token=token,
-        payload=payload,
-        now=generated_at,
-    )
+    if authority_backend == "local":
+        return acquire_local_live_run_lock(
+            output_root=output_root,
+            strategy=strategy,
+            token=token,
+            payload=payload,
+            now=generated_at,
+        )
+    raise ValueError(f"unsupported live authority backend: {authority_backend}")
 
 
 def should_use_postgres_authority_lease(config: FairValueLiveTradingJobConfig) -> bool:
-    return (
-        not config.submit_live_orders
-        and config.runtime_config_source == "postgres"
-    )
+    return resolve_live_authority_backend(config) == "postgres"
+
+
+def resolve_live_authority_backend(
+    config: FairValueLiveTradingJobConfig,
+) -> ResolvedLiveAuthorityBackend:
+    if config.live_authority_backend == "postgres":
+        return "postgres"
+    if config.live_authority_backend in {"s3", "local"}:
+        return config.live_authority_backend if config.submit_live_orders else "none"
+    if not config.submit_live_orders and config.runtime_config_source == "postgres":
+        return "postgres"
+    if not config.submit_live_orders:
+        return "none"
+    if config.s3_prefix:
+        return "s3"
+    return "local"
+
+
+def live_authority_acquire_metadata(config: FairValueLiveTradingJobConfig) -> dict[str, Any]:
+    return {
+        "source": "fair_value_live",
+        "live_authority_backend": resolve_live_authority_backend(config),
+        "live_authority_backend_requested": config.live_authority_backend,
+        "submit_live_orders": config.submit_live_orders,
+    }
 
 
 def acquire_postgres_live_decision_authority(
@@ -2201,6 +2245,7 @@ def acquire_postgres_live_decision_authority(
     generated_at: datetime,
     strategy: str = FAIR_VALUE_LIVE_STRATEGY,
     ttl_seconds: int = FAIR_VALUE_LIVE_LOCK_TTL_SECONDS,
+    metadata: Mapping[str, Any] | None = None,
 ) -> LiveRunLock:
     repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
     owner_id = f"{run_id}:{uuid4().hex[:12]}"
@@ -2211,8 +2256,9 @@ def acquire_postgres_live_decision_authority(
             owner_id=owner_id,
             now=generated_at,
             ttl_seconds=ttl_seconds,
-            metadata={
-                "source": "fair_value_live_report_only",
+            metadata=metadata
+            or {
+                "source": "fair_value_live",
                 "submit_live_orders": False,
             },
         )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -434,6 +434,9 @@ def test_fair_value_live_aws_template_enables_live_money_with_minimal_caps() -> 
     assert "DATABASE_URL" in template
     assert "--runtime-config-source" in template
     assert "postgres" in template
+    assert "LiveAuthorityBackend" in template
+    assert "--live-authority-backend" in template
+    assert 'LiveAuthorityBackend="${LIVE_AUTHORITY_BACKEND:-postgres}"' in deploy_script
     assert "--quote-stale-seconds" in template
     assert "--coinbase-feature-stale-seconds" in template
     assert "--brti-future-tolerance-seconds" in template

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -2248,6 +2248,156 @@ def test_postgres_authority_stale_token_prevents_live_mutations(
     ]
 
 
+def test_live_authority_backend_resolution_covers_postgres_and_fallbacks(
+    tmp_path: Path,
+) -> None:
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                s3_prefix="s3://example/fair-value-live",
+            )
+        )
+        == "s3"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                s3_prefix="s3://example/fair-value-live",
+                live_authority_backend="postgres",
+            )
+        )
+        == "postgres"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                runtime_config_source="postgres",
+                live_authority_backend="s3",
+            )
+        )
+        == "s3"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=False,
+                runtime_config_source="postgres",
+            )
+        )
+        == "postgres"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(output_root=tmp_path, submit_live_orders=False)
+        )
+        == "none"
+    )
+
+
+def test_postgres_authority_backend_keeps_s3_artifacts_out_of_authority(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-POSTGRES-AUTHORITY"
+    strategy = f"test_authority_backend_{uuid4().hex[:10]}"
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    seed_live_risk_state(now=now, strategy=strategy)
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "public_market_result",
+        lambda *, settings, ticker: {"status": "active", "result": None},
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "acquire_s3_live_run_lock",
+        lambda **kwargs: pytest.fail("Postgres authority must not acquire the S3 lock"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "release_s3_live_run_lock",
+        lambda *args, **kwargs: pytest.fail("Postgres authority must not release the S3 lock"),
+    )
+    uploads: list[dict[str, object]] = []
+
+    def fake_upload_artifacts_to_s3(artifacts, *, s3_prefix):
+        uploads.append({"s3_prefix": s3_prefix, "artifacts": sorted(artifacts)})
+        return [
+            {"artifact": name, "s3_uri": f"{s3_prefix.rstrip('/')}/{name}.json"}
+            for name in sorted(artifacts)
+        ]
+
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "upload_artifacts_to_s3",
+        fake_upload_artifacts_to_s3,
+    )
+    client = SequencedOrderClient([{"fill_count": 0, "cost": 0.0, "fees": 0.0}])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+            runtime_config_source="cli",
+            live_authority_backend="postgres",
+            s3_prefix="s3://example/fair-value-live",
+            quote_stale_seconds=120,
+            coinbase_feature_stale_seconds=180,
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now)
+    lease = manifest["runtime_controls"]["live_decision_authority_lease"]
+    persisted = LiveDecisionAuthorityLeaseRepository(settings.database_url).get(strategy=strategy)
+
+    assert client.requests != []
+    assert manifest["config"]["live_authority_backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_authority_backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_authority_backend_requested"] == "postgres"
+    assert manifest["runtime_controls"]["live_run_lock"]["backend"] == "postgres"
+    assert lease["backend"] == "postgres"
+    assert "postgres_authority_lease" in manifest["timing"]["phase_seconds"]
+    assert manifest["timing"]["phase_seconds"]["live_run_lock"] == 0.0
+    assert uploads == [
+        {
+            "s3_prefix": "s3://example/fair-value-live",
+            "artifacts": [
+                "decision_rows",
+                "live_order_attempts",
+                "live_reconciliation_report",
+                "manifest",
+            ],
+        }
+    ]
+    assert {upload["artifact"] for upload in manifest["s3_uploads"]} == {
+        "decision_rows",
+        "live_order_attempts",
+        "live_reconciliation_report",
+        "manifest",
+    }
+    assert persisted is not None
+    assert persisted.fencing_token == lease["fencing_token"]
+    assert persisted.status == "released"
+    assert persisted.metadata["submit_live_orders"] is True
+    assert persisted.metadata["live_authority_backend"] == "postgres"
+
+
 def test_live_trading_job_uses_dashboard_config_for_exposure_and_daily_caps(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

Implements ADB-320 as a stacked PR on top of ADB-319.

- Adds an explicit `live_authority_backend` config/CLI switch for `fair_value_live` with `auto`, `postgres`, `s3`, and `local` options.
- Lets AWS select Postgres live-decision authority explicitly while keeping S3 as the artifact store.
- Keeps S3 authority available as the temporary rollback path via `LIVE_AUTHORITY_BACKEND=s3` in the deploy script / CloudFormation parameter.
- Records requested/resolved authority backend evidence in manifests and lease metadata.
- Adds tests for backend resolution, AWS template wiring, S3 rollback availability, and S3 artifact upload remaining independent of runtime authority.

## Validation

- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_live_authority.py tests/test_live_risk.py tests/test_live_orders.py tests/test_deploy.py::test_fair_value_live_aws_template_enables_live_money_with_minimal_caps tests/test_fair_value_mvp.py::test_live_authority_backend_resolution_covers_postgres_and_fallbacks tests/test_fair_value_mvp.py::test_postgres_authority_backend_keeps_s3_artifacts_out_of_authority tests/test_fair_value_mvp.py::test_postgres_authority_stale_token_prevents_live_mutations tests/test_fair_value_mvp.py::test_postgres_authority_held_fails_closed_before_collection tests/test_fair_value_mvp.py::test_postgres_authority_unavailable_fails_closed_before_collection tests/test_fair_value_mvp.py::test_report_only_postgres_runtime_records_authority_lease_manifest tests/test_fair_value_mvp.py::test_live_trading_job_submits_capped_order_and_reports_settled_pnl tests/test_fair_value_mvp.py::test_live_trading_job_skips_order_when_live_run_lock_is_held tests/test_fair_value_mvp.py::test_lock_held_duplicate_does_not_replace_latest_dashboard_status tests/test_fair_value_mvp.py::test_live_trading_job_uses_dashboard_brti_market_context_source tests/test_operational_state.py::test_migrations_are_idempotent_and_create_complete_tracer_run`
- `git diff --check`
- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile src/alphadb/model_evaluation/fair_value_live_job.py src/alphadb/model_evaluation/cli.py tests/test_fair_value_mvp.py tests/test_deploy.py`
- `bash -n deploy/aws/deploy-fair-value-live-trading-job.sh`

## Stack

Base PR: https://github.com/sidmohan0/alphadb/pull/51