### PR TITLE
[codex] Surface live authority status

### DIFF
--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -34,6 +34,7 @@ from alphadb.deployment_intents import (
     deployment_intent_kwargs_from_payload,
 )
 from alphadb.health import HealthReport, collect_health
+from alphadb.live_authority import LiveDecisionAuthorityLeaseRepository
 from alphadb.live_runtime import (
     EXPENSIVE_YES_LIVE_STRATEGY,
     FAIR_VALUE_LIVE_STRATEGY,
@@ -52,6 +53,7 @@ from alphadb.portfolio import cached_portfolio_balance_payload
 
 ConfigRepositoryFactory = Callable[[str], LiveRuntimeConfigRepository]
 StatusRepositoryFactory = Callable[[str], LiveRunStatusRepository]
+AuthorityRepositoryFactory = Callable[[str], LiveDecisionAuthorityLeaseRepository]
 LiveRiskRepositoryFactory = Callable[[str], LiveRiskAdmissionRepository]
 StrategyRepositoryFactory = Callable[[str], DashboardStrategyRepository]
 DataExplorerRepositoryFactory = Callable[[str], DashboardDataExplorerRepository]
@@ -70,6 +72,9 @@ class DashboardService:
     settings: Settings
     config_repository_factory: ConfigRepositoryFactory = LiveRuntimeConfigRepository
     status_repository_factory: StatusRepositoryFactory = LiveRunStatusRepository
+    authority_repository_factory: AuthorityRepositoryFactory = (
+        LiveDecisionAuthorityLeaseRepository
+    )
     live_risk_repository_factory: LiveRiskRepositoryFactory = LiveRiskAdmissionRepository
     strategy_repository_factory: StrategyRepositoryFactory = DashboardStrategyRepository
     data_explorer_repository_factory: DataExplorerRepositoryFactory = (
@@ -99,9 +104,16 @@ class DashboardService:
         history = config_repository.recent_revisions(strategy=strategy, limit=6)
         status_repository = self.status_repository_factory(self.settings.database_url)
         latest_status = status_repository.latest_status(strategy=strategy)
+        authority_status, authority_error = _live_authority_status(
+            self.authority_repository_factory(self.settings.database_url),
+            strategy=strategy,
+        )
         live_status = latest_status.as_dict()
         status_summary = _mapping_or_empty(live_status.get("summary"))
         live_status.pop("summary", None)
+        live_status["live_decision_authority"] = authority_status
+        if authority_error:
+            live_status["live_decision_authority_error"] = authority_error
         report = self.health_collector(self.settings)
         return {
             "strategy": strategy,
@@ -132,11 +144,13 @@ class DashboardService:
         generated_at = datetime.now(UTC)
         config_repository = self.config_repository_factory(self.settings.database_url)
         status_repository = self.status_repository_factory(self.settings.database_url)
+        authority_repository = self.authority_repository_factory(self.settings.database_url)
         rows = [
             _strategy_operator_ledger_row(
                 strategy=strategy,
                 config_repository=config_repository,
                 status_repository=status_repository,
+                authority_repository=authority_repository,
             )
             for strategy in LIVE_DASHBOARD_STRATEGIES
         ]
@@ -503,6 +517,7 @@ def _strategy_operator_ledger_row(
     strategy: str,
     config_repository: LiveRuntimeConfigRepository,
     status_repository: LiveRunStatusRepository,
+    authority_repository: LiveDecisionAuthorityLeaseRepository,
 ) -> dict[str, Any]:
     metadata = runtime_strategy_metadata(strategy)
     active_config: dict[str, Any] | None = None
@@ -525,6 +540,10 @@ def _strategy_operator_ledger_row(
     except Exception as exc:
         recent_runs = []
         recent_runs_error = f"{type(exc).__name__}: {exc}"
+    authority_status, authority_error = _live_authority_status(
+        authority_repository,
+        strategy=strategy,
+    )
 
     health, health_detail = _strategy_operator_health(
         latest_status,
@@ -563,6 +582,10 @@ def _strategy_operator_ledger_row(
             config_error=config_error,
             status_error=status_error,
         ),
+        "authority_summary": _strategy_operator_authority_summary(
+            authority_status,
+            authority_error=authority_error,
+        ),
         "decision_outcome": latest_status.decision_outcome,
         "latest_attempt_status": latest_status.latest_attempt_status,
         "latest_attempt_reason": latest_status.latest_attempt_reason,
@@ -572,6 +595,7 @@ def _strategy_operator_ledger_row(
         "active_config": active_config,
         "config_error": config_error,
         "status_error": status_error,
+        "authority_error": authority_error,
         "recent_runs_error": recent_runs_error,
     }
 
@@ -712,6 +736,68 @@ def _recent_run_summaries(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, A
     normalized = [dict(row) for row in rows if isinstance(row, Mapping)]
     normalized.sort(key=lambda row: str(row.get("generated_at") or ""), reverse=True)
     return normalized[:3]
+
+
+def _live_authority_status(
+    authority_repository: LiveDecisionAuthorityLeaseRepository,
+    *,
+    strategy: str,
+) -> tuple[dict[str, Any], str | None]:
+    try:
+        return dict(authority_repository.status(strategy=strategy)), None
+    except Exception as exc:
+        return (
+            {
+                "schema_version": "alphadb_live_decision_authority_status.v1",
+                "backend": "postgres",
+                "strategy": strategy,
+                "state": "unavailable",
+                "reason": "live_decision_authority_unavailable",
+                "run_id": None,
+                "owner_id": None,
+                "fencing_token": None,
+                "acquired_at": None,
+                "expires_at": None,
+                "released_at": None,
+                "lease_status": None,
+            },
+            f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _strategy_operator_authority_summary(
+    authority_status: Mapping[str, Any],
+    *,
+    authority_error: str | None,
+) -> dict[str, Any]:
+    state = _optional_text(authority_status.get("state")) or "empty"
+    reason = _optional_text(authority_status.get("reason"))
+    run_id = _optional_text(authority_status.get("run_id"))
+    expires_at = _optional_text(authority_status.get("expires_at"))
+    if authority_error:
+        state = "unavailable"
+        detail = f"Authority state unavailable: {authority_error}"
+    elif state == "empty":
+        detail = "No Postgres authority lease recorded."
+    elif state == "held":
+        holder = f" by {run_id}" if run_id else ""
+        expiry = f" until {expires_at}" if expires_at else ""
+        detail = f"Authority held{holder}{expiry}."
+    elif state == "expired":
+        detail = f"Authority lease expired at {expires_at or 'unknown time'}."
+    elif state == "released":
+        detail = f"Authority lease released by {run_id or 'unknown run'}."
+    else:
+        detail = reason or f"Authority state: {state}"
+    return {
+        "state": state,
+        "detail": detail,
+        "backend": authority_status.get("backend"),
+        "reason": reason,
+        "run_id": run_id,
+        "fencing_token": authority_status.get("fencing_token"),
+        "expires_at": expires_at,
+    }
 
 
 def _strategy_operator_fleet_health(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:

--- a/src/alphadb/live_authority.py
+++ b/src/alphadb/live_authority.py
@@ -17,6 +17,7 @@ from alphadb.state.repository import OperationalStateRepository
 
 LIVE_DECISION_AUTHORITY_LEASE_SCHEMA = "alphadb_live_decision_authority_lease.v1"
 LIVE_DECISION_AUTHORITY_RESULT_SCHEMA = "alphadb_live_decision_authority_result.v1"
+LIVE_DECISION_AUTHORITY_STATUS_SCHEMA = "alphadb_live_decision_authority_status.v1"
 AuthorityAcquireStatus = Literal["acquired", "held"]
 AuthorityReleaseStatus = Literal["released", "stale"]
 AuthorityValidationStatus = Literal["validated", "stale"]
@@ -311,6 +312,67 @@ class LiveDecisionAuthorityLeaseRepository:
             current_lease=current,
             reason="stale_live_decision_authority_token",
         )
+
+    def status(
+        self,
+        *,
+        strategy: str = FAIR_VALUE_LIVE_STRATEGY,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        observed_at = ensure_utc(now or datetime.now(UTC))
+        current = self.get(strategy=strategy, apply_migrations=False)
+        return live_decision_authority_status(
+            strategy=strategy,
+            lease=current,
+            now=observed_at,
+        )
+
+
+def live_decision_authority_status(
+    *,
+    strategy: str,
+    lease: LiveDecisionAuthorityLease | None,
+    now: datetime,
+) -> dict[str, Any]:
+    if lease is None:
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_STATUS_SCHEMA,
+            "backend": "postgres",
+            "strategy": strategy,
+            "state": "empty",
+            "reason": "live_decision_authority_empty",
+            "run_id": None,
+            "owner_id": None,
+            "fencing_token": None,
+            "acquired_at": None,
+            "expires_at": None,
+            "released_at": None,
+            "lease_status": None,
+        }
+    if lease.status == "active" and lease.released_at is None:
+        state = "expired" if lease.expires_at <= now else "held"
+        reason = "live_decision_authority_expired" if state == "expired" else None
+    elif lease.status == "released" or lease.released_at is not None:
+        state = "released"
+        reason = None
+    else:
+        state = lease.status or "unknown"
+        reason = f"live_decision_authority_{state}"
+    return {
+        "schema_version": LIVE_DECISION_AUTHORITY_STATUS_SCHEMA,
+        "backend": "postgres",
+        "strategy": lease.strategy,
+        "state": state,
+        "reason": reason,
+        "run_id": lease.run_id,
+        "owner_id": lease.owner_id,
+        "fencing_token": lease.fencing_token,
+        "acquired_at": lease.acquired_at.isoformat(),
+        "expires_at": lease.expires_at.isoformat(),
+        "released_at": lease.released_at.isoformat() if lease.released_at else None,
+        "lease_status": lease.status,
+    }
 
 
 def lease_from_row(row: Mapping[str, Any]) -> LiveDecisionAuthorityLease:

--- a/src/alphadb/live_runtime.py
+++ b/src/alphadb/live_runtime.py
@@ -643,6 +643,10 @@ def build_fair_value_live_status(
     market_used = _market_exposure_for(latest_market, reconciliation)
     fill_status = _fill_status(latest_attempt, latest_reconciliation)
     decision_outcome = _decision_outcome(latest_status, manifest)
+    live_decision_authority = latest_live_decision_authority_status(
+        runtime_controls=runtime_controls,
+        latest_reason=latest_reason,
+    )
     return LiveRunStatus(
         run_id=_text(manifest.get("run_id")),
         strategy=status_strategy,
@@ -683,6 +687,7 @@ def build_fair_value_live_status(
             "market_context": dict(_mapping(manifest.get("market_context"))),
             "live_risk_admission_state": dict(live_risk_admission_state),
             "live_risk_refresh": dict(live_risk_refresh),
+            "live_decision_authority": live_decision_authority,
             "risk_state_classification": classify_risk_state(
                 live_risk_admission_state=live_risk_admission_state,
                 live_risk_refresh=live_risk_refresh,
@@ -696,6 +701,9 @@ def build_fair_value_live_status(
                     "orders_placed",
                     "filled_contracts",
                     "market_context_source",
+                    "live_authority_backend",
+                    "live_authority_backend_requested",
+                    "live_status_materialization_skip_reason",
                 )
             },
         },
@@ -730,6 +738,83 @@ def no_recent_live_run_status(*, strategy: str = FAIR_VALUE_LIVE_STRATEGY) -> Li
         summary={},
         recent_attempts=[],
     )
+
+
+def latest_live_decision_authority_status(
+    *,
+    runtime_controls: Mapping[str, Any],
+    latest_reason: str | None,
+) -> dict[str, Any]:
+    lease = _mapping(runtime_controls.get("live_decision_authority_lease"))
+    live_run_lock = _mapping(runtime_controls.get("live_run_lock"))
+    evidence = lease or (
+        live_run_lock if _text(live_run_lock.get("backend")) == "postgres" else {}
+    )
+    backend = (
+        _text(evidence.get("backend"))
+        or _text(runtime_controls.get("live_authority_backend"))
+    )
+    if not backend:
+        return _authority_status_payload(
+            backend=None,
+            state="empty",
+            reason="live_decision_authority_empty",
+        )
+    if backend != "postgres":
+        return _authority_status_payload(
+            backend=backend,
+            state="not_applicable",
+            reason=None,
+        )
+    validation = _mapping(runtime_controls.get("live_decision_authority_validation"))
+    validation_reason = _text(validation.get("reason"))
+    if validation and not bool(validation.get("valid", True)):
+        return _authority_status_payload(
+            backend="postgres",
+            state="stale",
+            reason=validation_reason or "stale_live_decision_authority_token",
+            evidence=evidence,
+        )
+    reason = _text(evidence.get("reason")) or latest_reason
+    acquired = bool(evidence.get("acquired"))
+    if acquired:
+        state = "acquired"
+    elif reason == "live_decision_authority_unavailable":
+        state = "unavailable"
+    elif reason:
+        state = "denied"
+    else:
+        state = "empty"
+        reason = "live_decision_authority_empty"
+    return _authority_status_payload(
+        backend="postgres",
+        state=state,
+        reason=reason,
+        evidence=evidence,
+    )
+
+
+def _authority_status_payload(
+    *,
+    backend: str | None,
+    state: str,
+    reason: str | None,
+    evidence: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    evidence = _mapping(evidence)
+    return {
+        "schema_version": "alphadb_live_decision_authority_status.v1",
+        "backend": backend,
+        "state": state,
+        "reason": reason,
+        "run_id": _text(evidence.get("run_id")),
+        "owner_id": _text(evidence.get("owner_id")),
+        "fencing_token": _optional_int(evidence.get("fencing_token")),
+        "acquired_at": _text(evidence.get("acquired_at")),
+        "expires_at": _text(evidence.get("expires_at")),
+        "released_at": _text(evidence.get("released_at")),
+        "lease_status": _text(evidence.get("status")),
+    }
 
 
 def _config_revision_from_row(row: Mapping[str, Any]) -> LiveRuntimeConfigRevision:

--- a/tests/test_dashboard_live_console.py
+++ b/tests/test_dashboard_live_console.py
@@ -98,6 +98,31 @@ class FakeStatusRepository:
 
 
 @dataclass
+class FakeAuthorityRepository:
+    database_url: str
+    payload: dict[str, Any] | None = None
+    error: Exception | None = None
+
+    def status(self, *, strategy: str) -> dict[str, Any]:
+        if self.error is not None:
+            raise self.error
+        return self.payload or {
+            "schema_version": "alphadb_live_decision_authority_status.v1",
+            "backend": "postgres",
+            "strategy": strategy,
+            "state": "empty",
+            "reason": "live_decision_authority_empty",
+            "run_id": None,
+            "owner_id": None,
+            "fencing_token": None,
+            "acquired_at": None,
+            "expires_at": None,
+            "released_at": None,
+            "lease_status": None,
+        }
+
+
+@dataclass
 class FakeLiveRiskRepository:
     database_url: str
     state: LiveRiskAdmissionState | None = None
@@ -160,9 +185,13 @@ def service(
     *,
     status: LiveRunStatus | None = None,
     recent: list[dict[str, Any]] | None = None,
+    authority_repository: FakeAuthorityRepository | None = None,
     live_risk_repository: FakeLiveRiskRepository | None = None,
 ) -> DashboardService:
     risk_repository = live_risk_repository or FakeLiveRiskRepository(
+        "postgresql://example.test/alphadb"
+    )
+    authority = authority_repository or FakeAuthorityRepository(
         "postgresql://example.test/alphadb"
     )
     return DashboardService(
@@ -173,6 +202,7 @@ def service(
             status=status or no_recent_live_run_status(),
             recent=recent,
         ),
+        authority_repository_factory=lambda database_url: authority,
         live_risk_repository_factory=lambda database_url: risk_repository,
         health_collector=ok_health,
         portfolio_balance_provider=lambda settings: {
@@ -310,6 +340,61 @@ def test_strategy_operator_ledger_caps_and_sorts_recent_runs() -> None:
     assert row["risk_summary"]["detail"] == "Daily $1.25/$50.00; market $2.00/$5.00"
     assert row["context_summary"]["latest_run_source"] == "brti_primary"
     assert row["context_summary"]["latest_run_status"] == "fresh"
+
+
+def test_live_payload_and_ledger_surface_live_authority_state() -> None:
+    repository = FakeConfigRepository("postgresql://example.test/alphadb")
+    authority = FakeAuthorityRepository(
+        "postgresql://example.test/alphadb",
+        payload={
+            "schema_version": "alphadb_live_decision_authority_status.v1",
+            "backend": "postgres",
+            "strategy": FAIR_VALUE_LIVE_STRATEGY,
+            "state": "held",
+            "reason": None,
+            "run_id": "fv_live_holder",
+            "owner_id": "worker_holder",
+            "fencing_token": 11,
+            "acquired_at": "2026-06-04T15:00:00+00:00",
+            "expires_at": "2026-06-04T15:03:00+00:00",
+            "released_at": None,
+            "lease_status": "active",
+        },
+    )
+    dashboard = service(repository, authority_repository=authority)
+
+    payload = dashboard.live_payload()
+    row = dashboard.strategy_operator_ledger_payload()["rows"][0]
+
+    assert payload["live_status"]["live_decision_authority"]["state"] == "held"
+    assert payload["live_status"]["live_decision_authority"]["run_id"] == "fv_live_holder"
+    assert payload["live_status"]["live_decision_authority"]["fencing_token"] == 11
+    assert "summary" not in payload["live_status"]
+    assert row["authority_summary"]["state"] == "held"
+    assert row["authority_summary"]["run_id"] == "fv_live_holder"
+    assert row["authority_summary"]["fencing_token"] == 11
+
+
+def test_live_payload_surfaces_authority_repository_failures_as_unavailable() -> None:
+    repository = FakeConfigRepository("postgresql://example.test/alphadb")
+    authority = FakeAuthorityRepository(
+        "postgresql://example.test/alphadb",
+        error=RuntimeError("authority database unavailable"),
+    )
+    dashboard = service(repository, authority_repository=authority)
+
+    payload = dashboard.live_payload()
+    row = dashboard.strategy_operator_ledger_payload()["rows"][0]
+
+    assert payload["live_status"]["live_decision_authority"]["state"] == "unavailable"
+    assert payload["live_status"]["live_decision_authority"]["reason"] == (
+        "live_decision_authority_unavailable"
+    )
+    assert payload["live_status"]["live_decision_authority_error"].startswith(
+        "RuntimeError: authority database unavailable"
+    )
+    assert row["authority_summary"]["state"] == "unavailable"
+    assert row["authority_error"].startswith("RuntimeError: authority database unavailable")
 
 
 def test_strategy_operator_ledger_marks_repository_failures_unavailable() -> None:

--- a/tests/test_live_authority.py
+++ b/tests/test_live_authority.py
@@ -175,3 +175,60 @@ def test_live_decision_authority_validate_active_denies_stale_token() -> None:
     assert stale_first.current_lease is not None
     assert stale_first.current_lease.fencing_token == reclaimed.lease.fencing_token
     assert valid_reclaimed.valid is True
+
+
+def test_live_decision_authority_status_reports_sparse_current_states() -> None:
+    repository = repository_or_skip()
+    now = datetime(2026, 6, 9, 23, 0, tzinfo=UTC)
+    empty_strategy = f"test_authority_empty_{uuid4().hex[:10]}"
+    held_strategy = f"test_authority_held_{uuid4().hex[:10]}"
+    expired_strategy = f"test_authority_expired_{uuid4().hex[:10]}"
+    released_strategy = f"test_authority_released_{uuid4().hex[:10]}"
+
+    held = repository.acquire(
+        strategy=held_strategy,
+        run_id="run_held",
+        owner_id="worker_held",
+        now=now,
+        ttl_seconds=60,
+    )
+    expired = repository.acquire(
+        strategy=expired_strategy,
+        run_id="run_expired",
+        owner_id="worker_expired",
+        now=now - timedelta(seconds=90),
+        ttl_seconds=60,
+    )
+    released = repository.acquire(
+        strategy=released_strategy,
+        run_id="run_released",
+        owner_id="worker_released",
+        now=now,
+        ttl_seconds=60,
+    )
+    repository.release(
+        strategy=released_strategy,
+        owner_id=released.lease.owner_id,
+        fencing_token=released.lease.fencing_token,
+        now=now + timedelta(seconds=1),
+    )
+
+    empty_status = repository.status(strategy=empty_strategy, now=now)
+    held_status = repository.status(strategy=held_strategy, now=now)
+    expired_status = repository.status(strategy=expired_strategy, now=now)
+    released_status = repository.status(strategy=released_strategy, now=now)
+
+    assert held.lease is not None
+    assert expired.lease is not None
+    assert released.lease is not None
+    assert empty_status["state"] == "empty"
+    assert empty_status["reason"] == "live_decision_authority_empty"
+    assert held_status["state"] == "held"
+    assert held_status["reason"] is None
+    assert held_status["run_id"] == "run_held"
+    assert held_status["fencing_token"] == held.lease.fencing_token
+    assert expired_status["state"] == "expired"
+    assert expired_status["reason"] == "live_decision_authority_expired"
+    assert expired_status["expires_at"] == expired.lease.expires_at.isoformat()
+    assert released_status["state"] == "released"
+    assert released_status["released_at"] is not None

--- a/tests/test_live_runtime.py
+++ b/tests/test_live_runtime.py
@@ -238,6 +238,97 @@ def test_live_status_summary_covers_submitted_no_fill_skipped_and_no_recent() ->
     assert no_recent.decision_outcome == "no_recent_run"
 
 
+def test_live_status_summary_surfaces_live_decision_authority_states() -> None:
+    base_manifest = {
+        "run_id": "fv_live_authority_status",
+        "generated_at": "2026-06-04T15:00:00+00:00",
+        "runtime_config": {"snapshot": {}},
+        "counts": {"live_attempts": 1},
+    }
+    base_attempt = {
+        "attempt_id": "attempt_authority",
+        "submitted_at": "2026-06-04T15:00:00+00:00",
+        "market_ticker": "KXBTC15M-AUTHORITY",
+        "status": "skipped",
+        "reason": "submit_live_orders_false",
+    }
+    acquired = build_fair_value_live_status(
+        manifest={
+            **base_manifest,
+            "runtime_controls": {
+                "live_decision_authority_lease": {
+                    "backend": "postgres",
+                    "acquired": True,
+                    "run_id": "fv_live_authority_status",
+                    "owner_id": "worker_1",
+                    "fencing_token": 7,
+                    "status": "released",
+                    "expires_at": "2026-06-04T15:03:00+00:00",
+                }
+            },
+        },
+        attempts_payload={"attempts": [base_attempt]},
+        reconciliation={"rows": []},
+    )
+    held = build_fair_value_live_status(
+        manifest={
+            **base_manifest,
+            "run_id": "fv_live_authority_held",
+            "runtime_controls": {
+                "live_decision_authority_lease": {
+                    "backend": "postgres",
+                    "acquired": False,
+                    "reason": "live_decision_authority_held",
+                    "run_id": "fv_live_existing",
+                    "owner_id": "worker_existing",
+                    "fencing_token": 6,
+                    "expires_at": "2026-06-04T15:02:00+00:00",
+                }
+            },
+        },
+        attempts_payload={
+            "attempts": [{**base_attempt, "reason": "live_decision_authority_held"}]
+        },
+        reconciliation={"rows": []},
+    )
+    unavailable = build_fair_value_live_status(
+        manifest={
+            **base_manifest,
+            "run_id": "fv_live_authority_unavailable",
+            "runtime_controls": {
+                "live_decision_authority_lease": {
+                    "backend": "postgres",
+                    "acquired": False,
+                    "reason": "live_decision_authority_unavailable",
+                }
+            },
+        },
+        attempts_payload={
+            "attempts": [
+                {**base_attempt, "reason": "live_decision_authority_unavailable"}
+            ]
+        },
+        reconciliation={"rows": []},
+    )
+    empty = build_fair_value_live_status(
+        manifest={**base_manifest, "run_id": "fv_live_authority_empty"},
+        attempts_payload={"attempts": [base_attempt]},
+        reconciliation={"rows": []},
+    )
+
+    assert acquired.summary["live_decision_authority"]["state"] == "acquired"
+    assert acquired.summary["live_decision_authority"]["fencing_token"] == 7
+    assert held.skip_reason == "live_decision_authority_held"
+    assert held.summary["live_decision_authority"]["state"] == "denied"
+    assert held.summary["live_decision_authority"]["reason"] == "live_decision_authority_held"
+    assert unavailable.skip_reason == "live_decision_authority_unavailable"
+    assert unavailable.summary["live_decision_authority"]["state"] == "unavailable"
+    assert empty.summary["live_decision_authority"]["state"] == "empty"
+    assert empty.summary["live_decision_authority"]["reason"] == (
+        "live_decision_authority_empty"
+    )
+
+
 def test_live_status_recent_attempt_rows_keep_last_50() -> None:
     attempts = [
         {


### PR DESCRIPTION
## Summary

Implements ADB-321 as a stacked PR on top of ADB-320.

- Adds sparse Postgres authority status projection from `live_decision_authority_leases` with `empty`, `held`, `expired`, and `released` states.
- Adds latest-run authority evidence to `LiveRunStatus.summary`, including acquired, denied, unavailable, stale, and empty states from manifests/runtime controls.
- Exposes current authority state through the dashboard live payload and Strategy Operator Ledger without scraping S3 lock objects.
- Represents authority read failures as `live_decision_authority_unavailable` instead of fake status.
- Adds tests for repository current-state projection, latest-run status projection, and dashboard unavailable/held authority paths.

## Validation

- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_live_authority.py tests/test_live_runtime.py tests/test_dashboard_live_console.py tests/test_fair_value_mvp.py::test_postgres_authority_backend_keeps_s3_artifacts_out_of_authority tests/test_fair_value_mvp.py::test_postgres_authority_stale_token_prevents_live_mutations tests/test_fair_value_mvp.py::test_postgres_authority_held_fails_closed_before_collection tests/test_fair_value_mvp.py::test_postgres_authority_unavailable_fails_closed_before_collection tests/test_fair_value_mvp.py::test_report_only_postgres_runtime_records_authority_lease_manifest`
- `git diff --check`
- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile src/alphadb/live_authority.py src/alphadb/live_runtime.py src/alphadb/dashboard/app.py tests/test_live_authority.py tests/test_live_runtime.py tests/test_dashboard_live_console.py`

## Stack

Base PR: https://github.com/sidmohan0/alphadb/pull/52