### PR TITLE
[codex] Land Postgres authority stack

### DIFF
--- a/deploy/aws/deploy-fair-value-live-trading-job.sh
+++ b/deploy/aws/deploy-fair-value-live-trading-job.sh
@@ -118,6 +118,7 @@ aws_cli cloudformation deploy \
     ScheduleState="${SCHEDULE_STATE:-DISABLED}" \
     MinEdgeValues="${MIN_EDGE_VALUES:-0.0,0.05,0.10}" \
     MinContractPrice="${MIN_CONTRACT_PRICE:-0.25}" \
+    LiveAuthorityBackend="${LIVE_AUTHORITY_BACKEND:-postgres}" \
     KalshiApiKeyIdSecretArn="$KALSHI_API_KEY_ID_SECRET_ARN" \
     KalshiPrivateKeyPemSecretArn="$KALSHI_PRIVATE_KEY_PEM_SECRET_ARN" \
     AwsRegionValue="$REGION"

--- a/deploy/aws/fair-value-live-trading-job.yaml
+++ b/deploy/aws/fair-value-live-trading-job.yaml
@@ -49,6 +49,13 @@ Parameters:
   MinContractPrice:
     Type: String
     Default: "0.25"
+  LiveAuthorityBackend:
+    Type: String
+    Default: postgres
+    AllowedValues:
+      - postgres
+      - s3
+    Description: Runtime authority backend; use s3 only as the temporary rollback path.
   KalshiApiKeyIdSecretArn:
     Type: String
     Description: Secrets Manager ARN whose value is KALSHI_API_KEY_ID.
@@ -178,6 +185,8 @@ Resources:
             - "60"
             - --runtime-config-source
             - postgres
+            - --live-authority-backend
+            - !Ref LiveAuthorityBackend
             - --submit-live-orders
           Environment:
             - Name: ALPHADB_ENV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ alphadb-repo-hygiene = "alphadb.repo_hygiene:main"
 alphadb-settlement = "alphadb.settlement.cli:main"
 alphadb-model-eval = "alphadb.model_evaluation.cli:main"
 alphadb-fair-value-live-report = "alphadb.model_evaluation.fair_value_live_report:main"
+alphadb-fair-value-live-latency-chart = "alphadb.model_evaluation.fair_value_live_latency_chart:main"
 alphadb-external-signals = "alphadb.external_signals.cli:main"
 alphadb-dashboard = "alphadb.dashboard.app:main"
 

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -34,6 +34,7 @@ from alphadb.deployment_intents import (
     deployment_intent_kwargs_from_payload,
 )
 from alphadb.health import HealthReport, collect_health
+from alphadb.live_authority import LiveDecisionAuthorityLeaseRepository
 from alphadb.live_runtime import (
     EXPENSIVE_YES_LIVE_STRATEGY,
     FAIR_VALUE_LIVE_STRATEGY,
@@ -52,6 +53,7 @@ from alphadb.portfolio import cached_portfolio_balance_payload
 
 ConfigRepositoryFactory = Callable[[str], LiveRuntimeConfigRepository]
 StatusRepositoryFactory = Callable[[str], LiveRunStatusRepository]
+AuthorityRepositoryFactory = Callable[[str], LiveDecisionAuthorityLeaseRepository]
 LiveRiskRepositoryFactory = Callable[[str], LiveRiskAdmissionRepository]
 StrategyRepositoryFactory = Callable[[str], DashboardStrategyRepository]
 DataExplorerRepositoryFactory = Callable[[str], DashboardDataExplorerRepository]
@@ -70,6 +72,9 @@ class DashboardService:
     settings: Settings
     config_repository_factory: ConfigRepositoryFactory = LiveRuntimeConfigRepository
     status_repository_factory: StatusRepositoryFactory = LiveRunStatusRepository
+    authority_repository_factory: AuthorityRepositoryFactory = (
+        LiveDecisionAuthorityLeaseRepository
+    )
     live_risk_repository_factory: LiveRiskRepositoryFactory = LiveRiskAdmissionRepository
     strategy_repository_factory: StrategyRepositoryFactory = DashboardStrategyRepository
     data_explorer_repository_factory: DataExplorerRepositoryFactory = (
@@ -99,9 +104,16 @@ class DashboardService:
         history = config_repository.recent_revisions(strategy=strategy, limit=6)
         status_repository = self.status_repository_factory(self.settings.database_url)
         latest_status = status_repository.latest_status(strategy=strategy)
+        authority_status, authority_error = _live_authority_status(
+            self.authority_repository_factory(self.settings.database_url),
+            strategy=strategy,
+        )
         live_status = latest_status.as_dict()
         status_summary = _mapping_or_empty(live_status.get("summary"))
         live_status.pop("summary", None)
+        live_status["live_decision_authority"] = authority_status
+        if authority_error:
+            live_status["live_decision_authority_error"] = authority_error
         report = self.health_collector(self.settings)
         return {
             "strategy": strategy,
@@ -132,11 +144,13 @@ class DashboardService:
         generated_at = datetime.now(UTC)
         config_repository = self.config_repository_factory(self.settings.database_url)
         status_repository = self.status_repository_factory(self.settings.database_url)
+        authority_repository = self.authority_repository_factory(self.settings.database_url)
         rows = [
             _strategy_operator_ledger_row(
                 strategy=strategy,
                 config_repository=config_repository,
                 status_repository=status_repository,
+                authority_repository=authority_repository,
             )
             for strategy in LIVE_DASHBOARD_STRATEGIES
         ]
@@ -503,6 +517,7 @@ def _strategy_operator_ledger_row(
     strategy: str,
     config_repository: LiveRuntimeConfigRepository,
     status_repository: LiveRunStatusRepository,
+    authority_repository: LiveDecisionAuthorityLeaseRepository,
 ) -> dict[str, Any]:
     metadata = runtime_strategy_metadata(strategy)
     active_config: dict[str, Any] | None = None
@@ -525,6 +540,10 @@ def _strategy_operator_ledger_row(
     except Exception as exc:
         recent_runs = []
         recent_runs_error = f"{type(exc).__name__}: {exc}"
+    authority_status, authority_error = _live_authority_status(
+        authority_repository,
+        strategy=strategy,
+    )
 
     health, health_detail = _strategy_operator_health(
         latest_status,
@@ -563,6 +582,10 @@ def _strategy_operator_ledger_row(
             config_error=config_error,
             status_error=status_error,
         ),
+        "authority_summary": _strategy_operator_authority_summary(
+            authority_status,
+            authority_error=authority_error,
+        ),
         "decision_outcome": latest_status.decision_outcome,
         "latest_attempt_status": latest_status.latest_attempt_status,
         "latest_attempt_reason": latest_status.latest_attempt_reason,
@@ -572,6 +595,7 @@ def _strategy_operator_ledger_row(
         "active_config": active_config,
         "config_error": config_error,
         "status_error": status_error,
+        "authority_error": authority_error,
         "recent_runs_error": recent_runs_error,
     }
 
@@ -712,6 +736,68 @@ def _recent_run_summaries(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, A
     normalized = [dict(row) for row in rows if isinstance(row, Mapping)]
     normalized.sort(key=lambda row: str(row.get("generated_at") or ""), reverse=True)
     return normalized[:3]
+
+
+def _live_authority_status(
+    authority_repository: LiveDecisionAuthorityLeaseRepository,
+    *,
+    strategy: str,
+) -> tuple[dict[str, Any], str | None]:
+    try:
+        return dict(authority_repository.status(strategy=strategy)), None
+    except Exception as exc:
+        return (
+            {
+                "schema_version": "alphadb_live_decision_authority_status.v1",
+                "backend": "postgres",
+                "strategy": strategy,
+                "state": "unavailable",
+                "reason": "live_decision_authority_unavailable",
+                "run_id": None,
+                "owner_id": None,
+                "fencing_token": None,
+                "acquired_at": None,
+                "expires_at": None,
+                "released_at": None,
+                "lease_status": None,
+            },
+            f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _strategy_operator_authority_summary(
+    authority_status: Mapping[str, Any],
+    *,
+    authority_error: str | None,
+) -> dict[str, Any]:
+    state = _optional_text(authority_status.get("state")) or "empty"
+    reason = _optional_text(authority_status.get("reason"))
+    run_id = _optional_text(authority_status.get("run_id"))
+    expires_at = _optional_text(authority_status.get("expires_at"))
+    if authority_error:
+        state = "unavailable"
+        detail = f"Authority state unavailable: {authority_error}"
+    elif state == "empty":
+        detail = "No Postgres authority lease recorded."
+    elif state == "held":
+        holder = f" by {run_id}" if run_id else ""
+        expiry = f" until {expires_at}" if expires_at else ""
+        detail = f"Authority held{holder}{expiry}."
+    elif state == "expired":
+        detail = f"Authority lease expired at {expires_at or 'unknown time'}."
+    elif state == "released":
+        detail = f"Authority lease released by {run_id or 'unknown run'}."
+    else:
+        detail = reason or f"Authority state: {state}"
+    return {
+        "state": state,
+        "detail": detail,
+        "backend": authority_status.get("backend"),
+        "reason": reason,
+        "run_id": run_id,
+        "fencing_token": authority_status.get("fencing_token"),
+        "expires_at": expires_at,
+    }
 
 
 def _strategy_operator_fleet_health(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:

--- a/src/alphadb/live_authority.py
+++ b/src/alphadb/live_authority.py
@@ -19,6 +19,7 @@ LIVE_DECISION_AUTHORITY_LEASE_SCHEMA = "alphadb_live_decision_authority_lease.v1
 LIVE_DECISION_AUTHORITY_RESULT_SCHEMA = "alphadb_live_decision_authority_result.v1"
 AuthorityAcquireStatus = Literal["acquired", "held"]
 AuthorityReleaseStatus = Literal["released", "stale"]
+AuthorityValidationStatus = Literal["validated", "stale"]
 
 
 @dataclass(frozen=True)
@@ -94,6 +95,29 @@ class LiveDecisionAuthorityReleaseResult:
             "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
             "backend": "postgres",
             "released": self.released,
+            "status": self.status,
+            "reason": self.reason,
+            "lease": lease.as_dict() if lease else None,
+        }
+
+
+@dataclass(frozen=True)
+class LiveDecisionAuthorityValidationResult:
+    status: AuthorityValidationStatus
+    lease: LiveDecisionAuthorityLease | None = None
+    current_lease: LiveDecisionAuthorityLease | None = None
+    reason: str | None = None
+
+    @property
+    def valid(self) -> bool:
+        return self.status == "validated"
+
+    def as_dict(self) -> dict[str, Any]:
+        lease = self.lease or self.current_lease
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": "postgres",
+            "valid": self.valid,
             "status": self.status,
             "reason": self.reason,
             "lease": lease.as_dict() if lease else None,
@@ -255,6 +279,36 @@ class LiveDecisionAuthorityLeaseRepository:
             status="stale",
             lease=None,
             current_lease=lease_from_row(current) if current else None,
+            reason="stale_live_decision_authority_token",
+        )
+
+    def validate_active(
+        self,
+        *,
+        strategy: str = FAIR_VALUE_LIVE_STRATEGY,
+        owner_id: str,
+        fencing_token: int,
+        now: datetime | None = None,
+    ) -> LiveDecisionAuthorityValidationResult:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        observed_at = ensure_utc(now or datetime.now(UTC))
+        current = self.get(strategy=strategy, apply_migrations=False)
+        if (
+            current is not None
+            and current.owner_id == owner_id
+            and current.fencing_token == fencing_token
+            and current.status == "active"
+            and current.released_at is None
+            and current.expires_at > observed_at
+        ):
+            return LiveDecisionAuthorityValidationResult(
+                status="validated",
+                lease=current,
+            )
+        return LiveDecisionAuthorityValidationResult(
+            status="stale",
+            lease=None,
+            current_lease=current,
             reason="stale_live_decision_authority_token",
         )
 

--- a/src/alphadb/live_authority.py
+++ b/src/alphadb/live_authority.py
@@ -17,6 +17,7 @@ from alphadb.state.repository import OperationalStateRepository
 
 LIVE_DECISION_AUTHORITY_LEASE_SCHEMA = "alphadb_live_decision_authority_lease.v1"
 LIVE_DECISION_AUTHORITY_RESULT_SCHEMA = "alphadb_live_decision_authority_result.v1"
+LIVE_DECISION_AUTHORITY_STATUS_SCHEMA = "alphadb_live_decision_authority_status.v1"
 AuthorityAcquireStatus = Literal["acquired", "held"]
 AuthorityReleaseStatus = Literal["released", "stale"]
 AuthorityValidationStatus = Literal["validated", "stale"]
@@ -311,6 +312,67 @@ class LiveDecisionAuthorityLeaseRepository:
             current_lease=current,
             reason="stale_live_decision_authority_token",
         )
+
+    def status(
+        self,
+        *,
+        strategy: str = FAIR_VALUE_LIVE_STRATEGY,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        OperationalStateRepository(self.database_url).apply_migrations()
+        observed_at = ensure_utc(now or datetime.now(UTC))
+        current = self.get(strategy=strategy, apply_migrations=False)
+        return live_decision_authority_status(
+            strategy=strategy,
+            lease=current,
+            now=observed_at,
+        )
+
+
+def live_decision_authority_status(
+    *,
+    strategy: str,
+    lease: LiveDecisionAuthorityLease | None,
+    now: datetime,
+) -> dict[str, Any]:
+    if lease is None:
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_STATUS_SCHEMA,
+            "backend": "postgres",
+            "strategy": strategy,
+            "state": "empty",
+            "reason": "live_decision_authority_empty",
+            "run_id": None,
+            "owner_id": None,
+            "fencing_token": None,
+            "acquired_at": None,
+            "expires_at": None,
+            "released_at": None,
+            "lease_status": None,
+        }
+    if lease.status == "active" and lease.released_at is None:
+        state = "expired" if lease.expires_at <= now else "held"
+        reason = "live_decision_authority_expired" if state == "expired" else None
+    elif lease.status == "released" or lease.released_at is not None:
+        state = "released"
+        reason = None
+    else:
+        state = lease.status or "unknown"
+        reason = f"live_decision_authority_{state}"
+    return {
+        "schema_version": LIVE_DECISION_AUTHORITY_STATUS_SCHEMA,
+        "backend": "postgres",
+        "strategy": lease.strategy,
+        "state": state,
+        "reason": reason,
+        "run_id": lease.run_id,
+        "owner_id": lease.owner_id,
+        "fencing_token": lease.fencing_token,
+        "acquired_at": lease.acquired_at.isoformat(),
+        "expires_at": lease.expires_at.isoformat(),
+        "released_at": lease.released_at.isoformat() if lease.released_at else None,
+        "lease_status": lease.status,
+    }
 
 
 def lease_from_row(row: Mapping[str, Any]) -> LiveDecisionAuthorityLease:

--- a/src/alphadb/live_runtime.py
+++ b/src/alphadb/live_runtime.py
@@ -643,6 +643,10 @@ def build_fair_value_live_status(
     market_used = _market_exposure_for(latest_market, reconciliation)
     fill_status = _fill_status(latest_attempt, latest_reconciliation)
     decision_outcome = _decision_outcome(latest_status, manifest)
+    live_decision_authority = latest_live_decision_authority_status(
+        runtime_controls=runtime_controls,
+        latest_reason=latest_reason,
+    )
     return LiveRunStatus(
         run_id=_text(manifest.get("run_id")),
         strategy=status_strategy,
@@ -683,6 +687,7 @@ def build_fair_value_live_status(
             "market_context": dict(_mapping(manifest.get("market_context"))),
             "live_risk_admission_state": dict(live_risk_admission_state),
             "live_risk_refresh": dict(live_risk_refresh),
+            "live_decision_authority": live_decision_authority,
             "risk_state_classification": classify_risk_state(
                 live_risk_admission_state=live_risk_admission_state,
                 live_risk_refresh=live_risk_refresh,
@@ -696,6 +701,9 @@ def build_fair_value_live_status(
                     "orders_placed",
                     "filled_contracts",
                     "market_context_source",
+                    "live_authority_backend",
+                    "live_authority_backend_requested",
+                    "live_status_materialization_skip_reason",
                 )
             },
         },
@@ -730,6 +738,83 @@ def no_recent_live_run_status(*, strategy: str = FAIR_VALUE_LIVE_STRATEGY) -> Li
         summary={},
         recent_attempts=[],
     )
+
+
+def latest_live_decision_authority_status(
+    *,
+    runtime_controls: Mapping[str, Any],
+    latest_reason: str | None,
+) -> dict[str, Any]:
+    lease = _mapping(runtime_controls.get("live_decision_authority_lease"))
+    live_run_lock = _mapping(runtime_controls.get("live_run_lock"))
+    evidence = lease or (
+        live_run_lock if _text(live_run_lock.get("backend")) == "postgres" else {}
+    )
+    backend = (
+        _text(evidence.get("backend"))
+        or _text(runtime_controls.get("live_authority_backend"))
+    )
+    if not backend:
+        return _authority_status_payload(
+            backend=None,
+            state="empty",
+            reason="live_decision_authority_empty",
+        )
+    if backend != "postgres":
+        return _authority_status_payload(
+            backend=backend,
+            state="not_applicable",
+            reason=None,
+        )
+    validation = _mapping(runtime_controls.get("live_decision_authority_validation"))
+    validation_reason = _text(validation.get("reason"))
+    if validation and not bool(validation.get("valid", True)):
+        return _authority_status_payload(
+            backend="postgres",
+            state="stale",
+            reason=validation_reason or "stale_live_decision_authority_token",
+            evidence=evidence,
+        )
+    reason = _text(evidence.get("reason")) or latest_reason
+    acquired = bool(evidence.get("acquired"))
+    if acquired:
+        state = "acquired"
+    elif reason == "live_decision_authority_unavailable":
+        state = "unavailable"
+    elif reason:
+        state = "denied"
+    else:
+        state = "empty"
+        reason = "live_decision_authority_empty"
+    return _authority_status_payload(
+        backend="postgres",
+        state=state,
+        reason=reason,
+        evidence=evidence,
+    )
+
+
+def _authority_status_payload(
+    *,
+    backend: str | None,
+    state: str,
+    reason: str | None,
+    evidence: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    evidence = _mapping(evidence)
+    return {
+        "schema_version": "alphadb_live_decision_authority_status.v1",
+        "backend": backend,
+        "state": state,
+        "reason": reason,
+        "run_id": _text(evidence.get("run_id")),
+        "owner_id": _text(evidence.get("owner_id")),
+        "fencing_token": _optional_int(evidence.get("fencing_token")),
+        "acquired_at": _text(evidence.get("acquired_at")),
+        "expires_at": _text(evidence.get("expires_at")),
+        "released_at": _text(evidence.get("released_at")),
+        "lease_status": _text(evidence.get("status")),
+    }
 
 
 def _config_revision_from_row(row: Mapping[str, Any]) -> LiveRuntimeConfigRevision:

--- a/src/alphadb/model_evaluation/cli.py
+++ b/src/alphadb/model_evaluation/cli.py
@@ -294,6 +294,12 @@ def build_parser() -> argparse.ArgumentParser:
         default="auto",
         help="Read dashboard-owned Postgres config, use CLI/env values, or choose by environment.",
     )
+    fair_live.add_argument(
+        "--live-authority-backend",
+        choices=("auto", "postgres", "s3", "local"),
+        default="auto",
+        help="Select live-decision authority backend; postgres keeps S3 as artifact storage only.",
+    )
     fair_live.add_argument("--output", default=None)
 
     expensive_yes_live = subparsers.add_parser(
@@ -515,6 +521,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 s3_prefix=args.s3_prefix,
                 submit_live_orders=args.submit_live_orders,
                 runtime_config_source=args.runtime_config_source,
+                live_authority_backend=args.live_authority_backend,
                 live_risk_state_stale_seconds=args.live_risk_state_stale_seconds,
                 quote_stale_seconds=args.quote_stale_seconds,
                 coinbase_feature_stale_seconds=args.coinbase_feature_stale_seconds,

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -204,11 +204,15 @@ class FairValueLiveTradingJob:
                     "status_materialization",
                     "artifact_write",
                 )
+                authority_denial_reason = live_run_lock.reason or "live_run_lock_held"
                 return self._materialize_one_cycle_run(
                     run_dir=run_dir,
                     run_id=run_id,
                     generated_at=generated_at,
-                    runtime_config=runtime_config_snapshot(original_config),
+                    runtime_config=runtime_config_snapshot(
+                        original_config,
+                        reason=authority_denial_reason,
+                    ),
                     collected=None,
                     selected_decision=None,
                     selected_row=None,
@@ -221,12 +225,12 @@ class FairValueLiveTradingJob:
                     admission_daily_loss_accounting=empty_live_risk_accounting(
                         generated_at=generated_at,
                         live_risk_timezone=original_config.live_risk_timezone,
-                        reason="live_run_lock_held",
+                        reason=authority_denial_reason,
                     ),
                     daily_loss_accounting=empty_live_risk_accounting(
                         generated_at=generated_at,
                         live_risk_timezone=original_config.live_risk_timezone,
-                        reason="live_run_lock_held",
+                        reason=authority_denial_reason,
                     ),
                     runtime_guard=runtime_guard_with_credential_materialization(
                         settings=settings,
@@ -235,7 +239,7 @@ class FairValueLiveTradingJob:
                     live_run_lock=live_run_lock,
                     timer=timer,
                     require_postgres=False,
-                    materialize_status=False,
+                    materialize_status=should_materialize_live_run_status(live_run_lock),
                 )
 
             with timer.phase("runtime_config"):
@@ -1178,9 +1182,19 @@ class PhaseTimer:
         }
 
 
-def runtime_config_snapshot(config: FairValueLiveTradingJobConfig) -> dict[str, Any]:
+def runtime_config_snapshot(
+    config: FairValueLiveTradingJobConfig,
+    *,
+    reason: str = "live_run_lock_held",
+) -> dict[str, Any]:
+    source = (
+        "not_read_authority_denied"
+        if reason.startswith("live_decision_authority_")
+        else "not_read_lock_held"
+    )
     return {
-        "source": "not_read_lock_held",
+        "source": source,
+        "not_read_reason": reason,
         "strategy": config.strategy,
         "config_id": None,
         "version": None,
@@ -1250,6 +1264,7 @@ def lock_held_attempt(
     live_run_lock: "LiveRunLock",
     strategy: str = FAIR_VALUE_LIVE_STRATEGY,
 ) -> dict[str, Any]:
+    reason = live_run_lock.reason or "live_run_lock_held"
     attempt = {
         "attempt_id": f"{live_run_id_prefix(strategy)}_order_{uuid4().hex[:12]}",
         "run_id": run_id,
@@ -1257,8 +1272,8 @@ def lock_held_attempt(
         "submitted_at": generated_at.isoformat(),
         "market_ticker": "",
         "side": None,
-        "decision": {"decision": "skip", "reason": "live_run_lock_held"},
-        "original_decision": {"decision": "skip", "reason": "live_run_lock_held"},
+        "decision": {"decision": "skip", "reason": reason},
+        "original_decision": {"decision": "skip", "reason": reason},
         "request_payload": {},
         "max_loss_dollars": 0.0,
         "daily_loss_used_before_dollars": 0.0,
@@ -1268,7 +1283,7 @@ def lock_held_attempt(
         "live_run_lock": live_run_lock.as_dict(),
         "attempt_index": 0,
         "status": "skipped",
-        "reason": live_run_lock.reason or "live_run_lock_held",
+        "reason": reason,
     }
     if live_run_lock.backend == "postgres":
         attempt["live_decision_authority_lease"] = live_run_lock.as_dict()
@@ -2017,6 +2032,8 @@ class LiveRunLock:
 
 
 def should_materialize_live_run_status(live_run_lock: LiveRunLock) -> bool:
+    if live_run_lock.backend == "postgres":
+        return True
     return live_run_lock.acquired or live_run_lock.reason != "live_run_lock_held"
 
 
@@ -2090,17 +2107,32 @@ def acquire_postgres_live_decision_authority(
 ) -> LiveRunLock:
     repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
     owner_id = f"{run_id}:{uuid4().hex[:12]}"
-    result = repository.acquire(
-        strategy=strategy,
-        run_id=run_id,
-        owner_id=owner_id,
-        now=generated_at,
-        ttl_seconds=ttl_seconds,
-        metadata={
-            "source": "fair_value_live_report_only",
-            "submit_live_orders": False,
-        },
-    )
+    try:
+        result = repository.acquire(
+            strategy=strategy,
+            run_id=run_id,
+            owner_id=owner_id,
+            now=generated_at,
+            ttl_seconds=ttl_seconds,
+            metadata={
+                "source": "fair_value_live_report_only",
+                "submit_live_orders": False,
+            },
+        )
+    except Exception as exc:
+        return LiveRunLock(
+            backend="postgres",
+            acquired=False,
+            token="",
+            strategy=strategy,
+            run_id=run_id,
+            reason="live_decision_authority_unavailable",
+            existing={
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            },
+            owner_id=owner_id,
+        )
     lease = result.lease or result.current_lease
     if result.acquired and lease is not None:
         return live_run_lock_from_authority_lease(

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -26,6 +26,7 @@ from alphadb.live_orders import (
 )
 from alphadb.live_authority import (
     LIVE_DECISION_AUTHORITY_LEASE_SCHEMA,
+    LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
     LiveDecisionAuthorityLease,
     LiveDecisionAuthorityLeaseRepository,
 )
@@ -309,9 +310,20 @@ class FairValueLiveTradingJob:
                 "risk_state_bootstrapped": False,
                 "risk_state_read_reason": "risk_state_not_required",
             }
+            authority_validation = validate_live_run_lock_authority(
+                live_run_lock,
+                now=generated_at,
+            )
+            if not authority_validation.get("valid", True):
+                risk_state_read = {
+                    **dict(risk_state_read),
+                    "risk_state_read_reason": "live_decision_authority_validation_failed",
+                    "live_decision_authority_validation": authority_validation,
+                }
             should_prepare_risk_state = (
                 self.config.submit_live_orders
                 and guard.can_submit_live_orders
+                and bool(authority_validation.get("valid", True))
                 and any(decision.get("decision") == "trade" for decision, _row in selected_pairs)
             )
             if should_prepare_risk_state:
@@ -537,6 +549,25 @@ class FairValueLiveTradingJob:
         if not runtime_guard.get("can_submit_live_orders"):
             reason = str(runtime_guard.get("denial_reason") or "live_orders_disabled")
             return ({**base, "status": "skipped", "reason": reason}, None, None)
+        authority_validation = validate_live_run_lock_authority(
+            live_run_lock,
+            now=generated_at,
+        )
+        if live_run_lock.backend == "postgres":
+            base["live_decision_authority_validation"] = authority_validation
+        if not authority_validation.get("valid", True):
+            return (
+                {
+                    **base,
+                    "status": "skipped",
+                    "reason": str(
+                        authority_validation.get("reason")
+                        or "stale_live_decision_authority_token"
+                    ),
+                },
+                None,
+                None,
+            )
         try:
             materialize_private_key_from_env()
         except Exception as exc:
@@ -931,6 +962,22 @@ class FairValueLiveTradingJob:
             ),
             "artifacts": artifact_records(artifacts),
         }
+        if materialize_status and live_run_lock.backend == "postgres" and live_run_lock.acquired:
+            status_authority_validation = validate_live_run_lock_authority(
+                live_run_lock,
+                now=generated_at,
+            )
+            manifest["runtime_controls"][
+                "live_decision_authority_validation"
+            ] = status_authority_validation
+            if not status_authority_validation.get("valid", True):
+                manifest["runtime_controls"][
+                    "live_status_materialization_skip_reason"
+                ] = str(
+                    status_authority_validation.get("reason")
+                    or "stale_live_decision_authority_token"
+                )
+                materialize_status = False
         if materialize_status:
             with timer.phase("status_materialization"):
                 materialize_live_run_status(
@@ -2035,6 +2082,56 @@ def should_materialize_live_run_status(live_run_lock: LiveRunLock) -> bool:
     if live_run_lock.backend == "postgres":
         return True
     return live_run_lock.acquired or live_run_lock.reason != "live_run_lock_held"
+
+
+def validate_live_run_lock_authority(
+    live_run_lock: LiveRunLock,
+    *,
+    now: datetime,
+) -> dict[str, Any]:
+    if live_run_lock.backend != "postgres":
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": live_run_lock.backend,
+            "valid": True,
+            "status": "not_required",
+            "reason": None,
+            "lease": None,
+        }
+    if (
+        not live_run_lock.acquired
+        or live_run_lock.authority_repository is None
+        or live_run_lock.owner_id is None
+        or live_run_lock.fencing_token is None
+    ):
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": "postgres",
+            "valid": False,
+            "status": "unavailable",
+            "reason": live_run_lock.reason or "live_decision_authority_unavailable",
+            "lease": live_run_lock.as_dict(),
+        }
+    try:
+        return live_run_lock.authority_repository.validate_active(
+            strategy=live_run_lock.strategy,
+            owner_id=live_run_lock.owner_id,
+            fencing_token=live_run_lock.fencing_token,
+            now=now,
+        ).as_dict()
+    except Exception as exc:
+        return {
+            "schema_version": LIVE_DECISION_AUTHORITY_RESULT_SCHEMA,
+            "backend": "postgres",
+            "valid": False,
+            "status": "unavailable",
+            "reason": "live_decision_authority_unavailable",
+            "lease": live_run_lock.as_dict(),
+            "error": {
+                "error_type": type(exc).__name__,
+                "message": str(exc),
+            },
+        }
 
 
 def acquire_live_run_lock(

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -78,6 +78,8 @@ FAIR_VALUE_LIVE_LOCK_TTL_SECONDS = 180
 DEFAULT_LIVE_RISK_TIMEZONE = "America/Los_Angeles"
 RuntimeConfigSource = Literal["auto", "postgres", "cli"]
 LiveDecisionPolicy = Literal["fair_value", "expensive_yes"]
+LiveAuthorityBackend = Literal["auto", "postgres", "s3", "local"]
+ResolvedLiveAuthorityBackend = Literal["none", "postgres", "s3", "local"]
 AWS_LIKE_ENVIRONMENTS = {"aws", "prod", "production"}
 
 
@@ -102,6 +104,7 @@ class FairValueLiveTradingJobConfig:
     s3_prefix: str | None = None
     submit_live_orders: bool = False
     runtime_config_source: RuntimeConfigSource = "auto"
+    live_authority_backend: LiveAuthorityBackend = "auto"
     live_risk_timezone: str = DEFAULT_LIVE_RISK_TIMEZONE
     live_risk_state_stale_seconds: int = DEFAULT_LIVE_RISK_STALE_SECONDS
     live_risk_refresh_max_lookup_count: int = 3
@@ -132,6 +135,7 @@ class FairValueLiveTradingJobConfig:
             "s3_prefix": self.s3_prefix,
             "submit_live_orders": self.submit_live_orders,
             "runtime_config_source": self.runtime_config_source,
+            "live_authority_backend": self.live_authority_backend,
             "live_risk_timezone": self.live_risk_timezone,
             "live_risk_state_stale_seconds": self.live_risk_state_stale_seconds,
             "live_risk_refresh_max_lookup_count": self.live_risk_refresh_max_lookup_count,
@@ -168,9 +172,10 @@ class FairValueLiveTradingJob:
         run_dir = self.config.output_root / run_id
         run_dir.mkdir(parents=True, exist_ok=True)
         timer = PhaseTimer()
+        authority_backend = resolve_live_authority_backend(self.config)
         authority_phase = (
             "postgres_authority_lease"
-            if should_use_postgres_authority_lease(self.config)
+            if authority_backend == "postgres"
             else "live_run_lock"
         )
         with timer.phase(authority_phase):
@@ -182,7 +187,8 @@ class FairValueLiveTradingJob:
                 enabled=self.config.submit_live_orders,
                 strategy=self.config.strategy,
                 settings=settings,
-                use_postgres_authority=should_use_postgres_authority_lease(self.config),
+                authority_backend=authority_backend,
+                authority_metadata=live_authority_acquire_metadata(self.config),
             )
         try:
             if not live_run_lock.acquired:
@@ -803,6 +809,8 @@ class FairValueLiveTradingJob:
             "min_contract_price": self.config.min_contract_price,
             "market_context_source": self.config.market_context_source,
             "brti_future_tolerance_seconds": self.config.brti_future_tolerance_seconds,
+            "live_authority_backend": live_run_lock.backend,
+            "live_authority_backend_requested": self.config.live_authority_backend,
             "admission_daily_loss_accounting": dict(admission_daily_loss_accounting),
             "daily_loss_accounting": dict(daily_loss_accounting),
             "runtime_guard": dict(runtime_guard),
@@ -1256,6 +1264,7 @@ def runtime_config_snapshot(
             "max_markets": config.max_markets,
             "market_context_source": config.market_context_source,
             "brti_future_tolerance_seconds": config.brti_future_tolerance_seconds,
+            "live_authority_backend": config.live_authority_backend,
         },
     }
 
@@ -2144,15 +2153,17 @@ def acquire_live_run_lock(
     strategy: str = FAIR_VALUE_LIVE_STRATEGY,
     ttl_seconds: int = FAIR_VALUE_LIVE_LOCK_TTL_SECONDS,
     settings: Settings | None = None,
-    use_postgres_authority: bool = False,
+    authority_backend: ResolvedLiveAuthorityBackend = "none",
+    authority_metadata: Mapping[str, Any] | None = None,
 ) -> LiveRunLock:
-    if use_postgres_authority:
+    if authority_backend == "postgres":
         return acquire_postgres_live_decision_authority(
             settings=settings or settings_from_env(),
             run_id=run_id,
             generated_at=generated_at,
             strategy=strategy,
             ttl_seconds=ttl_seconds,
+            metadata=authority_metadata,
         )
     if not enabled:
         return LiveRunLock(
@@ -2170,7 +2181,16 @@ def acquire_live_run_lock(
         token=token,
         ttl_seconds=ttl_seconds,
     )
-    if s3_prefix:
+    if authority_backend == "s3":
+        if not s3_prefix:
+            return LiveRunLock(
+                backend="s3",
+                acquired=False,
+                token="",
+                strategy=strategy,
+                run_id=run_id,
+                reason="live_authority_s3_prefix_missing",
+            )
         return acquire_s3_live_run_lock(
             s3_prefix=s3_prefix,
             strategy=strategy,
@@ -2178,20 +2198,44 @@ def acquire_live_run_lock(
             payload=payload,
             now=generated_at,
         )
-    return acquire_local_live_run_lock(
-        output_root=output_root,
-        strategy=strategy,
-        token=token,
-        payload=payload,
-        now=generated_at,
-    )
+    if authority_backend == "local":
+        return acquire_local_live_run_lock(
+            output_root=output_root,
+            strategy=strategy,
+            token=token,
+            payload=payload,
+            now=generated_at,
+        )
+    raise ValueError(f"unsupported live authority backend: {authority_backend}")
 
 
 def should_use_postgres_authority_lease(config: FairValueLiveTradingJobConfig) -> bool:
-    return (
-        not config.submit_live_orders
-        and config.runtime_config_source == "postgres"
-    )
+    return resolve_live_authority_backend(config) == "postgres"
+
+
+def resolve_live_authority_backend(
+    config: FairValueLiveTradingJobConfig,
+) -> ResolvedLiveAuthorityBackend:
+    if config.live_authority_backend == "postgres":
+        return "postgres"
+    if config.live_authority_backend in {"s3", "local"}:
+        return config.live_authority_backend if config.submit_live_orders else "none"
+    if not config.submit_live_orders and config.runtime_config_source == "postgres":
+        return "postgres"
+    if not config.submit_live_orders:
+        return "none"
+    if config.s3_prefix:
+        return "s3"
+    return "local"
+
+
+def live_authority_acquire_metadata(config: FairValueLiveTradingJobConfig) -> dict[str, Any]:
+    return {
+        "source": "fair_value_live",
+        "live_authority_backend": resolve_live_authority_backend(config),
+        "live_authority_backend_requested": config.live_authority_backend,
+        "submit_live_orders": config.submit_live_orders,
+    }
 
 
 def acquire_postgres_live_decision_authority(
@@ -2201,6 +2245,7 @@ def acquire_postgres_live_decision_authority(
     generated_at: datetime,
     strategy: str = FAIR_VALUE_LIVE_STRATEGY,
     ttl_seconds: int = FAIR_VALUE_LIVE_LOCK_TTL_SECONDS,
+    metadata: Mapping[str, Any] | None = None,
 ) -> LiveRunLock:
     repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
     owner_id = f"{run_id}:{uuid4().hex[:12]}"
@@ -2211,8 +2256,9 @@ def acquire_postgres_live_decision_authority(
             owner_id=owner_id,
             now=generated_at,
             ttl_seconds=ttl_seconds,
-            metadata={
-                "source": "fair_value_live_report_only",
+            metadata=metadata
+            or {
+                "source": "fair_value_live",
                 "submit_live_orders": False,
             },
         )

--- a/src/alphadb/model_evaluation/fair_value_live_latency_chart.py
+++ b/src/alphadb/model_evaluation/fair_value_live_latency_chart.py
@@ -1,0 +1,296 @@
+"""Generate public-safe fair-value live hot-path latency summaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from alphadb.model_evaluation.fair_value_live_report import as_mapping
+
+
+LATENCY_SUMMARY_SCHEMA = "alphadb_aws_fair_value_live_hot_path_latency.v2"
+DEFAULT_PRE_CHANGE_S3_AUTHORITY_MEAN_SECONDS = 0.808771
+DEFAULT_PRE_CHANGE_S3_AUTHORITY_CONTRIBUTION = 0.71
+
+COMPONENT_LABELS = {
+    "runtime_config": "Runtime config",
+    "postgres_authority_lease": "Postgres authority",
+    "live_run_lock": "S3 live lock",
+    "collection": "Market collection",
+    "risk_state_read": "Risk state read",
+    "risk_refresh": "Risk refresh",
+    "risk_admission": "Risk admission",
+    "submit_attempt_persist": "Attempt persist",
+    "submit": "Submit",
+    "status_materialization": "Status",
+    "artifact_write": "Artifacts",
+    "other": "Other",
+}
+
+COMPONENT_COLORS = {
+    "runtime_config": "#4f7cac",
+    "postgres_authority_lease": "#2e7d5b",
+    "live_run_lock": "#b85c38",
+    "collection": "#d6a84f",
+    "risk_state_read": "#7a5ea8",
+    "risk_refresh": "#8b8f50",
+    "risk_admission": "#6b8f71",
+    "submit_attempt_persist": "#8c6d62",
+    "submit": "#b04a5a",
+    "status_materialization": "#4f8f9f",
+    "artifact_write": "#6d7b8d",
+    "other": "#9aa0a6",
+}
+
+COMPONENT_ORDER = (
+    "runtime_config",
+    "postgres_authority_lease",
+    "live_run_lock",
+    "collection",
+    "risk_state_read",
+    "risk_refresh",
+    "risk_admission",
+    "submit_attempt_persist",
+    "submit",
+    "status_materialization",
+    "artifact_write",
+    "other",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="alphadb-fair-value-live-latency-chart")
+    parser.add_argument("--input", required=True, type=Path, help="Fair-value live report JSON")
+    parser.add_argument("--summary-output", required=True, type=Path)
+    parser.add_argument("--svg-output", required=True, type=Path)
+    parser.add_argument(
+        "--pre-change-authority-mean-seconds",
+        type=float,
+        default=DEFAULT_PRE_CHANGE_S3_AUTHORITY_MEAN_SECONDS,
+    )
+    parser.add_argument(
+        "--pre-change-authority-contribution",
+        type=float,
+        default=DEFAULT_PRE_CHANGE_S3_AUTHORITY_CONTRIBUTION,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = json.loads(args.input.read_text(encoding="utf-8"))
+    if not isinstance(report, Mapping):
+        raise SystemExit("--input must be a JSON object")
+
+    summary = build_latency_summary(
+        report,
+        source_report=args.input,
+        pre_change_authority_mean_seconds=args.pre_change_authority_mean_seconds,
+        pre_change_authority_contribution=args.pre_change_authority_contribution,
+    )
+    args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_output.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.svg_output.parent.mkdir(parents=True, exist_ok=True)
+    args.svg_output.write_text(render_latency_svg(summary), encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def build_latency_summary(
+    report: Mapping[str, Any],
+    *,
+    source_report: Path,
+    pre_change_authority_mean_seconds: float,
+    pre_change_authority_contribution: float,
+) -> dict[str, Any]:
+    report_summary = as_mapping(report.get("summary"))
+    latency = as_mapping(report_summary.get("latency"))
+    authority = as_mapping(report_summary.get("live_authority"))
+    orders = as_mapping(report_summary.get("orders"))
+    total_elapsed = as_mapping(latency.get("total_elapsed_seconds"))
+    authority_phase = as_mapping(latency.get("authority_phase"))
+    component_means = ordered_component_means(
+        as_mapping(latency.get("component_means_seconds"))
+    )
+
+    authority_mean = parse_float(authority_phase.get("mean_seconds"))
+    post_change_contribution = parse_float(authority_phase.get("mean_hot_path_contribution"))
+    improvement: dict[str, Any] = {
+        "pre_change_authority_mean_seconds": round(pre_change_authority_mean_seconds, 6),
+        "pre_change_authority_contribution": round(pre_change_authority_contribution, 6),
+        "post_change_authority_mean_seconds": authority_mean,
+        "post_change_authority_contribution": post_change_contribution,
+    }
+    if authority_mean is not None:
+        improvement["authority_mean_delta_seconds"] = round(
+            authority_mean - pre_change_authority_mean_seconds,
+            6,
+        )
+        improvement["authority_mean_improvement_ratio"] = round(
+            (pre_change_authority_mean_seconds - authority_mean)
+            / pre_change_authority_mean_seconds,
+            6,
+        )
+    if post_change_contribution is not None:
+        improvement["authority_contribution_delta"] = round(
+            post_change_contribution - pre_change_authority_contribution,
+            6,
+        )
+
+    return {
+        "schema_version": LATENCY_SUMMARY_SCHEMA,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "source_report": str(source_report),
+        "interval": report.get("interval"),
+        "report_status": report.get("status"),
+        "schedule_state": report_summary.get("schedule_state"),
+        "legacy_structural_schedule_state": report_summary.get(
+            "legacy_structural_schedule_state"
+        ),
+        "run_count": report_summary.get("run_count"),
+        "runtime_config_source": as_mapping(report_summary.get("config")).get("source"),
+        "runtime_guard": report_summary.get("runtime_guard"),
+        "live_authority": authority,
+        "orders": orders,
+        "total_elapsed_seconds": total_elapsed,
+        "authority_phase": authority_phase,
+        "component_means_seconds": component_means,
+        "comparison": improvement,
+        "notes": [
+            "Read-only summary from generated AWS report and S3 manifests; no task is triggered by this command.",
+            "Segment widths use mean phase contribution to mean manifest total.",
+            "S3 should remain artifact/audit storage; Postgres should be runtime authority after the rollout deploy.",
+        ],
+    }
+
+
+def ordered_component_means(component_means: Mapping[str, Any]) -> dict[str, float]:
+    output: dict[str, float] = {}
+    for key in COMPONENT_ORDER:
+        value = parse_float(component_means.get(key))
+        if value is not None and value > 0:
+            output[key] = round(value, 6)
+    for key in sorted(component_means):
+        if key in output:
+            continue
+        value = parse_float(component_means.get(key))
+        if value is not None and value > 0:
+            output[key] = round(value, 6)
+    return output
+
+
+def render_latency_svg(summary: Mapping[str, Any]) -> str:
+    components = as_mapping(summary.get("component_means_seconds"))
+    total = sum(float(value) for value in components.values())
+    total_elapsed = parse_float(as_mapping(summary.get("total_elapsed_seconds")).get("mean"))
+    denominator = total_elapsed or total or 1.0
+    width = 1120
+    height = 360
+    margin_x = 56
+    bar_width = width - (margin_x * 2)
+    bar_y = 114
+    bar_height = 42
+    title = "Fair-value live AWS hot-path latency"
+    subtitle = (
+        f"runs={summary.get('run_count')} | authority="
+        f"{as_mapping(summary.get('authority_phase')).get('name') or 'unknown'} | "
+        f"backend={as_mapping(summary.get('live_authority')).get('backend_latest') or 'unknown'}"
+    )
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-label="{escape_xml(title)}">',
+        '<rect width="1120" height="360" fill="#f8faf7"/>',
+        f'<text x="{margin_x}" y="48" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#18211f">{escape_xml(title)}</text>',
+        f'<text x="{margin_x}" y="78" font-family="Inter, Arial, sans-serif" font-size="14" fill="#4c5753">{escape_xml(subtitle)}</text>',
+    ]
+
+    cursor = margin_x
+    for name, value in components.items():
+        seconds = float(value)
+        segment_width = max(seconds / denominator * bar_width, 1.0)
+        color = COMPONENT_COLORS.get(name, "#9aa0a6")
+        label = COMPONENT_LABELS.get(name, name.replace("_", " ").title())
+        parts.append(
+            f'<rect x="{cursor:.2f}" y="{bar_y}" width="{segment_width:.2f}" height="{bar_height}" fill="{color}"/>'
+        )
+        if segment_width >= 84:
+            parts.append(
+                f'<text x="{cursor + 10:.2f}" y="{bar_y + 26}" font-family="Inter, Arial, sans-serif" font-size="12" fill="#ffffff">{escape_xml(label)}</text>'
+            )
+        cursor += segment_width
+
+    comparison = as_mapping(summary.get("comparison"))
+    authority_phase = as_mapping(summary.get("authority_phase"))
+    details = [
+        f"mean total: {format_seconds(total_elapsed)}",
+        f"authority mean: {format_seconds(authority_phase.get('mean_seconds'))}",
+        f"authority p95: {format_seconds(authority_phase.get('p95_seconds'))}",
+        f"vs S3 baseline: {format_delta(comparison.get('authority_mean_delta_seconds'))}",
+        f"submitted orders: {as_mapping(summary.get('orders')).get('submitted', 0)}",
+    ]
+    for index, detail in enumerate(details):
+        parts.append(
+            f'<text x="{margin_x}" y="{205 + index * 24}" font-family="Inter, Arial, sans-serif" font-size="14" fill="#25302d">{escape_xml(detail)}</text>'
+        )
+
+    legend_x = 430
+    legend_y = 198
+    for index, (name, value) in enumerate(components.items()):
+        x = legend_x + (index % 2) * 300
+        y = legend_y + (index // 2) * 28
+        label = COMPONENT_LABELS.get(name, name.replace("_", " ").title())
+        parts.append(
+            f'<rect x="{x}" y="{y - 12}" width="12" height="12" fill="{COMPONENT_COLORS.get(name, "#9aa0a6")}"/>'
+        )
+        parts.append(
+            f'<text x="{x + 20}" y="{y}" font-family="Inter, Arial, sans-serif" font-size="13" fill="#25302d">{escape_xml(label)} {format_seconds(value)}</text>'
+        )
+
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+def format_seconds(value: Any) -> str:
+    parsed = parse_float(value)
+    if parsed is None:
+        return "n/a"
+    return f"{parsed:.3f}s"
+
+
+def format_delta(value: Any) -> str:
+    parsed = parse_float(value)
+    if parsed is None:
+        return "n/a"
+    sign = "+" if parsed >= 0 else ""
+    return f"{sign}{parsed:.3f}s"
+
+
+def parse_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed != parsed:
+        return None
+    return parsed
+
+
+def escape_xml(value: Any) -> str:
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/alphadb/model_evaluation/fair_value_live_report.py
+++ b/src/alphadb/model_evaluation/fair_value_live_report.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import re
+import statistics
 import time
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
@@ -371,6 +372,7 @@ def build_summary(*, values: Mapping[str, Any], runs: Sequence[Mapping[str, Any]
     ]
     live_risk_state = as_mapping(latest_value(runs, "live_risk_admission_state"))
     live_risk_refresh = as_mapping(latest_value(runs, "live_risk_refresh"))
+    latency = summarize_latency(runs)
     return {
         "schedule_state": fair_rule.get("State"),
         "legacy_structural_schedule_state": structural_rule.get("State"),
@@ -382,6 +384,8 @@ def build_summary(*, values: Mapping[str, Any], runs: Sequence[Mapping[str, Any]
         "legacy_structural_live_activity": bool(structural_logs),
         "config": latest_value(runs, "runtime_config"),
         "runtime_guard": latest_value(runs, "runtime_guard"),
+        "live_authority": summarize_live_authority(runs),
+        "latency": latency,
         "executable_quote": latest_value(runs, "executable_quote"),
         "live_edge_attribution": latest_value(runs, "live_edge_attribution"),
         "live_edge_attribution_buckets": summarize_live_edge_attribution_buckets(
@@ -411,6 +415,7 @@ def build_summary(*, values: Mapping[str, Any], runs: Sequence[Mapping[str, Any]
 
 def summarize_run(*, run_id: str, artifacts: Mapping[str, Any]) -> dict[str, Any]:
     manifest = as_mapping(artifacts.get("manifest"))
+    runtime_controls = as_mapping(manifest.get("runtime_controls"))
     attempts_payload = as_mapping(artifacts.get("live_order_attempts"))
     reconciliation = as_mapping(artifacts.get("live_reconciliation_report"))
     attempts = as_sequence(attempts_payload.get("attempts"))
@@ -428,7 +433,10 @@ def summarize_run(*, run_id: str, artifacts: Mapping[str, Any]) -> dict[str, Any
         "run_id": run_id,
         "generated_at": manifest.get("generated_at"),
         "runtime_config": manifest.get("runtime_config"),
-        "runtime_guard": as_mapping(manifest.get("runtime_controls")).get("runtime_guard"),
+        "runtime_controls": dict(runtime_controls),
+        "runtime_guard": runtime_controls.get("runtime_guard"),
+        "live_authority": summarize_run_live_authority(manifest),
+        "timing": summarize_manifest_timing(manifest),
         "executable_quote": manifest.get("executable_quote"),
         "one_cycle": manifest.get("one_cycle"),
         "hot_path_scope": manifest.get("hot_path_scope"),
@@ -445,6 +453,177 @@ def summarize_run(*, run_id: str, artifacts: Mapping[str, Any]) -> dict[str, Any
         "orders": orders,
         "reconciliation": summarize_reconciliation(reconciliation),
     }
+
+
+def summarize_manifest_timing(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    timing = as_mapping(manifest.get("timing"))
+    phase_seconds: dict[str, float] = {}
+    for phase, value in as_mapping(timing.get("phase_seconds")).items():
+        parsed = parse_float(value)
+        if parsed is not None:
+            phase_seconds[str(phase)] = parsed
+    output: dict[str, Any] = {"phase_seconds": phase_seconds}
+    total_elapsed = parse_float(timing.get("total_elapsed_seconds"))
+    if total_elapsed is not None:
+        output["total_elapsed_seconds"] = total_elapsed
+    quote_to_submit = parse_float(timing.get("quote_to_submit_seconds"))
+    if quote_to_submit is not None:
+        output["quote_to_submit_seconds"] = quote_to_submit
+    authority_phase = authority_phase_name(phase_seconds)
+    if authority_phase:
+        output["authority_phase"] = authority_phase
+        output["authority_phase_seconds"] = phase_seconds[authority_phase]
+    return output
+
+
+def summarize_run_live_authority(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    runtime_controls = as_mapping(manifest.get("runtime_controls"))
+    live_run_lock = as_mapping(runtime_controls.get("live_run_lock"))
+    lease = as_mapping(runtime_controls.get("live_decision_authority_lease"))
+    backend = (
+        live_run_lock.get("backend")
+        or runtime_controls.get("live_authority_backend")
+        or lease.get("backend")
+    )
+    output: dict[str, Any] = {}
+    if backend:
+        output["backend"] = str(backend)
+    requested = runtime_controls.get("live_authority_backend_requested")
+    if requested:
+        output["backend_requested"] = str(requested)
+    if "acquired" in live_run_lock:
+        output["acquired"] = bool(live_run_lock.get("acquired"))
+    reason = live_run_lock.get("reason") or lease.get("reason")
+    if reason:
+        output["reason"] = str(reason)
+    for key in ("run_id", "owner_id", "fencing_token", "lease_status", "acquired_at", "expires_at", "released_at"):
+        value = lease.get(key, live_run_lock.get(key))
+        if value is not None:
+            output[key] = value
+    return output
+
+
+def summarize_live_authority(runs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    authorities = [as_mapping(run.get("live_authority")) for run in runs]
+    authorities = [authority for authority in authorities if authority]
+    latest = authorities[-1] if authorities else {}
+    backends = Counter(str(authority.get("backend")) for authority in authorities if authority.get("backend"))
+    acquired_count = sum(1 for authority in authorities if authority.get("acquired") is True)
+    denied_count = sum(1 for authority in authorities if authority.get("acquired") is False)
+    output: dict[str, Any] = {
+        "backend_latest": latest.get("backend"),
+        "backend_counts": dict(backends),
+        "acquired_count": acquired_count,
+        "denied_count": denied_count,
+        "fencing_token_observed": any(
+            authority.get("fencing_token") is not None for authority in authorities
+        ),
+    }
+    if latest:
+        output["latest"] = dict(latest)
+    return output
+
+
+def summarize_latency(runs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    timings = [as_mapping(run.get("timing")) for run in runs]
+    total_values = [
+        value
+        for timing in timings
+        if (value := parse_float(timing.get("total_elapsed_seconds"))) is not None
+    ]
+    phase_names = sorted(
+        {
+            phase
+            for timing in timings
+            for phase in as_mapping(timing.get("phase_seconds")).keys()
+        }
+    )
+    phase_seconds = {
+        phase: stats(
+            [
+                value
+                for timing in timings
+                if (
+                    value := parse_float(
+                        as_mapping(timing.get("phase_seconds")).get(phase)
+                    )
+                )
+                is not None
+            ]
+        )
+        for phase in phase_names
+    }
+    authority_phase = authority_phase_name(
+        {
+            phase: as_mapping(stat).get("mean")
+            for phase, stat in phase_seconds.items()
+            if as_mapping(stat).get("mean") is not None
+        }
+    )
+    component_means = component_mean_contribution(
+        total_mean=stats(total_values).get("mean"),
+        phase_seconds=phase_seconds,
+        authority_phase=authority_phase,
+    )
+    output: dict[str, Any] = {
+        "total_elapsed_seconds": stats(total_values),
+        "phase_seconds": phase_seconds,
+        "component_means_seconds": component_means,
+    }
+    if authority_phase:
+        authority_stats = as_mapping(phase_seconds.get(authority_phase))
+        total_mean = parse_float(as_mapping(output["total_elapsed_seconds"]).get("mean"))
+        authority_mean = parse_float(authority_stats.get("mean"))
+        output["authority_phase"] = {
+            "name": authority_phase,
+            "mean_seconds": authority_mean,
+            "p95_seconds": authority_stats.get("p95"),
+            "mean_hot_path_contribution": (
+                round(authority_mean / total_mean, 6)
+                if authority_mean is not None and total_mean
+                else None
+            ),
+        }
+    return output
+
+
+def authority_phase_name(phase_seconds: Mapping[str, Any]) -> str | None:
+    for phase in ("postgres_authority_lease", "live_run_lock"):
+        if phase in phase_seconds:
+            return phase
+    return None
+
+
+def component_mean_contribution(
+    *,
+    total_mean: Any,
+    phase_seconds: Mapping[str, Any],
+    authority_phase: str | None,
+) -> dict[str, float]:
+    names = [
+        "runtime_config",
+        authority_phase or "live_run_lock",
+        "collection",
+        "risk_state_read",
+        "risk_refresh",
+        "risk_admission",
+        "submit_attempt_persist",
+        "submit",
+        "status_materialization",
+        "artifact_write",
+    ]
+    output: dict[str, float] = {}
+    used_total = 0.0
+    for name in names:
+        mean = parse_float(as_mapping(phase_seconds.get(name)).get("mean"))
+        if mean is None or name in output:
+            continue
+        output[name] = round(mean, 6)
+        used_total += mean
+    parsed_total = parse_float(total_mean)
+    if parsed_total is not None:
+        output["other"] = round(max(parsed_total - used_total, 0.0), 6)
+    return output
 
 
 def summarize_attempts(
@@ -652,6 +831,57 @@ def as_mapping(value: Any) -> Mapping[str, Any]:
 
 def as_sequence(value: Any) -> Sequence[Any]:
     return value if isinstance(value, Sequence) and not isinstance(value, (str, bytes)) else ()
+
+
+def parse_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed != parsed:
+        return None
+    return parsed
+
+
+def stats(values: Sequence[float]) -> dict[str, float | int | None]:
+    ordered = sorted(float(value) for value in values)
+    if not ordered:
+        return {
+            "count": 0,
+            "min": None,
+            "mean": None,
+            "p50": None,
+            "p90": None,
+            "p95": None,
+            "p99": None,
+            "max": None,
+            "stdev": None,
+        }
+    return {
+        "count": len(ordered),
+        "min": round(ordered[0], 6),
+        "mean": round(statistics.fmean(ordered), 6),
+        "p50": percentile(ordered, 50),
+        "p90": percentile(ordered, 90),
+        "p95": percentile(ordered, 95),
+        "p99": percentile(ordered, 99),
+        "max": round(ordered[-1], 6),
+        "stdev": round(statistics.stdev(ordered), 6) if len(ordered) > 1 else 0.0,
+    }
+
+
+def percentile(values: Sequence[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return round(ordered[0], 6)
+    rank = (len(ordered) - 1) * pct / 100.0
+    lower_index = int(rank)
+    upper_index = min(lower_index + 1, len(ordered) - 1)
+    fraction = rank - lower_index
+    value = ordered[lower_index] + (ordered[upper_index] - ordered[lower_index]) * fraction
+    return round(value, 6)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_dashboard_live_console.py
+++ b/tests/test_dashboard_live_console.py
@@ -98,6 +98,31 @@ class FakeStatusRepository:
 
 
 @dataclass
+class FakeAuthorityRepository:
+    database_url: str
+    payload: dict[str, Any] | None = None
+    error: Exception | None = None
+
+    def status(self, *, strategy: str) -> dict[str, Any]:
+        if self.error is not None:
+            raise self.error
+        return self.payload or {
+            "schema_version": "alphadb_live_decision_authority_status.v1",
+            "backend": "postgres",
+            "strategy": strategy,
+            "state": "empty",
+            "reason": "live_decision_authority_empty",
+            "run_id": None,
+            "owner_id": None,
+            "fencing_token": None,
+            "acquired_at": None,
+            "expires_at": None,
+            "released_at": None,
+            "lease_status": None,
+        }
+
+
+@dataclass
 class FakeLiveRiskRepository:
     database_url: str
     state: LiveRiskAdmissionState | None = None
@@ -160,9 +185,13 @@ def service(
     *,
     status: LiveRunStatus | None = None,
     recent: list[dict[str, Any]] | None = None,
+    authority_repository: FakeAuthorityRepository | None = None,
     live_risk_repository: FakeLiveRiskRepository | None = None,
 ) -> DashboardService:
     risk_repository = live_risk_repository or FakeLiveRiskRepository(
+        "postgresql://example.test/alphadb"
+    )
+    authority = authority_repository or FakeAuthorityRepository(
         "postgresql://example.test/alphadb"
     )
     return DashboardService(
@@ -173,6 +202,7 @@ def service(
             status=status or no_recent_live_run_status(),
             recent=recent,
         ),
+        authority_repository_factory=lambda database_url: authority,
         live_risk_repository_factory=lambda database_url: risk_repository,
         health_collector=ok_health,
         portfolio_balance_provider=lambda settings: {
@@ -310,6 +340,61 @@ def test_strategy_operator_ledger_caps_and_sorts_recent_runs() -> None:
     assert row["risk_summary"]["detail"] == "Daily $1.25/$50.00; market $2.00/$5.00"
     assert row["context_summary"]["latest_run_source"] == "brti_primary"
     assert row["context_summary"]["latest_run_status"] == "fresh"
+
+
+def test_live_payload_and_ledger_surface_live_authority_state() -> None:
+    repository = FakeConfigRepository("postgresql://example.test/alphadb")
+    authority = FakeAuthorityRepository(
+        "postgresql://example.test/alphadb",
+        payload={
+            "schema_version": "alphadb_live_decision_authority_status.v1",
+            "backend": "postgres",
+            "strategy": FAIR_VALUE_LIVE_STRATEGY,
+            "state": "held",
+            "reason": None,
+            "run_id": "fv_live_holder",
+            "owner_id": "worker_holder",
+            "fencing_token": 11,
+            "acquired_at": "2026-06-04T15:00:00+00:00",
+            "expires_at": "2026-06-04T15:03:00+00:00",
+            "released_at": None,
+            "lease_status": "active",
+        },
+    )
+    dashboard = service(repository, authority_repository=authority)
+
+    payload = dashboard.live_payload()
+    row = dashboard.strategy_operator_ledger_payload()["rows"][0]
+
+    assert payload["live_status"]["live_decision_authority"]["state"] == "held"
+    assert payload["live_status"]["live_decision_authority"]["run_id"] == "fv_live_holder"
+    assert payload["live_status"]["live_decision_authority"]["fencing_token"] == 11
+    assert "summary" not in payload["live_status"]
+    assert row["authority_summary"]["state"] == "held"
+    assert row["authority_summary"]["run_id"] == "fv_live_holder"
+    assert row["authority_summary"]["fencing_token"] == 11
+
+
+def test_live_payload_surfaces_authority_repository_failures_as_unavailable() -> None:
+    repository = FakeConfigRepository("postgresql://example.test/alphadb")
+    authority = FakeAuthorityRepository(
+        "postgresql://example.test/alphadb",
+        error=RuntimeError("authority database unavailable"),
+    )
+    dashboard = service(repository, authority_repository=authority)
+
+    payload = dashboard.live_payload()
+    row = dashboard.strategy_operator_ledger_payload()["rows"][0]
+
+    assert payload["live_status"]["live_decision_authority"]["state"] == "unavailable"
+    assert payload["live_status"]["live_decision_authority"]["reason"] == (
+        "live_decision_authority_unavailable"
+    )
+    assert payload["live_status"]["live_decision_authority_error"].startswith(
+        "RuntimeError: authority database unavailable"
+    )
+    assert row["authority_summary"]["state"] == "unavailable"
+    assert row["authority_error"].startswith("RuntimeError: authority database unavailable")
 
 
 def test_strategy_operator_ledger_marks_repository_failures_unavailable() -> None:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -434,6 +434,9 @@ def test_fair_value_live_aws_template_enables_live_money_with_minimal_caps() -> 
     assert "DATABASE_URL" in template
     assert "--runtime-config-source" in template
     assert "postgres" in template
+    assert "LiveAuthorityBackend" in template
+    assert "--live-authority-backend" in template
+    assert 'LiveAuthorityBackend="${LIVE_AUTHORITY_BACKEND:-postgres}"' in deploy_script
     assert "--quote-stale-seconds" in template
     assert "--coinbase-feature-stale-seconds" in template
     assert "--brti-future-tolerance-seconds" in template

--- a/tests/test_fair_value_live_report.py
+++ b/tests/test_fair_value_live_report.py
@@ -10,6 +10,10 @@ from types import SimpleNamespace
 from typing import Any
 
 from alphadb.model_evaluation import fair_value_live_report as report_module
+from alphadb.model_evaluation.fair_value_live_latency_chart import (
+    build_latency_summary,
+    render_latency_svg,
+)
 from alphadb.model_evaluation.fair_value_live_report import (
     Boto3FairValueLiveEvidenceClient,
     FairValueLiveReportConfig,
@@ -185,10 +189,39 @@ class S3OnlyEvidenceClient(FailingEvidenceClient):
                     },
                 },
                 "runtime_controls": {
+                    "live_authority_backend": "postgres",
+                    "live_authority_backend_requested": "postgres",
+                    "live_run_lock": {
+                        "backend": "postgres",
+                        "acquired": True,
+                        "run_id": "fv_live_20260606T171540Z",
+                        "owner_id": "owner-1",
+                        "fencing_token": 12,
+                        "lease_status": "released",
+                    },
+                    "live_decision_authority_lease": {
+                        "backend": "postgres",
+                        "acquired": True,
+                        "run_id": "fv_live_20260606T171540Z",
+                        "owner_id": "owner-1",
+                        "fencing_token": 12,
+                        "lease_status": "released",
+                    },
                     "runtime_guard": {
                         "credentials_present": True,
                         "can_submit_live_orders": True,
                     }
+                },
+                "timing": {
+                    "total_elapsed_seconds": 1.25,
+                    "phase_seconds": {
+                        "runtime_config": 0.08,
+                        "postgres_authority_lease": 0.03,
+                        "live_run_lock": 0.0,
+                        "collection": 0.12,
+                        "status_materialization": 0.07,
+                        "artifact_write": 0.01,
+                    },
                 },
                 "executable_quote": {
                     "source": "kalshi_orderbook",
@@ -280,6 +313,24 @@ def test_report_uses_reachable_s3_artifacts_for_partial_zero_order_report() -> N
     assert report["summary"]["run_count"] == 1
     assert report["summary"]["config"]["config_id"] == "live_cfg_deaa1bcf8660"
     assert report["summary"]["runtime_guard"]["credentials_present"] is True
+    assert report["summary"]["live_authority"]["backend_latest"] == "postgres"
+    assert report["summary"]["live_authority"]["fencing_token_observed"] is True
+    assert report["summary"]["live_authority"]["latest"]["fencing_token"] == 12
+    assert report["summary"]["latency"]["total_elapsed_seconds"]["mean"] == 1.25
+    assert report["summary"]["latency"]["authority_phase"] == {
+        "name": "postgres_authority_lease",
+        "mean_seconds": 0.03,
+        "p95_seconds": 0.03,
+        "mean_hot_path_contribution": 0.024,
+    }
+    assert report["summary"]["latency"]["component_means_seconds"] == {
+        "runtime_config": 0.08,
+        "postgres_authority_lease": 0.03,
+        "collection": 0.12,
+        "status_materialization": 0.07,
+        "artifact_write": 0.01,
+        "other": 0.94,
+    }
     assert report["summary"]["executable_quote"]["source"] == "kalshi_orderbook"
     assert report["summary"]["live_edge_attribution"]["edge_shortfall"] == 0.02
     assert report["summary"]["live_edge_attribution_buckets"] == [
@@ -296,6 +347,8 @@ def test_report_uses_reachable_s3_artifacts_for_partial_zero_order_report() -> N
     }
     assert report["summary"]["reconciliation"]["net_pnl_dollars"] == 0.0
     assert report["runs"][0]["selected_decision"]["reason"] == "edge_below_min"
+    assert report["runs"][0]["live_authority"]["backend"] == "postgres"
+    assert report["runs"][0]["timing"]["authority_phase"] == "postgres_authority_lease"
     assert report["runs"][0]["live_edge_attribution"]["attribution_class"] == "threshold_drag"
     assert report["runs"][0]["live_edge_attributions"][0]["edge"] == 0.03
 
@@ -323,6 +376,64 @@ def test_fair_value_live_report_has_public_console_command() -> None:
         pyproject["project"]["scripts"]["alphadb-fair-value-live-report"]
         == "alphadb.model_evaluation.fair_value_live_report:main"
     )
+    assert (
+        pyproject["project"]["scripts"]["alphadb-fair-value-live-latency-chart"]
+        == "alphadb.model_evaluation.fair_value_live_latency_chart:main"
+    )
+
+
+def test_latency_chart_summary_compares_postgres_authority_to_s3_baseline() -> None:
+    report = {
+        "status": "complete",
+        "interval": {
+            "start": "2026-06-10T00:20:00+00:00",
+            "end": "2026-06-10T00:40:00+00:00",
+        },
+        "summary": {
+            "schedule_state": "ENABLED",
+            "legacy_structural_schedule_state": "DISABLED",
+            "run_count": 3,
+            "config": {"source": "dashboard_postgres"},
+            "runtime_guard": {"can_submit_live_orders": True},
+            "orders": {"submitted": 0, "skipped": 3},
+            "live_authority": {
+                "backend_latest": "postgres",
+                "fencing_token_observed": True,
+            },
+            "latency": {
+                "total_elapsed_seconds": {"mean": 0.42, "p95": 0.5},
+                "authority_phase": {
+                    "name": "postgres_authority_lease",
+                    "mean_seconds": 0.02,
+                    "p95_seconds": 0.03,
+                    "mean_hot_path_contribution": 0.047619,
+                },
+                "component_means_seconds": {
+                    "runtime_config": 0.08,
+                    "postgres_authority_lease": 0.02,
+                    "collection": 0.12,
+                    "status_materialization": 0.07,
+                    "artifact_write": 0.01,
+                    "other": 0.12,
+                },
+            },
+        },
+    }
+
+    summary = build_latency_summary(
+        report,
+        source_report=Path("aws-report.json"),
+        pre_change_authority_mean_seconds=0.808771,
+        pre_change_authority_contribution=0.71,
+    )
+    svg = render_latency_svg(summary)
+
+    assert summary["live_authority"]["backend_latest"] == "postgres"
+    assert summary["authority_phase"]["name"] == "postgres_authority_lease"
+    assert summary["comparison"]["authority_mean_delta_seconds"] == -0.788771
+    assert summary["comparison"]["authority_mean_improvement_ratio"] == 0.975271
+    assert "Postgres authority" in svg
+    assert "vs S3 baseline: -0.789s" in svg
 
 
 def test_boto3_adapter_configures_local_aws_profile_region_and_metadata(monkeypatch) -> None:

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -1970,6 +1970,162 @@ def test_report_only_postgres_runtime_records_authority_lease_manifest(
     assert persisted.released_at is not None
 
 
+def test_postgres_authority_held_fails_closed_before_collection(
+    tmp_path: Path,
+    monkeypatch,
+    request,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    strategy = f"test_authority_held_{uuid4().hex[:10]}"
+    repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
+    held = repository.acquire(
+        strategy=strategy,
+        run_id="fv_live_existing_authority",
+        owner_id="existing_worker",
+        now=now,
+        ttl_seconds=300,
+    )
+    assert held.acquired is True
+    assert held.lease is not None
+    request.addfinalizer(
+        lambda: repository.release(
+            strategy=strategy,
+            owner_id=held.lease.owner_id,
+            fencing_token=held.lease.fencing_token,
+        )
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_kalshi_client",
+        lambda source, settings: pytest.fail("authority-held run must not collect market data"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_coinbase_client",
+        lambda source: pytest.fail("authority-held run must not collect market data"),
+    )
+    client = SequencedOrderClient([])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            submit_live_orders=False,
+            runtime_config_source="postgres",
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now + timedelta(seconds=10))
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    status = LiveRunStatusRepository(settings.database_url).latest_status(strategy=strategy)
+
+    assert client.requests == []
+    assert manifest["runtime_config"]["source"] == "not_read_authority_denied"
+    assert manifest["runtime_config"]["not_read_reason"] == "live_decision_authority_held"
+    assert manifest["runtime_controls"]["orders_placed"] == 0
+    assert manifest["runtime_controls"]["live_status_materialized"] is True
+    assert manifest["runtime_controls"]["live_run_lock"]["backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_run_lock"]["acquired"] is False
+    assert manifest["runtime_controls"]["live_run_lock"]["reason"] == (
+        "live_decision_authority_held"
+    )
+    assert manifest["runtime_controls"]["live_decision_authority_lease"]["existing"][
+        "run_id"
+    ] == "fv_live_existing_authority"
+    assert manifest["counts"]["collected_rows"] == 0
+    assert manifest["timing"]["phase_seconds"]["collection"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["risk_admission"] == 0.0
+    assert attempts["attempts"][0]["status"] == "skipped"
+    assert attempts["attempts"][0]["reason"] == "live_decision_authority_held"
+    assert attempts["attempts"][0]["decision"]["reason"] == "live_decision_authority_held"
+    assert attempts["skip_reasons"] == [
+        {"reason": "live_decision_authority_held", "count": 1}
+    ]
+    assert status.run_id == manifest["run_id"]
+    assert status.decision_outcome == "skipped"
+    assert status.latest_attempt_reason == "live_decision_authority_held"
+    assert status.skip_reason == "live_decision_authority_held"
+
+
+def test_postgres_authority_unavailable_fails_closed_before_collection(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    strategy = f"test_authority_unavailable_{uuid4().hex[:10]}"
+
+    def raise_authority_unavailable(self, **kwargs):
+        raise psycopg.OperationalError("authority database unavailable")
+
+    monkeypatch.setattr(
+        LiveDecisionAuthorityLeaseRepository,
+        "acquire",
+        raise_authority_unavailable,
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_kalshi_client",
+        lambda source, settings: pytest.fail("authority-error run must not collect market data"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "make_coinbase_client",
+        lambda source: pytest.fail("authority-error run must not collect market data"),
+    )
+    client = SequencedOrderClient([])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            submit_live_orders=False,
+            runtime_config_source="postgres",
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now)
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    status = LiveRunStatusRepository(settings.database_url).latest_status(strategy=strategy)
+
+    assert client.requests == []
+    assert manifest["runtime_config"]["source"] == "not_read_authority_denied"
+    assert manifest["runtime_config"]["not_read_reason"] == (
+        "live_decision_authority_unavailable"
+    )
+    assert manifest["runtime_controls"]["orders_placed"] == 0
+    assert manifest["runtime_controls"]["live_status_materialized"] is True
+    assert manifest["runtime_controls"]["live_run_lock"]["backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_run_lock"]["acquired"] is False
+    assert manifest["runtime_controls"]["live_run_lock"]["reason"] == (
+        "live_decision_authority_unavailable"
+    )
+    assert manifest["runtime_controls"]["live_decision_authority_lease"]["existing"][
+        "error_type"
+    ] == "OperationalError"
+    assert manifest["counts"]["collected_rows"] == 0
+    assert manifest["timing"]["phase_seconds"]["collection"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["submit"] == 0.0
+    assert attempts["attempts"][0]["status"] == "skipped"
+    assert attempts["attempts"][0]["reason"] == "live_decision_authority_unavailable"
+    assert attempts["skip_reasons"] == [
+        {"reason": "live_decision_authority_unavailable", "count": 1}
+    ]
+    assert status.run_id == manifest["run_id"]
+    assert status.decision_outcome == "skipped"
+    assert status.latest_attempt_reason == "live_decision_authority_unavailable"
+    assert status.skip_reason == "live_decision_authority_unavailable"
+
+
 def test_live_trading_job_uses_dashboard_config_for_exposure_and_daily_caps(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -2248,6 +2248,156 @@ def test_postgres_authority_stale_token_prevents_live_mutations(
     ]
 
 
+def test_live_authority_backend_resolution_covers_postgres_and_fallbacks(
+    tmp_path: Path,
+) -> None:
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                s3_prefix="s3://example/fair-value-live",
+            )
+        )
+        == "s3"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                s3_prefix="s3://example/fair-value-live",
+                live_authority_backend="postgres",
+            )
+        )
+        == "postgres"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                runtime_config_source="postgres",
+                live_authority_backend="s3",
+            )
+        )
+        == "s3"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=False,
+                runtime_config_source="postgres",
+            )
+        )
+        == "postgres"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(output_root=tmp_path, submit_live_orders=False)
+        )
+        == "none"
+    )
+
+
+def test_postgres_authority_backend_keeps_s3_artifacts_out_of_authority(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-POSTGRES-AUTHORITY"
+    strategy = f"test_authority_backend_{uuid4().hex[:10]}"
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    seed_live_risk_state(now=now, strategy=strategy)
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "public_market_result",
+        lambda *, settings, ticker: {"status": "active", "result": None},
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "acquire_s3_live_run_lock",
+        lambda **kwargs: pytest.fail("Postgres authority must not acquire the S3 lock"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "release_s3_live_run_lock",
+        lambda *args, **kwargs: pytest.fail("Postgres authority must not release the S3 lock"),
+    )
+    uploads: list[dict[str, object]] = []
+
+    def fake_upload_artifacts_to_s3(artifacts, *, s3_prefix):
+        uploads.append({"s3_prefix": s3_prefix, "artifacts": sorted(artifacts)})
+        return [
+            {"artifact": name, "s3_uri": f"{s3_prefix.rstrip('/')}/{name}.json"}
+            for name in sorted(artifacts)
+        ]
+
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "upload_artifacts_to_s3",
+        fake_upload_artifacts_to_s3,
+    )
+    client = SequencedOrderClient([{"fill_count": 0, "cost": 0.0, "fees": 0.0}])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+            runtime_config_source="cli",
+            live_authority_backend="postgres",
+            s3_prefix="s3://example/fair-value-live",
+            quote_stale_seconds=120,
+            coinbase_feature_stale_seconds=180,
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now)
+    lease = manifest["runtime_controls"]["live_decision_authority_lease"]
+    persisted = LiveDecisionAuthorityLeaseRepository(settings.database_url).get(strategy=strategy)
+
+    assert client.requests != []
+    assert manifest["config"]["live_authority_backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_authority_backend"] == "postgres"
+    assert manifest["runtime_controls"]["live_authority_backend_requested"] == "postgres"
+    assert manifest["runtime_controls"]["live_run_lock"]["backend"] == "postgres"
+    assert lease["backend"] == "postgres"
+    assert "postgres_authority_lease" in manifest["timing"]["phase_seconds"]
+    assert manifest["timing"]["phase_seconds"]["live_run_lock"] == 0.0
+    assert uploads == [
+        {
+            "s3_prefix": "s3://example/fair-value-live",
+            "artifacts": [
+                "decision_rows",
+                "live_order_attempts",
+                "live_reconciliation_report",
+                "manifest",
+            ],
+        }
+    ]
+    assert {upload["artifact"] for upload in manifest["s3_uploads"]} == {
+        "decision_rows",
+        "live_order_attempts",
+        "live_reconciliation_report",
+        "manifest",
+    }
+    assert persisted is not None
+    assert persisted.fencing_token == lease["fencing_token"]
+    assert persisted.status == "released"
+    assert persisted.metadata["submit_live_orders"] is True
+    assert persisted.metadata["live_authority_backend"] == "postgres"
+
+
 def test_live_trading_job_uses_dashboard_config_for_exposure_and_daily_caps(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -2126,6 +2126,128 @@ def test_postgres_authority_unavailable_fails_closed_before_collection(
     assert status.skip_reason == "live_decision_authority_unavailable"
 
 
+def test_postgres_authority_stale_token_prevents_live_mutations(
+    tmp_path: Path,
+    monkeypatch,
+    request,
+) -> None:
+    live_runtime_repository_or_skip()
+    settings = live_enabled_settings()
+    now = datetime(2026, 6, 4, 15, 0, tzinfo=UTC)
+    ticker = "KXBTC15M-FV-STALE-AUTHORITY"
+    strategy = f"test_authority_stale_{uuid4().hex[:10]}"
+    repository = LiveDecisionAuthorityLeaseRepository(settings.database_url)
+    first = repository.acquire(
+        strategy=strategy,
+        run_id="fv_live_stale_worker",
+        owner_id="stale_worker",
+        now=now - timedelta(seconds=31),
+        ttl_seconds=30,
+    )
+    current = repository.acquire(
+        strategy=strategy,
+        run_id="fv_live_current_worker",
+        owner_id="current_worker",
+        now=now,
+        ttl_seconds=300,
+    )
+    assert first.lease is not None
+    assert current.lease is not None
+    request.addfinalizer(
+        lambda: repository.release(
+            strategy=strategy,
+            owner_id=current.lease.owner_id,
+            fencing_token=current.lease.fencing_token,
+        )
+    )
+    stale_lock = fair_value_live_job.live_run_lock_from_authority_lease(
+        first.lease,
+        acquired=True,
+        authority_repository=repository,
+    )
+    install_live_job_fixture(monkeypatch, now=now, ticker=ticker)
+    seed_live_risk_state(now=now, strategy=strategy)
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "public_market_result",
+        lambda *, settings, ticker: {"status": "active", "result": None},
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "acquire_live_run_lock",
+        lambda **kwargs: stale_lock,
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "bounded_refresh_before_admission",
+        lambda **kwargs: pytest.fail("stale token must not refresh risk state"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job.LiveRiskAdmissionRepository,
+        "admit_order",
+        lambda self, **kwargs: pytest.fail("stale token must not reserve risk"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job.LiveOrderRepository,
+        "persist",
+        lambda self, attempt: pytest.fail("stale token must not persist live attempt"),
+    )
+    monkeypatch.setattr(
+        fair_value_live_job,
+        "materialize_live_run_status",
+        lambda **kwargs: pytest.fail("stale token must not materialize live status"),
+    )
+    client = SequencedOrderClient([{"fill_count": 1, "cost": 0.4, "fees": 0.01}])
+
+    manifest = FairValueLiveTradingJob(
+        config=FairValueLiveTradingJobConfig(
+            output_root=tmp_path,
+            strategy=strategy,
+            source="kalshi-public",
+            coinbase_source="coinbase-live",
+            max_markets=1,
+            max_order_dollars=5.0,
+            max_ticker_exposure_dollars=5.0,
+            max_daily_loss_dollars=50.0,
+            submit_live_orders=True,
+            quote_stale_seconds=120,
+            coinbase_feature_stale_seconds=180,
+        ),
+        settings=settings,
+        order_client=client,
+    ).run(now=now)
+
+    attempts = json.loads(Path(manifest["artifacts"]["live_order_attempts"]["path"]).read_text())
+    attempt = attempts["attempts"][0]
+    authority_validation = attempt["live_decision_authority_validation"]
+
+    assert client.requests == []
+    assert manifest["runtime_controls"]["orders_placed"] == 0
+    assert manifest["runtime_controls"]["live_status_materialized"] is False
+    assert manifest["runtime_controls"]["live_status_materialization_skip_reason"] == (
+        "stale_live_decision_authority_token"
+    )
+    assert manifest["runtime_controls"]["live_decision_authority_validation"]["valid"] is False
+    assert manifest["runtime_controls"]["live_decision_authority_validation"]["reason"] == (
+        "stale_live_decision_authority_token"
+    )
+    assert manifest["runtime_controls"]["admission_daily_loss_accounting"][
+        "risk_state_read_reason"
+    ] == "live_decision_authority_validation_failed"
+    assert manifest["counts"]["live_skipped"] == 1
+    assert manifest["timing"]["phase_seconds"]["risk_admission"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["submit_attempt_persist"] == 0.0
+    assert manifest["timing"]["phase_seconds"]["submit"] == 0.0
+    assert attempt["status"] == "skipped"
+    assert attempt["reason"] == "stale_live_decision_authority_token"
+    assert authority_validation["valid"] is False
+    assert authority_validation["reason"] == "stale_live_decision_authority_token"
+    assert authority_validation["lease"]["run_id"] == "fv_live_current_worker"
+    assert attempts["skip_reasons"] == [
+        {"reason": "stale_live_decision_authority_token", "count": 1}
+    ]
+
+
 def test_live_trading_job_uses_dashboard_config_for_exposure_and_daily_caps(
     tmp_path: Path,
     monkeypatch,
@@ -2426,6 +2548,7 @@ def live_risk_repository_or_skip() -> LiveRiskAdmissionRepository:
 def seed_live_risk_state(
     *,
     now: datetime,
+    strategy: str = "fair_value_live",
     daily_loss_used_dollars: float = 0.0,
     open_exposure_dollars: float = 0.0,
     pending_exposure_dollars: float = 0.0,
@@ -2441,6 +2564,7 @@ def seed_live_risk_state(
         live_risk_timezone="America/Los_Angeles",
     )
     repository.upsert_state(
+        strategy=strategy,
         live_risk_day=live_risk_day,
         daily_loss_used_dollars=daily_loss_used_dollars,
         open_exposure_dollars=open_exposure_dollars,

--- a/tests/test_live_authority.py
+++ b/tests/test_live_authority.py
@@ -175,3 +175,60 @@ def test_live_decision_authority_validate_active_denies_stale_token() -> None:
     assert stale_first.current_lease is not None
     assert stale_first.current_lease.fencing_token == reclaimed.lease.fencing_token
     assert valid_reclaimed.valid is True
+
+
+def test_live_decision_authority_status_reports_sparse_current_states() -> None:
+    repository = repository_or_skip()
+    now = datetime(2026, 6, 9, 23, 0, tzinfo=UTC)
+    empty_strategy = f"test_authority_empty_{uuid4().hex[:10]}"
+    held_strategy = f"test_authority_held_{uuid4().hex[:10]}"
+    expired_strategy = f"test_authority_expired_{uuid4().hex[:10]}"
+    released_strategy = f"test_authority_released_{uuid4().hex[:10]}"
+
+    held = repository.acquire(
+        strategy=held_strategy,
+        run_id="run_held",
+        owner_id="worker_held",
+        now=now,
+        ttl_seconds=60,
+    )
+    expired = repository.acquire(
+        strategy=expired_strategy,
+        run_id="run_expired",
+        owner_id="worker_expired",
+        now=now - timedelta(seconds=90),
+        ttl_seconds=60,
+    )
+    released = repository.acquire(
+        strategy=released_strategy,
+        run_id="run_released",
+        owner_id="worker_released",
+        now=now,
+        ttl_seconds=60,
+    )
+    repository.release(
+        strategy=released_strategy,
+        owner_id=released.lease.owner_id,
+        fencing_token=released.lease.fencing_token,
+        now=now + timedelta(seconds=1),
+    )
+
+    empty_status = repository.status(strategy=empty_strategy, now=now)
+    held_status = repository.status(strategy=held_strategy, now=now)
+    expired_status = repository.status(strategy=expired_strategy, now=now)
+    released_status = repository.status(strategy=released_strategy, now=now)
+
+    assert held.lease is not None
+    assert expired.lease is not None
+    assert released.lease is not None
+    assert empty_status["state"] == "empty"
+    assert empty_status["reason"] == "live_decision_authority_empty"
+    assert held_status["state"] == "held"
+    assert held_status["reason"] is None
+    assert held_status["run_id"] == "run_held"
+    assert held_status["fencing_token"] == held.lease.fencing_token
+    assert expired_status["state"] == "expired"
+    assert expired_status["reason"] == "live_decision_authority_expired"
+    assert expired_status["expires_at"] == expired.lease.expires_at.isoformat()
+    assert released_status["state"] == "released"
+    assert released_status["released_at"] is not None

--- a/tests/test_live_authority.py
+++ b/tests/test_live_authority.py
@@ -126,3 +126,52 @@ def test_live_decision_authority_expired_reclaim_denies_stale_release() -> None:
     assert current is not None
     assert current.owner_id == "worker_reclaimed"
     assert current.status == "active"
+
+
+def test_live_decision_authority_validate_active_denies_stale_token() -> None:
+    repository = repository_or_skip()
+    strategy = f"test_authority_{uuid4().hex[:10]}"
+    now = datetime(2026, 6, 9, 22, 30, tzinfo=UTC)
+
+    first = repository.acquire(
+        strategy=strategy,
+        run_id="run_first",
+        owner_id="worker_first",
+        now=now,
+        ttl_seconds=30,
+    )
+    valid_first = repository.validate_active(
+        strategy=strategy,
+        owner_id="worker_first",
+        fencing_token=first.lease.fencing_token,
+        now=now + timedelta(seconds=5),
+    )
+    reclaimed = repository.acquire(
+        strategy=strategy,
+        run_id="run_reclaimed",
+        owner_id="worker_reclaimed",
+        now=now + timedelta(seconds=31),
+        ttl_seconds=30,
+    )
+    stale_first = repository.validate_active(
+        strategy=strategy,
+        owner_id="worker_first",
+        fencing_token=first.lease.fencing_token,
+        now=now + timedelta(seconds=32),
+    )
+    valid_reclaimed = repository.validate_active(
+        strategy=strategy,
+        owner_id="worker_reclaimed",
+        fencing_token=reclaimed.lease.fencing_token,
+        now=now + timedelta(seconds=32),
+    )
+
+    assert first.lease is not None
+    assert reclaimed.lease is not None
+    assert valid_first.valid is True
+    assert valid_first.reason is None
+    assert stale_first.valid is False
+    assert stale_first.reason == "stale_live_decision_authority_token"
+    assert stale_first.current_lease is not None
+    assert stale_first.current_lease.fencing_token == reclaimed.lease.fencing_token
+    assert valid_reclaimed.valid is True

--- a/tests/test_live_runtime.py
+++ b/tests/test_live_runtime.py
@@ -238,6 +238,97 @@ def test_live_status_summary_covers_submitted_no_fill_skipped_and_no_recent() ->
     assert no_recent.decision_outcome == "no_recent_run"
 
 
+def test_live_status_summary_surfaces_live_decision_authority_states() -> None:
+    base_manifest = {
+        "run_id": "fv_live_authority_status",
+        "generated_at": "2026-06-04T15:00:00+00:00",
+        "runtime_config": {"snapshot": {}},
+        "counts": {"live_attempts": 1},
+    }
+    base_attempt = {
+        "attempt_id": "attempt_authority",
+        "submitted_at": "2026-06-04T15:00:00+00:00",
+        "market_ticker": "KXBTC15M-AUTHORITY",
+        "status": "skipped",
+        "reason": "submit_live_orders_false",
+    }
+    acquired = build_fair_value_live_status(
+        manifest={
+            **base_manifest,
+            "runtime_controls": {
+                "live_decision_authority_lease": {
+                    "backend": "postgres",
+                    "acquired": True,
+                    "run_id": "fv_live_authority_status",
+                    "owner_id": "worker_1",
+                    "fencing_token": 7,
+                    "status": "released",
+                    "expires_at": "2026-06-04T15:03:00+00:00",
+                }
+            },
+        },
+        attempts_payload={"attempts": [base_attempt]},
+        reconciliation={"rows": []},
+    )
+    held = build_fair_value_live_status(
+        manifest={
+            **base_manifest,
+            "run_id": "fv_live_authority_held",
+            "runtime_controls": {
+                "live_decision_authority_lease": {
+                    "backend": "postgres",
+                    "acquired": False,
+                    "reason": "live_decision_authority_held",
+                    "run_id": "fv_live_existing",
+                    "owner_id": "worker_existing",
+                    "fencing_token": 6,
+                    "expires_at": "2026-06-04T15:02:00+00:00",
+                }
+            },
+        },
+        attempts_payload={
+            "attempts": [{**base_attempt, "reason": "live_decision_authority_held"}]
+        },
+        reconciliation={"rows": []},
+    )
+    unavailable = build_fair_value_live_status(
+        manifest={
+            **base_manifest,
+            "run_id": "fv_live_authority_unavailable",
+            "runtime_controls": {
+                "live_decision_authority_lease": {
+                    "backend": "postgres",
+                    "acquired": False,
+                    "reason": "live_decision_authority_unavailable",
+                }
+            },
+        },
+        attempts_payload={
+            "attempts": [
+                {**base_attempt, "reason": "live_decision_authority_unavailable"}
+            ]
+        },
+        reconciliation={"rows": []},
+    )
+    empty = build_fair_value_live_status(
+        manifest={**base_manifest, "run_id": "fv_live_authority_empty"},
+        attempts_payload={"attempts": [base_attempt]},
+        reconciliation={"rows": []},
+    )
+
+    assert acquired.summary["live_decision_authority"]["state"] == "acquired"
+    assert acquired.summary["live_decision_authority"]["fencing_token"] == 7
+    assert held.skip_reason == "live_decision_authority_held"
+    assert held.summary["live_decision_authority"]["state"] == "denied"
+    assert held.summary["live_decision_authority"]["reason"] == "live_decision_authority_held"
+    assert unavailable.skip_reason == "live_decision_authority_unavailable"
+    assert unavailable.summary["live_decision_authority"]["state"] == "unavailable"
+    assert empty.summary["live_decision_authority"]["state"] == "empty"
+    assert empty.summary["live_decision_authority"]["reason"] == (
+        "live_decision_authority_empty"
+    )
+
+
 def test_live_status_recent_attempt_rows_keep_last_50() -> None:
     attempts = [
         {


### PR DESCRIPTION
## Summary
- lands the remaining Postgres live-decision authority lease stack on main after the stacked branch merges
- includes ADB-319 authority fencing, ADB-320 backend rollout switch, ADB-321 authority status, and ADB-322 latency evidence/report helper
- keeps S3 as artifact/audit storage while Postgres owns live runtime authority

## Why this PR exists
The stacked PRs #51-#54 were merged into their parent feature branches, but only #50 is currently on main. This PR makes main the source of truth for the completed stack.

## Validation already run on the stacked slices
- focused pytest suites for live authority, fair-value live worker, live runtime, dashboard live console, deploy template, and report generation
- GitHub CI was green on the stacked PRs
- ADB-322 AWS evidence accepted in Linear: 11 scheduled runs, postgres authority backend observed on all runs, fencing token observed, submitted orders 0, CloudWatch errors 0

## Notes
- This is a consolidation PR; no new live AWS action is performed by opening it.
- ADB-323 should branch after this lands on main.