### PR TITLE
[codex] Add live latency evidence summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ alphadb-repo-hygiene = "alphadb.repo_hygiene:main"
 alphadb-settlement = "alphadb.settlement.cli:main"
 alphadb-model-eval = "alphadb.model_evaluation.cli:main"
 alphadb-fair-value-live-report = "alphadb.model_evaluation.fair_value_live_report:main"
+alphadb-fair-value-live-latency-chart = "alphadb.model_evaluation.fair_value_live_latency_chart:main"
 alphadb-external-signals = "alphadb.external_signals.cli:main"
 alphadb-dashboard = "alphadb.dashboard.app:main"
 

--- a/src/alphadb/model_evaluation/fair_value_live_latency_chart.py
+++ b/src/alphadb/model_evaluation/fair_value_live_latency_chart.py
@@ -1,0 +1,296 @@
+"""Generate public-safe fair-value live hot-path latency summaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from alphadb.model_evaluation.fair_value_live_report import as_mapping
+
+
+LATENCY_SUMMARY_SCHEMA = "alphadb_aws_fair_value_live_hot_path_latency.v2"
+DEFAULT_PRE_CHANGE_S3_AUTHORITY_MEAN_SECONDS = 0.808771
+DEFAULT_PRE_CHANGE_S3_AUTHORITY_CONTRIBUTION = 0.71
+
+COMPONENT_LABELS = {
+    "runtime_config": "Runtime config",
+    "postgres_authority_lease": "Postgres authority",
+    "live_run_lock": "S3 live lock",
+    "collection": "Market collection",
+    "risk_state_read": "Risk state read",
+    "risk_refresh": "Risk refresh",
+    "risk_admission": "Risk admission",
+    "submit_attempt_persist": "Attempt persist",
+    "submit": "Submit",
+    "status_materialization": "Status",
+    "artifact_write": "Artifacts",
+    "other": "Other",
+}
+
+COMPONENT_COLORS = {
+    "runtime_config": "#4f7cac",
+    "postgres_authority_lease": "#2e7d5b",
+    "live_run_lock": "#b85c38",
+    "collection": "#d6a84f",
+    "risk_state_read": "#7a5ea8",
+    "risk_refresh": "#8b8f50",
+    "risk_admission": "#6b8f71",
+    "submit_attempt_persist": "#8c6d62",
+    "submit": "#b04a5a",
+    "status_materialization": "#4f8f9f",
+    "artifact_write": "#6d7b8d",
+    "other": "#9aa0a6",
+}
+
+COMPONENT_ORDER = (
+    "runtime_config",
+    "postgres_authority_lease",
+    "live_run_lock",
+    "collection",
+    "risk_state_read",
+    "risk_refresh",
+    "risk_admission",
+    "submit_attempt_persist",
+    "submit",
+    "status_materialization",
+    "artifact_write",
+    "other",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-fair-value-live-latency-chart")
+    parser.add_argument("--input", required=True, type=Path, help="Fair-value live report JSON")
+    parser.add_argument("--summary-output", required=True, type=Path)
+    parser.add_argument("--svg-output", required=True, type=Path)
+    parser.add_argument(
+        "--pre-change-authority-mean-seconds",
+        type=float,
+        default=DEFAULT_PRE_CHANGE_S3_AUTHORITY_MEAN_SECONDS,
+    )
+    parser.add_argument(
+        "--pre-change-authority-contribution",
+        type=float,
+        default=DEFAULT_PRE_CHANGE_S3_AUTHORITY_CONTRIBUTION,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = json.loads(args.input.read_text(encoding="utf-8"))
+    if not isinstance(report, Mapping):
+        raise SystemExit("--input must be a JSON object")
+
+    summary = build_latency_summary(
+        report,
+        source_report=args.input,
+        pre_change_authority_mean_seconds=args.pre_change_authority_mean_seconds,
+        pre_change_authority_contribution=args.pre_change_authority_contribution,
+    )
+    args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_output.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.svg_output.parent.mkdir(parents=True, exist_ok=True)
+    args.svg_output.write_text(render_latency_svg(summary), encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def build_latency_summary(
+    report: Mapping[str, Any],
+    *,
+    source_report: Path,
+    pre_change_authority_mean_seconds: float,
+    pre_change_authority_contribution: float,
+) -> dict[str, Any]:
+    report_summary = as_mapping(report.get("summary"))
+    latency = as_mapping(report_summary.get("latency"))
+    authority = as_mapping(report_summary.get("live_authority"))
+    orders = as_mapping(report_summary.get("orders"))
+    total_elapsed = as_mapping(latency.get("total_elapsed_seconds"))
+    authority_phase = as_mapping(latency.get("authority_phase"))
+    component_means = ordered_component_means(
+        as_mapping(latency.get("component_means_seconds"))
+    )
+
+    authority_mean = parse_float(authority_phase.get("mean_seconds"))
+    post_change_contribution = parse_float(authority_phase.get("mean_hot_path_contribution"))
+    improvement: dict[str, Any] = {
+        "pre_change_authority_mean_seconds": round(pre_change_authority_mean_seconds, 6),
+        "pre_change_authority_contribution": round(pre_change_authority_contribution, 6),
+        "post_change_authority_mean_seconds": authority_mean,
+        "post_change_authority_contribution": post_change_contribution,
+    }
+    if authority_mean is not None:
+        improvement["authority_mean_delta_seconds"] = round(
+            authority_mean - pre_change_authority_mean_seconds,
+            6,
+        )
+        improvement["authority_mean_improvement_ratio"] = round(
+            (pre_change_authority_mean_seconds - authority_mean)
+            / pre_change_authority_mean_seconds,
+            6,
+        )
+    if post_change_contribution is not None:
+        improvement["authority_contribution_delta"] = round(
+            post_change_contribution - pre_change_authority_contribution,
+            6,
+        )
+
+    return {
+        "schema_version": LATENCY_SUMMARY_SCHEMA,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "source_report": str(source_report),
+        "interval": report.get("interval"),
+        "report_status": report.get("status"),
+        "schedule_state": report_summary.get("schedule_state"),
+        "legacy_structural_schedule_state": report_summary.get(
+            "legacy_structural_schedule_state"
+        ),
+        "run_count": report_summary.get("run_count"),
+        "runtime_config_source": as_mapping(report_summary.get("config")).get("source"),
+        "runtime_guard": report_summary.get("runtime_guard"),
+        "live_authority": authority,
+        "orders": orders,
+        "total_elapsed_seconds": total_elapsed,
+        "authority_phase": authority_phase,
+        "component_means_seconds": component_means,
+        "comparison": improvement,
+        "notes": [
+            "Read-only summary from generated AWS report and S3 manifests; no task is triggered by this command.",
+            "Segment widths use mean phase contribution to mean manifest total.",
+            "S3 should remain artifact/audit storage; Postgres should be runtime authority after the rollout deploy.",
+        ],
+    }
+
+
+def ordered_component_means(component_means: Mapping[str, Any]) -> dict[str, float]:
+    output: dict[str, float] = {}
+    for key in COMPONENT_ORDER:
+        value = parse_float(component_means.get(key))
+        if value is not None and value > 0:
+            output[key] = round(value, 6)
+    for key in sorted(component_means):
+        if key in output:
+            continue
+        value = parse_float(component_means.get(key))
+        if value is not None and value > 0:
+            output[key] = round(value, 6)
+    return output
+
+
+def render_latency_svg(summary: Mapping[str, Any]) -> str:
+    components = as_mapping(summary.get("component_means_seconds"))
+    total = sum(float(value) for value in components.values())
+    total_elapsed = parse_float(as_mapping(summary.get("total_elapsed_seconds")).get("mean"))
+    denominator = total_elapsed or total or 1.0
+    width = 1120
+    height = 360
+    margin_x = 56
+    bar_width = width - (margin_x * 2)
+    bar_y = 114
+    bar_height = 42
+    title = "Fair-value live AWS hot-path latency"
+    subtitle = (
+        f"runs={summary.get('run_count')} | authority="
+        f"{as_mapping(summary.get('authority_phase')).get('name') or 'unknown'} | "
+        f"backend={as_mapping(summary.get('live_authority')).get('backend_latest') or 'unknown'}"
+    )
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-label="{escape_xml(title)}">',
+        '<rect width="1120" height="360" fill="#f8faf7"/>',
+        f'<text x="{margin_x}" y="48" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#18211f">{escape_xml(title)}</text>',
+        f'<text x="{margin_x}" y="78" font-family="Inter, Arial, sans-serif" font-size="14" fill="#4c5753">{escape_xml(subtitle)}</text>',
+    ]
+
+    cursor = margin_x
+    for name, value in components.items():
+        seconds = float(value)
+        segment_width = max(seconds / denominator * bar_width, 1.0)
+        color = COMPONENT_COLORS.get(name, "#9aa0a6")
+        label = COMPONENT_LABELS.get(name, name.replace("_", " ").title())
+        parts.append(
+            f'<rect x="{cursor:.2f}" y="{bar_y}" width="{segment_width:.2f}" height="{bar_height}" fill="{color}"/>'
+        )
+        if segment_width >= 84:
+            parts.append(
+                f'<text x="{cursor + 10:.2f}" y="{bar_y + 26}" font-family="Inter, Arial, sans-serif" font-size="12" fill="#ffffff">{escape_xml(label)}</text>'
+            )
+        cursor += segment_width
+
+    comparison = as_mapping(summary.get("comparison"))
+    authority_phase = as_mapping(summary.get("authority_phase"))
+    details = [
+        f"mean total: {format_seconds(total_elapsed)}",
+        f"authority mean: {format_seconds(authority_phase.get('mean_seconds'))}",
+        f"authority p95: {format_seconds(authority_phase.get('p95_seconds'))}",
+        f"vs S3 baseline: {format_delta(comparison.get('authority_mean_delta_seconds'))}",
+        f"submitted orders: {as_mapping(summary.get('orders')).get('submitted', 0)}",
+    ]
+    for index, detail in enumerate(details):
+        parts.append(
+            f'<text x="{margin_x}" y="{205 + index * 24}" font-family="Inter, Arial, sans-serif" font-size="14" fill="#25302d">{escape_xml(detail)}</text>'
+        )
+
+    legend_x = 430
+    legend_y = 198
+    for index, (name, value) in enumerate(components.items()):
+        x = legend_x + (index % 2) * 300
+        y = legend_y + (index // 2) * 28
+        label = COMPONENT_LABELS.get(name, name.replace("_", " ").title())
+        parts.append(
+            f'<rect x="{x}" y="{y - 12}" width="12" height="12" fill="{COMPONENT_COLORS.get(name, "#9aa0a6")}"/>'
+        )
+        parts.append(
+            f'<text x="{x + 20}" y="{y}" font-family="Inter, Arial, sans-serif" font-size="13" fill="#25302d">{escape_xml(label)} {format_seconds(value)}</text>'
+        )
+
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+def format_seconds(value: Any) -> str:
+    parsed = parse_float(value)
+    if parsed is None:
+        return "n/a"
+    return f"{parsed:.3f}s"
+
+
+def format_delta(value: Any) -> str:
+    parsed = parse_float(value)
+    if parsed is None:
+        return "n/a"
+    sign = "+" if parsed >= 0 else ""
+    return f"{sign}{parsed:.3f}s"
+
+
+def parse_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed != parsed:
+        return None
+    return parsed
+
+
+def escape_xml(value: Any) -> str:
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/alphadb/model_evaluation/fair_value_live_report.py
+++ b/src/alphadb/model_evaluation/fair_value_live_report.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import re
+import statistics
 import time
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
@@ -371,6 +372,7 @@ def build_summary(*, values: Mapping[str, Any], runs: Sequence[Mapping[str, Any]
     ]
     live_risk_state = as_mapping(latest_value(runs, "live_risk_admission_state"))
     live_risk_refresh = as_mapping(latest_value(runs, "live_risk_refresh"))
+    latency = summarize_latency(runs)
     return {
         "schedule_state": fair_rule.get("State"),
         "legacy_structural_schedule_state": structural_rule.get("State"),
@@ -382,6 +384,8 @@ def build_summary(*, values: Mapping[str, Any], runs: Sequence[Mapping[str, Any]
         "legacy_structural_live_activity": bool(structural_logs),
         "config": latest_value(runs, "runtime_config"),
         "runtime_guard": latest_value(runs, "runtime_guard"),
+        "live_authority": summarize_live_authority(runs),
+        "latency": latency,
         "executable_quote": latest_value(runs, "executable_quote"),
         "live_edge_attribution": latest_value(runs, "live_edge_attribution"),
         "live_edge_attribution_buckets": summarize_live_edge_attribution_buckets(
@@ -411,6 +415,7 @@ def build_summary(*, values: Mapping[str, Any], runs: Sequence[Mapping[str, Any]
 
 def summarize_run(*, run_id: str, artifacts: Mapping[str, Any]) -> dict[str, Any]:
     manifest = as_mapping(artifacts.get("manifest"))
+    runtime_controls = as_mapping(manifest.get("runtime_controls"))
     attempts_payload = as_mapping(artifacts.get("live_order_attempts"))
     reconciliation = as_mapping(artifacts.get("live_reconciliation_report"))
     attempts = as_sequence(attempts_payload.get("attempts"))
@@ -428,7 +433,10 @@ def summarize_run(*, run_id: str, artifacts: Mapping[str, Any]) -> dict[str, Any
         "run_id": run_id,
         "generated_at": manifest.get("generated_at"),
         "runtime_config": manifest.get("runtime_config"),
-        "runtime_guard": as_mapping(manifest.get("runtime_controls")).get("runtime_guard"),
+        "runtime_controls": dict(runtime_controls),
+        "runtime_guard": runtime_controls.get("runtime_guard"),
+        "live_authority": summarize_run_live_authority(manifest),
+        "timing": summarize_manifest_timing(manifest),
         "executable_quote": manifest.get("executable_quote"),
         "one_cycle": manifest.get("one_cycle"),
         "hot_path_scope": manifest.get("hot_path_scope"),
@@ -445,6 +453,177 @@ def summarize_run(*, run_id: str, artifacts: Mapping[str, Any]) -> dict[str, Any
         "orders": orders,
         "reconciliation": summarize_reconciliation(reconciliation),
     }
+
+
+def summarize_manifest_timing(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    timing = as_mapping(manifest.get("timing"))
+    phase_seconds: dict[str, float] = {}
+    for phase, value in as_mapping(timing.get("phase_seconds")).items():
+        parsed = parse_float(value)
+        if parsed is not None:
+            phase_seconds[str(phase)] = parsed
+    output: dict[str, Any] = {"phase_seconds": phase_seconds}
+    total_elapsed = parse_float(timing.get("total_elapsed_seconds"))
+    if total_elapsed is not None:
+        output["total_elapsed_seconds"] = total_elapsed
+    quote_to_submit = parse_float(timing.get("quote_to_submit_seconds"))
+    if quote_to_submit is not None:
+        output["quote_to_submit_seconds"] = quote_to_submit
+    authority_phase = authority_phase_name(phase_seconds)
+    if authority_phase:
+        output["authority_phase"] = authority_phase
+        output["authority_phase_seconds"] = phase_seconds[authority_phase]
+    return output
+
+
+def summarize_run_live_authority(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    runtime_controls = as_mapping(manifest.get("runtime_controls"))
+    live_run_lock = as_mapping(runtime_controls.get("live_run_lock"))
+    lease = as_mapping(runtime_controls.get("live_decision_authority_lease"))
+    backend = (
+        live_run_lock.get("backend")
+        or runtime_controls.get("live_authority_backend")
+        or lease.get("backend")
+    )
+    output: dict[str, Any] = {}
+    if backend:
+        output["backend"] = str(backend)
+    requested = runtime_controls.get("live_authority_backend_requested")
+    if requested:
+        output["backend_requested"] = str(requested)
+    if "acquired" in live_run_lock:
+        output["acquired"] = bool(live_run_lock.get("acquired"))
+    reason = live_run_lock.get("reason") or lease.get("reason")
+    if reason:
+        output["reason"] = str(reason)
+    for key in ("run_id", "owner_id", "fencing_token", "lease_status", "acquired_at", "expires_at", "released_at"):
+        value = lease.get(key, live_run_lock.get(key))
+        if value is not None:
+            output[key] = value
+    return output
+
+
+def summarize_live_authority(runs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    authorities = [as_mapping(run.get("live_authority")) for run in runs]
+    authorities = [authority for authority in authorities if authority]
+    latest = authorities[-1] if authorities else {}
+    backends = Counter(str(authority.get("backend")) for authority in authorities if authority.get("backend"))
+    acquired_count = sum(1 for authority in authorities if authority.get("acquired") is True)
+    denied_count = sum(1 for authority in authorities if authority.get("acquired") is False)
+    output: dict[str, Any] = {
+        "backend_latest": latest.get("backend"),
+        "backend_counts": dict(backends),
+        "acquired_count": acquired_count,
+        "denied_count": denied_count,
+        "fencing_token_observed": any(
+            authority.get("fencing_token") is not None for authority in authorities
+        ),
+    }
+    if latest:
+        output["latest"] = dict(latest)
+    return output
+
+
+def summarize_latency(runs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    timings = [as_mapping(run.get("timing")) for run in runs]
+    total_values = [
+        value
+        for timing in timings
+        if (value := parse_float(timing.get("total_elapsed_seconds"))) is not None
+    ]
+    phase_names = sorted(
+        {
+            phase
+            for timing in timings
+            for phase in as_mapping(timing.get("phase_seconds")).keys()
+        }
+    )
+    phase_seconds = {
+        phase: stats(
+            [
+                value
+                for timing in timings
+                if (
+                    value := parse_float(
+                        as_mapping(timing.get("phase_seconds")).get(phase)
+                    )
+                )
+                is not None
+            ]
+        )
+        for phase in phase_names
+    }
+    authority_phase = authority_phase_name(
+        {
+            phase: as_mapping(stat).get("mean")
+            for phase, stat in phase_seconds.items()
+            if as_mapping(stat).get("mean") is not None
+        }
+    )
+    component_means = component_mean_contribution(
+        total_mean=stats(total_values).get("mean"),
+        phase_seconds=phase_seconds,
+        authority_phase=authority_phase,
+    )
+    output: dict[str, Any] = {
+        "total_elapsed_seconds": stats(total_values),
+        "phase_seconds": phase_seconds,
+        "component_means_seconds": component_means,
+    }
+    if authority_phase:
+        authority_stats = as_mapping(phase_seconds.get(authority_phase))
+        total_mean = parse_float(as_mapping(output["total_elapsed_seconds"]).get("mean"))
+        authority_mean = parse_float(authority_stats.get("mean"))
+        output["authority_phase"] = {
+            "name": authority_phase,
+            "mean_seconds": authority_mean,
+            "p95_seconds": authority_stats.get("p95"),
+            "mean_hot_path_contribution": (
+                round(authority_mean / total_mean, 6)
+                if authority_mean is not None and total_mean
+                else None
+            ),
+        }
+    return output
+
+
+def authority_phase_name(phase_seconds: Mapping[str, Any]) -> str | None:
+    for phase in ("postgres_authority_lease", "live_run_lock"):
+        if phase in phase_seconds:
+            return phase
+    return None
+
+
+def component_mean_contribution(
+    *,
+    total_mean: Any,
+    phase_seconds: Mapping[str, Any],
+    authority_phase: str | None,
+) -> dict[str, float]:
+    names = [
+        "runtime_config",
+        authority_phase or "live_run_lock",
+        "collection",
+        "risk_state_read",
+        "risk_refresh",
+        "risk_admission",
+        "submit_attempt_persist",
+        "submit",
+        "status_materialization",
+        "artifact_write",
+    ]
+    output: dict[str, float] = {}
+    used_total = 0.0
+    for name in names:
+        mean = parse_float(as_mapping(phase_seconds.get(name)).get("mean"))
+        if mean is None or name in output:
+            continue
+        output[name] = round(mean, 6)
+        used_total += mean
+    parsed_total = parse_float(total_mean)
+    if parsed_total is not None:
+        output["other"] = round(max(parsed_total - used_total, 0.0), 6)
+    return output
 
 
 def summarize_attempts(
@@ -652,6 +831,57 @@ def as_mapping(value: Any) -> Mapping[str, Any]:
 
 def as_sequence(value: Any) -> Sequence[Any]:
     return value if isinstance(value, Sequence) and not isinstance(value, (str, bytes)) else ()
+
+
+def parse_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed != parsed:
+        return None
+    return parsed
+
+
+def stats(values: Sequence[float]) -> dict[str, float | int | None]:
+    ordered = sorted(float(value) for value in values)
+    if not ordered:
+        return {
+            "count": 0,
+            "min": None,
+            "mean": None,
+            "p50": None,
+            "p90": None,
+            "p95": None,
+            "p99": None,
+            "max": None,
+            "stdev": None,
+        }
+    return {
+        "count": len(ordered),
+        "min": round(ordered[0], 6),
+        "mean": round(statistics.fmean(ordered), 6),
+        "p50": percentile(ordered, 50),
+        "p90": percentile(ordered, 90),
+        "p95": percentile(ordered, 95),
+        "p99": percentile(ordered, 99),
+        "max": round(ordered[-1], 6),
+        "stdev": round(statistics.stdev(ordered), 6) if len(ordered) > 1 else 0.0,
+    }
+
+
+def percentile(values: Sequence[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return round(ordered[0], 6)
+    rank = (len(ordered) - 1) * pct / 100.0
+    lower_index = int(rank)
+    upper_index = min(lower_index + 1, len(ordered) - 1)
+    fraction = rank - lower_index
+    value = ordered[lower_index] + (ordered[upper_index] - ordered[lower_index]) * fraction
+    return round(value, 6)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_fair_value_live_report.py
+++ b/tests/test_fair_value_live_report.py
@@ -10,6 +10,10 @@ from types import SimpleNamespace
 from typing import Any
 
 from alphadb.model_evaluation import fair_value_live_report as report_module
+from alphadb.model_evaluation.fair_value_live_latency_chart import (
+    build_latency_summary,
+    render_latency_svg,
+)
 from alphadb.model_evaluation.fair_value_live_report import (
     Boto3FairValueLiveEvidenceClient,
     FairValueLiveReportConfig,
@@ -185,10 +189,39 @@ class S3OnlyEvidenceClient(FailingEvidenceClient):
                     },
                 },
                 "runtime_controls": {
+                    "live_authority_backend": "postgres",
+                    "live_authority_backend_requested": "postgres",
+                    "live_run_lock": {
+                        "backend": "postgres",
+                        "acquired": True,
+                        "run_id": "fv_live_20260606T171540Z",
+                        "owner_id": "owner-1",
+                        "fencing_token": 12,
+                        "lease_status": "released",
+                    },
+                    "live_decision_authority_lease": {
+                        "backend": "postgres",
+                        "acquired": True,
+                        "run_id": "fv_live_20260606T171540Z",
+                        "owner_id": "owner-1",
+                        "fencing_token": 12,
+                        "lease_status": "released",
+                    },
                     "runtime_guard": {
                         "credentials_present": True,
                         "can_submit_live_orders": True,
                     }
+                },
+                "timing": {
+                    "total_elapsed_seconds": 1.25,
+                    "phase_seconds": {
+                        "runtime_config": 0.08,
+                        "postgres_authority_lease": 0.03,
+                        "live_run_lock": 0.0,
+                        "collection": 0.12,
+                        "status_materialization": 0.07,
+                        "artifact_write": 0.01,
+                    },
                 },
                 "executable_quote": {
                     "source": "kalshi_orderbook",
@@ -280,6 +313,24 @@ def test_report_uses_reachable_s3_artifacts_for_partial_zero_order_report() -> N
     assert report["summary"]["run_count"] == 1
     assert report["summary"]["config"]["config_id"] == "live_cfg_deaa1bcf8660"
     assert report["summary"]["runtime_guard"]["credentials_present"] is True
+    assert report["summary"]["live_authority"]["backend_latest"] == "postgres"
+    assert report["summary"]["live_authority"]["fencing_token_observed"] is True
+    assert report["summary"]["live_authority"]["latest"]["fencing_token"] == 12
+    assert report["summary"]["latency"]["total_elapsed_seconds"]["mean"] == 1.25
+    assert report["summary"]["latency"]["authority_phase"] == {
+        "name": "postgres_authority_lease",
+        "mean_seconds": 0.03,
+        "p95_seconds": 0.03,
+        "mean_hot_path_contribution": 0.024,
+    }
+    assert report["summary"]["latency"]["component_means_seconds"] == {
+        "runtime_config": 0.08,
+        "postgres_authority_lease": 0.03,
+        "collection": 0.12,
+        "status_materialization": 0.07,
+        "artifact_write": 0.01,
+        "other": 0.94,
+    }
     assert report["summary"]["executable_quote"]["source"] == "kalshi_orderbook"
     assert report["summary"]["live_edge_attribution"]["edge_shortfall"] == 0.02
     assert report["summary"]["live_edge_attribution_buckets"] == [
@@ -296,6 +347,8 @@ def test_report_uses_reachable_s3_artifacts_for_partial_zero_order_report() -> N
     }
     assert report["summary"]["reconciliation"]["net_pnl_dollars"] == 0.0
     assert report["runs"][0]["selected_decision"]["reason"] == "edge_below_min"
+    assert report["runs"][0]["live_authority"]["backend"] == "postgres"
+    assert report["runs"][0]["timing"]["authority_phase"] == "postgres_authority_lease"
     assert report["runs"][0]["live_edge_attribution"]["attribution_class"] == "threshold_drag"
     assert report["runs"][0]["live_edge_attributions"][0]["edge"] == 0.03
 
@@ -323,6 +376,64 @@ def test_fair_value_live_report_has_public_console_command() -> None:
         pyproject["project"]["scripts"]["alphadb-fair-value-live-report"]
         == "alphadb.model_evaluation.fair_value_live_report:main"
     )
+    assert (
+        pyproject["project"]["scripts"]["alphadb-fair-value-live-latency-chart"]
+        == "alphadb.model_evaluation.fair_value_live_latency_chart:main"
+    )
+
+
+def test_latency_chart_summary_compares_postgres_authority_to_s3_baseline() -> None:
+    report = {
+        "status": "complete",
+        "interval": {
+            "start": "2026-06-10T00:20:00+00:00",
+            "end": "2026-06-10T00:40:00+00:00",
+        },
+        "summary": {
+            "schedule_state": "ENABLED",
+            "legacy_structural_schedule_state": "DISABLED",
+            "run_count": 3,
+            "config": {"source": "dashboard_postgres"},
+            "runtime_guard": {"can_submit_live_orders": True},
+            "orders": {"submitted": 0, "skipped": 3},
+            "live_authority": {
+                "backend_latest": "postgres",
+                "fencing_token_observed": True,
+            },
+            "latency": {
+                "total_elapsed_seconds": {"mean": 0.42, "p95": 0.5},
+                "authority_phase": {
+                    "name": "postgres_authority_lease",
+                    "mean_seconds": 0.02,
+                    "p95_seconds": 0.03,
+                    "mean_hot_path_contribution": 0.047619,
+                },
+                "component_means_seconds": {
+                    "runtime_config": 0.08,
+                    "postgres_authority_lease": 0.02,
+                    "collection": 0.12,
+                    "status_materialization": 0.07,
+                    "artifact_write": 0.01,
+                    "other": 0.12,
+                },
+            },
+        },
+    }
+
+    summary = build_latency_summary(
+        report,
+        source_report=Path("aws-report.json"),
+        pre_change_authority_mean_seconds=0.808771,
+        pre_change_authority_contribution=0.71,
+    )
+    svg = render_latency_svg(summary)
+
+    assert summary["live_authority"]["backend_latest"] == "postgres"
+    assert summary["authority_phase"]["name"] == "postgres_authority_lease"
+    assert summary["comparison"]["authority_mean_delta_seconds"] == -0.788771
+    assert summary["comparison"]["authority_mean_improvement_ratio"] == 0.975271
+    assert "Postgres authority" in svg
+    assert "vs S3 baseline: -0.789s" in svg
 
 
 def test_boto3_adapter_configures_local_aws_profile_region_and_metadata(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add read-only authority/latency summaries to the fair-value live AWS report
- add a console command that turns a report JSON into a public-safe latency summary and SVG stacked bar
- cover the Postgres-authority comparison path in focused tests

## ADB-322 evidence
- deployed task definition: alphadb-fair-value-live:16
- deployed image: 766780331843.dkr.ecr.us-east-2.amazonaws.com/alphadb-dashboard:1edabf3-20260610005651
- schedule policy: preserved existing ENABLED fair-value schedule; legacy structural schedule remained DISABLED
- final evidence interval: 2026-06-10T01:00:00Z to 2026-06-10T01:10:00Z
- run count: 11
- authority backend counts: postgres=11
- fencing token observed: true
- submitted orders: 0
- CloudWatch error events: 0
- total runtime mean/p95: 0.442106s / 0.484768s
- authority phase mean/p95: 0.089933s / 0.117206s
- S3 baseline authority mean/contribution: 0.808771s / 71%
- post-change authority contribution: 20.342%

## Validation
- PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_fair_value_live_report.py
- PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check src/alphadb/model_evaluation/fair_value_live_report.py src/alphadb/model_evaluation/fair_value_live_latency_chart.py tests/test_fair_value_live_report.py
- python3 -m py_compile src/alphadb/model_evaluation/fair_value_live_report.py src/alphadb/model_evaluation/fair_value_live_latency_chart.py tests/test_fair_value_live_report.py
- git diff --check