### PR TITLE
[codex] Demote S3 live authority

### DIFF
--- a/deploy/aws/deploy-fair-value-live-trading-job.sh
+++ b/deploy/aws/deploy-fair-value-live-trading-job.sh
@@ -32,6 +32,13 @@ require_command docker
 require_command git
 require_command python3
 
+LIVE_AUTHORITY_BACKEND_VALUE="${LIVE_AUTHORITY_BACKEND:-postgres}"
+if [[ "$LIVE_AUTHORITY_BACKEND_VALUE" != "postgres" ]]; then
+  echo "LIVE_AUTHORITY_BACKEND must be postgres; S3 live-run lock authority has been retired." >&2
+  echo "Keep REPORT_BUCKET_NAME/REPORT_PREFIX or --s3-prefix for artifact uploads only." >&2
+  exit 1
+fi
+
 if [[ "${SCHEDULE_STATE:-DISABLED}" == "ENABLED" ]]; then
   if [[ -n "${FAIR_VALUE_LIVE_SMOKE_EVIDENCE:-}" ]]; then
     python3 scripts/validate-fair-value-live-smoke.py "$FAIR_VALUE_LIVE_SMOKE_EVIDENCE"
@@ -118,7 +125,6 @@ aws_cli cloudformation deploy \
     ScheduleState="${SCHEDULE_STATE:-DISABLED}" \
     MinEdgeValues="${MIN_EDGE_VALUES:-0.0,0.05,0.10}" \
     MinContractPrice="${MIN_CONTRACT_PRICE:-0.25}" \
-    LiveAuthorityBackend="${LIVE_AUTHORITY_BACKEND:-postgres}" \
     KalshiApiKeyIdSecretArn="$KALSHI_API_KEY_ID_SECRET_ARN" \
     KalshiPrivateKeyPemSecretArn="$KALSHI_PRIVATE_KEY_PEM_SECRET_ARN" \
     AwsRegionValue="$REGION"

--- a/deploy/aws/fair-value-live-trading-job.yaml
+++ b/deploy/aws/fair-value-live-trading-job.yaml
@@ -49,13 +49,6 @@ Parameters:
   MinContractPrice:
     Type: String
     Default: "0.25"
-  LiveAuthorityBackend:
-    Type: String
-    Default: postgres
-    AllowedValues:
-      - postgres
-      - s3
-    Description: Runtime authority backend; use s3 only as the temporary rollback path.
   KalshiApiKeyIdSecretArn:
     Type: String
     Description: Secrets Manager ARN whose value is KALSHI_API_KEY_ID.
@@ -139,7 +132,6 @@ Resources:
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                  - s3:DeleteObject
                 Resource: !Sub arn:aws:s3:::${ReportBucketName}/${ReportPrefix}/*
 
   LiveTaskDefinition:
@@ -186,7 +178,7 @@ Resources:
             - --runtime-config-source
             - postgres
             - --live-authority-backend
-            - !Ref LiveAuthorityBackend
+            - postgres
             - --submit-live-orders
           Environment:
             - Name: ALPHADB_ENV

--- a/docs/adr/0004-postgres-live-decision-authority-lease.md
+++ b/docs/adr/0004-postgres-live-decision-authority-lease.md
@@ -24,5 +24,6 @@ inspectable control plane while preserving fail-closed singleton behavior.
   workers cannot mutate state after a newer worker takes authority.
 - S3 manifests should record lease evidence for auditability, but S3 must not be
   the source of runtime authority.
-- Existing S3 lock behavior may remain as a transitional fallback until
-  before/after AWS evidence proves the Postgres lease path.
+- The transitional S3 live-run lock fallback is retired after AWS post-change
+  evidence proved the Postgres lease path; stale S3 authority configuration
+  should be rejected rather than silently used.

--- a/docs/deployment/live-money-cutover-checklist.md
+++ b/docs/deployment/live-money-cutover-checklist.md
@@ -20,6 +20,10 @@ deployment, live config changes, schedule changes, or order submission.
   AWS live worker. The task may carry CLI fallback defaults for local/fixture
   paths, but `--runtime-config-source postgres` makes the dashboard/Postgres
   revision authoritative in AWS.
+- The AlphaDB fair-value live worker gets runtime singleton authority from the
+  Postgres Live-decision authority lease. `REPORT_BUCKET_NAME`,
+  `REPORT_PREFIX`, and `--s3-prefix` are artifact/audit destinations only; do
+  not deploy AWS live workers with `LIVE_AUTHORITY_BACKEND=s3`.
 
 ## AWS Assumptions
 
@@ -106,7 +110,8 @@ Capture these items before calling the cutover complete:
   evidence that `runtime_config.source` is `dashboard_postgres`.
 - Worker manifest: S3 URI, `runtime_config.config_id`,
   `runtime_config.version`, `runtime_config.source`, and exact
-  `runtime_config.snapshot`.
+  `runtime_config.snapshot`, plus `runtime_controls.live_authority_backend =
+  postgres` and Postgres `live_decision_authority_lease` evidence.
 - One-cycle smoke evidence JSON validated by
   `scripts/validate-fair-value-live-smoke.py`, proving:
   `p95_runtime_seconds < 45`, `overlapping_task_count = 0`,

--- a/docs/prd/postgres-live-decision-authority-lease.md
+++ b/docs/prd/postgres-live-decision-authority-lease.md
@@ -59,7 +59,7 @@ same authority mechanism.
 21. As a platform engineer, I want AWS rollout to support a temporary implementation switch, so that the Postgres path can be proven before S3 is removed.
 22. As a platform engineer, I want the existing local file lock behavior to remain available for fixture/local runs unless deliberately changed, so that local smoke paths stay simple.
 23. As a platform engineer, I want the AWS worker to use Postgres authority when `runtime_config_source=postgres`, so that production-like live authority does not depend on S3.
-24. As a platform engineer, I want S3 lock code to remain only as a transitional fallback, so that rollback is available during cutover.
+24. As a platform engineer, I want the S3 lock fallback retired after Postgres evidence passes, so that stale S3 authority config is not silently used after cutover.
 25. As a platform engineer, I want migration tests for the lease table, so that deployment cannot silently miss the authority schema.
 26. As a platform engineer, I want race tests for acquire, held, expired, release, and stale-token cases, so that the safety contract is proven.
 27. As a runtime maintainer, I want the live worker to stop market collection when authority is held, so that no downstream live path runs without authority.
@@ -87,7 +87,7 @@ same authority mechanism.
 - Keep the existing live worker behavior that stops before market collection when authority is not acquired.
 - Preserve current fail-closed behavior: authority unavailable, database unavailable, stale token, or version conflict means no live order attempt.
 - Keep S3 artifact writes and S3 manifest evidence. S3 remains evidence, not authority.
-- Add a runtime authority implementation choice during rollout. AWS should move to the Postgres authority lease after tests and smoke evidence pass; S3 lock can remain as a temporary fallback.
+- After tests and AWS smoke evidence pass, AWS uses the Postgres authority lease as the runtime authority path. The S3 live-run lock is no longer a normal fallback; S3 remains artifact storage and audit evidence.
 - Preserve local fixture ergonomics. Local runs with no live order submission may continue to use the existing no-op authority behavior.
 - Keep live risk admission state separate. The authority lease says "this worker may run"; live risk admission state says "this proposed order is admissible."
 - Keep bounded live-risk admission refresh separate from lease acquisition. The lease must not scan prior orders, settle P&L, or resolve pending exposure.

--- a/docs/strategy/fair-value-live-strategy.md
+++ b/docs/strategy/fair-value-live-strategy.md
@@ -99,6 +99,9 @@ admission result, and phase timings. The seeded canary defaults are:
 - The Cockpit reset action clears realized daily loss for the active live risk
   day only; it preserves open exposure, pending exposure, and pending
   reservations.
+- Runtime authority is the Postgres Live-decision authority lease. S3 is still
+  used for immutable manifests and run artifacts, not for production singleton
+  authority.
 
 Change the non-secret values in the dashboard and click `Save`. The next AWS
 run reads the latest active Postgres config. Secrets and infrastructure wiring
@@ -108,8 +111,8 @@ remain in AWS/Secrets Manager.
 
 ```mermaid
 flowchart TD
-    A["Every minute AWS trigger"] --> B{"Acquire live-decision lock"}
-    B -- "Held" --> C["Skip: live_run_lock_held; write compact evidence"]
+    A["Every minute AWS trigger"] --> B{"Acquire Postgres live-decision authority lease"}
+    B -- "Held/unavailable" --> C["Skip: live_decision_authority_*; write compact evidence"]
     B -- "Acquired" --> D["Read active dashboard config from Postgres"]
     D --> E["Fetch current KXBTC15M market quotes and configured market context"]
     E --> F{"Fresh quote and primary context?"}

--- a/src/alphadb/model_evaluation/cli.py
+++ b/src/alphadb/model_evaluation/cli.py
@@ -296,9 +296,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fair_live.add_argument(
         "--live-authority-backend",
-        choices=("auto", "postgres", "s3", "local"),
+        choices=("auto", "postgres", "local"),
         default="auto",
-        help="Select live-decision authority backend; postgres keeps S3 as artifact storage only.",
+        help="Select live-decision authority backend; S3 is artifact storage only.",
     )
     fair_live.add_argument("--output", default=None)
 

--- a/src/alphadb/model_evaluation/fair_value_live_job.py
+++ b/src/alphadb/model_evaluation/fair_value_live_job.py
@@ -78,8 +78,8 @@ FAIR_VALUE_LIVE_LOCK_TTL_SECONDS = 180
 DEFAULT_LIVE_RISK_TIMEZONE = "America/Los_Angeles"
 RuntimeConfigSource = Literal["auto", "postgres", "cli"]
 LiveDecisionPolicy = Literal["fair_value", "expensive_yes"]
-LiveAuthorityBackend = Literal["auto", "postgres", "s3", "local"]
-ResolvedLiveAuthorityBackend = Literal["none", "postgres", "s3", "local"]
+LiveAuthorityBackend = Literal["auto", "postgres", "local"]
+ResolvedLiveAuthorityBackend = Literal["none", "postgres", "local"]
 AWS_LIKE_ENVIRONMENTS = {"aws", "prod", "production"}
 
 
@@ -172,7 +172,10 @@ class FairValueLiveTradingJob:
         run_dir = self.config.output_root / run_id
         run_dir.mkdir(parents=True, exist_ok=True)
         timer = PhaseTimer()
-        authority_backend = resolve_live_authority_backend(self.config)
+        authority_backend = resolve_live_authority_backend(
+            self.config,
+            environment=settings.environment,
+        )
         authority_phase = (
             "postgres_authority_lease"
             if authority_backend == "postgres"
@@ -181,14 +184,16 @@ class FairValueLiveTradingJob:
         with timer.phase(authority_phase):
             live_run_lock = acquire_live_run_lock(
                 output_root=self.config.output_root,
-                s3_prefix=self.config.s3_prefix,
                 run_id=run_id,
                 generated_at=generated_at,
                 enabled=self.config.submit_live_orders,
                 strategy=self.config.strategy,
                 settings=settings,
                 authority_backend=authority_backend,
-                authority_metadata=live_authority_acquire_metadata(self.config),
+                authority_metadata=live_authority_acquire_metadata(
+                    self.config,
+                    authority_backend=authority_backend,
+                ),
             )
         try:
             if not live_run_lock.acquired:
@@ -2015,10 +2020,7 @@ class LiveRunLock:
     run_id: str | None = None
     reason: str | None = None
     path: Path | None = None
-    bucket: str | None = None
-    key: str | None = None
     existing: Mapping[str, Any] | None = None
-    client: Any = None
     owner_id: str | None = None
     fencing_token: int | None = None
     lease_status: str | None = None
@@ -2054,10 +2056,6 @@ class LiveRunLock:
             payload["released_at"] = self.released_at.isoformat()
         if self.path is not None:
             payload["path"] = str(self.path)
-        if self.bucket is not None:
-            payload["bucket"] = self.bucket
-        if self.key is not None:
-            payload["key"] = self.key
         if self.existing is not None:
             payload["existing"] = dict(self.existing)
         return payload
@@ -2067,13 +2065,6 @@ class LiveRunLock:
             return
         if self.backend == "local" and self.path is not None:
             release_local_live_run_lock(self.path, token=self.token)
-        if self.backend == "s3" and self.client is not None and self.bucket and self.key:
-            release_s3_live_run_lock(
-                self.client,
-                bucket=self.bucket,
-                key=self.key,
-                token=self.token,
-            )
         if (
             self.backend == "postgres"
             and self.authority_repository is not None
@@ -2146,7 +2137,6 @@ def validate_live_run_lock_authority(
 def acquire_live_run_lock(
     *,
     output_root: Path,
-    s3_prefix: str | None,
     run_id: str,
     generated_at: datetime,
     enabled: bool,
@@ -2181,23 +2171,6 @@ def acquire_live_run_lock(
         token=token,
         ttl_seconds=ttl_seconds,
     )
-    if authority_backend == "s3":
-        if not s3_prefix:
-            return LiveRunLock(
-                backend="s3",
-                acquired=False,
-                token="",
-                strategy=strategy,
-                run_id=run_id,
-                reason="live_authority_s3_prefix_missing",
-            )
-        return acquire_s3_live_run_lock(
-            s3_prefix=s3_prefix,
-            strategy=strategy,
-            token=token,
-            payload=payload,
-            now=generated_at,
-        )
     if authority_backend == "local":
         return acquire_local_live_run_lock(
             output_root=output_root,
@@ -2215,24 +2188,41 @@ def should_use_postgres_authority_lease(config: FairValueLiveTradingJobConfig) -
 
 def resolve_live_authority_backend(
     config: FairValueLiveTradingJobConfig,
+    *,
+    environment: str | None = None,
 ) -> ResolvedLiveAuthorityBackend:
+    if config.live_authority_backend == "s3":
+        raise ValueError(
+            "S3 live-run lock authority has been retired; use postgres for "
+            "runtime authority and keep s3_prefix for artifact uploads"
+        )
     if config.live_authority_backend == "postgres":
         return "postgres"
-    if config.live_authority_backend in {"s3", "local"}:
-        return config.live_authority_backend if config.submit_live_orders else "none"
+    if config.live_authority_backend == "local":
+        return "local" if config.submit_live_orders else "none"
     if not config.submit_live_orders and config.runtime_config_source == "postgres":
         return "postgres"
     if not config.submit_live_orders:
         return "none"
-    if config.s3_prefix:
-        return "s3"
+    if config.runtime_config_source == "postgres":
+        return "postgres"
+    if (
+        config.runtime_config_source == "auto"
+        and (environment or "").lower() in AWS_LIKE_ENVIRONMENTS
+    ):
+        return "postgres"
     return "local"
 
 
-def live_authority_acquire_metadata(config: FairValueLiveTradingJobConfig) -> dict[str, Any]:
+def live_authority_acquire_metadata(
+    config: FairValueLiveTradingJobConfig,
+    *,
+    authority_backend: ResolvedLiveAuthorityBackend | None = None,
+) -> dict[str, Any]:
     return {
         "source": "fair_value_live",
-        "live_authority_backend": resolve_live_authority_backend(config),
+        "live_authority_backend": authority_backend
+        or resolve_live_authority_backend(config),
         "live_authority_backend_requested": config.live_authority_backend,
         "submit_live_orders": config.submit_live_orders,
     }
@@ -2396,92 +2386,6 @@ def release_local_live_run_lock(path: Path, *, token: str) -> None:
         pass
 
 
-def acquire_s3_live_run_lock(
-    *,
-    s3_prefix: str,
-    strategy: str = FAIR_VALUE_LIVE_STRATEGY,
-    token: str,
-    payload: Mapping[str, Any],
-    now: datetime,
-) -> LiveRunLock:
-    bucket, prefix = parse_s3_prefix(s3_prefix)
-    key = live_run_lock_s3_key(prefix, strategy=strategy)
-    try:
-        import boto3  # type: ignore[import-not-found]
-    except Exception as exc:  # pragma: no cover - depends on AWS image environment
-        raise RuntimeError("S3 live-run locking requires boto3") from exc
-    client = boto3.client("s3")
-    for _attempt in range(2):
-        try:
-            client.put_object(
-                Bucket=bucket,
-                Key=key,
-                Body=json.dumps(dict(payload), sort_keys=True).encode("utf-8"),
-                ContentType="application/json",
-                IfNoneMatch="*",
-            )
-            return LiveRunLock(
-                backend="s3",
-                acquired=True,
-                token=token,
-                strategy=strategy,
-                bucket=bucket,
-                key=key,
-                client=client,
-            )
-        except Exception as exc:
-            if not s3_precondition_failed(exc):
-                raise
-            existing = read_s3_json_or_empty(client, bucket=bucket, key=key)
-            if live_run_lock_expired(existing, now=now):
-                try:
-                    client.delete_object(Bucket=bucket, Key=key)
-                except Exception:
-                    pass
-                continue
-            return LiveRunLock(
-                backend="s3",
-                acquired=False,
-                token=token,
-                strategy=strategy,
-                reason="live_run_lock_held",
-                bucket=bucket,
-                key=key,
-                existing=existing,
-            )
-    return LiveRunLock(
-        backend="s3",
-        acquired=False,
-        token=token,
-        strategy=strategy,
-        reason="live_run_lock_held",
-        bucket=bucket,
-        key=key,
-        existing=read_s3_json_or_empty(client, bucket=bucket, key=key),
-    )
-
-
-def release_s3_live_run_lock(client: Any, *, bucket: str, key: str, token: str) -> None:
-    existing = read_s3_json_or_empty(client, bucket=bucket, key=key)
-    if existing and existing.get("token") != token:
-        return
-    try:
-        client.delete_object(Bucket=bucket, Key=key)
-    except Exception:
-        pass
-
-
-def live_run_lock_s3_key(prefix: str, *, strategy: str = FAIR_VALUE_LIVE_STRATEGY) -> str:
-    filename = (
-        "fair-value-live-run.lock"
-        if strategy == FAIR_VALUE_LIVE_STRATEGY
-        else f"{strategy}-run.lock"
-    )
-    return "/".join(
-        part.strip("/") for part in (prefix, "_locks", filename) if part
-    )
-
-
 def live_run_lock_expired(payload: Mapping[str, Any], *, now: datetime) -> bool:
     expires_at = parse_datetime(payload.get("expires_at"))
     return expires_at is not None and expires_at <= ensure_utc(now)
@@ -2493,20 +2397,6 @@ def read_json_file_or_empty(path: Path) -> dict[str, Any]:
     except Exception:
         return {}
     return dict(payload) if isinstance(payload, Mapping) else {}
-
-
-def read_s3_json_or_empty(client: Any, *, bucket: str, key: str) -> dict[str, Any]:
-    try:
-        body = client.get_object(Bucket=bucket, Key=key)["Body"].read().decode("utf-8")
-        payload = json.loads(body)
-    except Exception:
-        return {}
-    return dict(payload) if isinstance(payload, Mapping) else {}
-
-
-def s3_precondition_failed(exc: Exception) -> bool:
-    code = str(getattr(exc, "response", {}).get("Error", {}).get("Code", ""))
-    return code in {"PreconditionFailed", "412"}
 
 
 def live_order_request(order: Mapping[str, Any], *, run_id: str) -> dict[str, Any]:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -434,9 +434,11 @@ def test_fair_value_live_aws_template_enables_live_money_with_minimal_caps() -> 
     assert "DATABASE_URL" in template
     assert "--runtime-config-source" in template
     assert "postgres" in template
-    assert "LiveAuthorityBackend" in template
+    assert "LiveAuthorityBackend" not in template
     assert "--live-authority-backend" in template
-    assert 'LiveAuthorityBackend="${LIVE_AUTHORITY_BACKEND:-postgres}"' in deploy_script
+    assert 'LIVE_AUTHORITY_BACKEND_VALUE="${LIVE_AUTHORITY_BACKEND:-postgres}"' in deploy_script
+    assert "S3 live-run lock authority has been retired" in deploy_script
+    assert "      - s3\n" not in template
     assert "--quote-stale-seconds" in template
     assert "--coinbase-feature-stale-seconds" in template
     assert "--brti-future-tolerance-seconds" in template
@@ -457,7 +459,7 @@ def test_fair_value_live_aws_template_enables_live_money_with_minimal_caps() -> 
     assert "KALSHI_PRIVATE_KEY_PEM" in template
     assert "s3:GetObject" in template
     assert "s3:PutObject" in template
-    assert "s3:DeleteObject" in template
+    assert "s3:DeleteObject" not in template
 
 
 def test_fair_value_live_smoke_validator_requires_runtime_gate_evidence(tmp_path: Path) -> None:

--- a/tests/test_fair_value_mvp.py
+++ b/tests/test_fair_value_mvp.py
@@ -2248,7 +2248,7 @@ def test_postgres_authority_stale_token_prevents_live_mutations(
     ]
 
 
-def test_live_authority_backend_resolution_covers_postgres_and_fallbacks(
+def test_live_authority_backend_resolution_demotes_s3_prefix_to_artifacts(
     tmp_path: Path,
 ) -> None:
     assert (
@@ -2256,10 +2256,22 @@ def test_live_authority_backend_resolution_covers_postgres_and_fallbacks(
             FairValueLiveTradingJobConfig(
                 output_root=tmp_path,
                 submit_live_orders=True,
+                runtime_config_source="postgres",
                 s3_prefix="s3://example/fair-value-live",
             )
         )
-        == "s3"
+        == "postgres"
+    )
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                runtime_config_source="cli",
+                s3_prefix="s3://example/fair-value-live",
+            )
+        )
+        == "local"
     )
     assert (
         fair_value_live_job.resolve_live_authority_backend(
@@ -2277,11 +2289,30 @@ def test_live_authority_backend_resolution_covers_postgres_and_fallbacks(
             FairValueLiveTradingJobConfig(
                 output_root=tmp_path,
                 submit_live_orders=True,
+            ),
+            environment="aws",
+        )
+        == "postgres"
+    )
+    with pytest.raises(ValueError, match="S3 live-run lock authority has been retired"):
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
                 runtime_config_source="postgres",
                 live_authority_backend="s3",
+                s3_prefix="s3://example/fair-value-live",
             )
         )
-        == "s3"
+    assert (
+        fair_value_live_job.resolve_live_authority_backend(
+            FairValueLiveTradingJobConfig(
+                output_root=tmp_path,
+                submit_live_orders=True,
+                live_authority_backend="local",
+            )
+        )
+        == "local"
     )
     assert (
         fair_value_live_job.resolve_live_authority_backend(
@@ -2316,16 +2347,6 @@ def test_postgres_authority_backend_keeps_s3_artifacts_out_of_authority(
         fair_value_live_job,
         "public_market_result",
         lambda *, settings, ticker: {"status": "active", "result": None},
-    )
-    monkeypatch.setattr(
-        fair_value_live_job,
-        "acquire_s3_live_run_lock",
-        lambda **kwargs: pytest.fail("Postgres authority must not acquire the S3 lock"),
-    )
-    monkeypatch.setattr(
-        fair_value_live_job,
-        "release_s3_live_run_lock",
-        lambda *args, **kwargs: pytest.fail("Postgres authority must not release the S3 lock"),
     )
     uploads: list[dict[str, object]] = []
 
@@ -2396,6 +2417,7 @@ def test_postgres_authority_backend_keeps_s3_artifacts_out_of_authority(
     assert persisted.status == "released"
     assert persisted.metadata["submit_live_orders"] is True
     assert persisted.metadata["live_authority_backend"] == "postgres"
+    assert persisted.metadata["live_authority_backend_requested"] == "postgres"
 
 
 def test_live_trading_job_uses_dashboard_config_for_exposure_and_daily_caps(


### PR DESCRIPTION
## Summary

- retire S3 as a selectable fair-value live runtime authority backend
- make AWS fair-value live authority Postgres-only while preserving S3 artifact uploads
- update docs and tests so stale S3 authority config fails loudly instead of being silently used

## Validation

- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest`
- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile src/alphadb/model_evaluation/fair_value_live_job.py src/alphadb/model_evaluation/cli.py tests/test_fair_value_mvp.py tests/test_deploy.py`
- `git diff --check`

## Notes

`alphadb-repo-hygiene` was not installed in this shell, and `pre-commit run --all-files` could not run because this worktree has no `.pre-commit-config.yaml`.
