### PR TITLE
[codex] Add bidirectional live edge attribution

### DIFF
--- a/apps/dashboard/components/live/live-operations.tsx
+++ b/apps/dashboard/components/live/live-operations.tsx
@@ -50,11 +50,38 @@ interface ResetDailyLimitsResponse {
 type Tone = "good" | "warn" | "bad" | "muted"
 
 interface LiveEdgeAttribution {
+  side?: string | null
+  fair_value?: number | null
+  price?: number | null
+  fee_per_contract?: number | null
+  raw_gap?: number | null
   edge?: number | null
   min_edge?: number | null
   edge_shortfall?: number | null
   edge_margin?: number | null
   edge_cleared?: boolean | null
+  side_evaluations?: LiveSideEvaluation[] | null
+  side_evaluation_summary?: Record<string, unknown> | null
+}
+
+interface LiveSideEvaluation {
+  side?: string | null
+  selected?: boolean | null
+  valid?: boolean | null
+  status?: string | null
+  reason?: string | null
+  comparison_reason?: string | null
+  probability?: number | null
+  fair_value?: number | null
+  price?: number | null
+  fee_per_contract?: number | null
+  raw_gap?: number | null
+  edge?: number | null
+  min_edge?: number | null
+  edge_shortfall?: number | null
+  edge_margin?: number | null
+  edge_cleared?: boolean | null
+  min_contract_price?: number | null
 }
 
 const CONFIG_FIELDS = [
@@ -204,10 +231,11 @@ function normalizePanelSize(id: PanelId, width: unknown, height: unknown): Panel
 }
 
 function normalizePanelLayout(value: unknown): PanelLayoutItem[] {
-  const rawItems = Array.isArray(value)
+  const record = asRecord(value)
+  const rawItems: unknown[] = Array.isArray(value)
     ? value
-    : Array.isArray(asRecord(value).items)
-      ? asRecord(value).items
+    : Array.isArray(record.items)
+      ? record.items
       : []
   const ordered: PanelLayoutItem[] = []
   const seen = new Set<PanelId>()
@@ -309,6 +337,64 @@ function edgeGapText(attribution: LiveEdgeAttribution) {
     return `+${optionalPercent(derivedMargin)}`
   }
   return "--"
+}
+
+function sideEvaluationGapText(evaluation: LiveSideEvaluation) {
+  return edgeGapText(evaluation as LiveEdgeAttribution)
+}
+
+function sideEvaluations(attribution: LiveEdgeAttribution): LiveSideEvaluation[] {
+  const evaluations = Array.isArray(attribution.side_evaluations)
+    ? attribution.side_evaluations
+      .filter((evaluation) => evaluation && typeof evaluation === "object")
+      .map((evaluation) => evaluation as LiveSideEvaluation)
+    : []
+  if (evaluations.length) return evaluations
+  if (!hasLegacyAttribution(attribution)) return []
+  return [{
+    side: attribution.side,
+    selected: Boolean(attribution.side),
+    valid: attribution.price !== null && attribution.price !== undefined,
+    status: attribution.edge_cleared ? "cleared" : "legacy_selected_side",
+    reason: "legacy_selected_side_attribution",
+    comparison_reason: "legacy_selected_side_attribution",
+    probability: attribution.fair_value,
+    fair_value: attribution.fair_value,
+    price: attribution.price,
+    fee_per_contract: attribution.fee_per_contract,
+    raw_gap: attribution.raw_gap,
+    edge: attribution.edge,
+    min_edge: attribution.min_edge,
+    edge_shortfall: attribution.edge_shortfall,
+    edge_margin: attribution.edge_margin,
+    edge_cleared: attribution.edge_cleared,
+  }]
+}
+
+function hasLegacyAttribution(attribution: LiveEdgeAttribution) {
+  return Boolean(
+    attribution.side ||
+    (attribution.edge !== null && attribution.edge !== undefined) ||
+    (attribution.price !== null && attribution.price !== undefined),
+  )
+}
+
+function sideToneClass(evaluation: LiveSideEvaluation) {
+  if (evaluation.selected) return "border-cockpit-accent-border bg-cockpit-accent-soft"
+  if (evaluation.edge_cleared) return "border-success/50 bg-success/10"
+  if (evaluation.valid === false || evaluation.status === "unavailable") {
+    return "border-field-border/70 bg-surface-inset text-muted-foreground"
+  }
+  return "border-field-border/70 bg-surface-inset"
+}
+
+function sideBadgeClass(evaluation: LiveSideEvaluation) {
+  if (evaluation.selected) return "border-cockpit-accent-border text-foreground"
+  if (evaluation.edge_cleared) return "border-success/50 text-success"
+  if (evaluation.valid === false || evaluation.status === "unavailable") {
+    return "border-field-border/70 text-muted-foreground"
+  }
+  return "border-field-border/70 text-foreground"
 }
 
 function seconds(value: unknown) {
@@ -1229,6 +1315,8 @@ function ActivityFeed({
 function AttemptDetails({ attempt }: { attempt: Record<string, unknown> }) {
   const riskAdmission = asRecord(attempt.risk_admission)
   const configVersion = text(attempt.config_version, "")
+  const attribution = edgeAttribution(attempt)
+  const evaluations = sideEvaluations(attribution)
   return (
     <div className="grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
       <ActivityDetail label="Side" value={text(attempt.side)} />
@@ -1239,6 +1327,69 @@ function AttemptDetails({ attempt }: { attempt: Record<string, unknown> }) {
       <ActivityDetail label="Max loss" value={optionalMoney(attempt.max_loss_dollars)} />
       <ActivityDetail label="Risk admission" value={text(riskAdmission.status || riskAdmission.reason)} />
       <ActivityDetail label="Config" value={configVersion ? `v${configVersion}` : text(attempt.config_id)} />
+      <SideEvaluationComparison evaluations={evaluations} />
+    </div>
+  )
+}
+
+function SideEvaluationComparison({ evaluations }: { evaluations: LiveSideEvaluation[] }) {
+  return (
+    <NestedSurface className="min-w-0 px-2 py-2 sm:col-span-2 lg:col-span-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-muted-foreground">YES / NO edge comparison</div>
+        <span className="font-mono text-[11px] text-muted-foreground">
+          {evaluations.length ? `${evaluations.length} side${evaluations.length === 1 ? "" : "s"}` : "--"}
+        </span>
+      </div>
+      {evaluations.length ? (
+        <div className="mt-2 grid gap-2 md:grid-cols-2">
+          {evaluations.map((evaluation, index) => (
+            <div
+              className={`min-w-0 rounded-md border px-2 py-2 ${sideToneClass(evaluation)}`}
+              key={`${text(evaluation.side, "side")}-${index}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-mono text-xs font-medium uppercase text-foreground">
+                  {text(evaluation.side)}
+                </span>
+                <span
+                  className={`rounded-sm border px-1.5 py-0.5 text-[11px] ${sideBadgeClass(evaluation)}`}
+                >
+                  {evaluation.selected ? "selected" : text(evaluation.status, "available")}
+                </span>
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1">
+                <SideEvaluationMetric
+                  label="Fair value"
+                  value={optionalPercent(evaluation.fair_value ?? evaluation.probability)}
+                />
+                <SideEvaluationMetric label="Ask" value={optionalPercent(evaluation.price)} />
+                <SideEvaluationMetric label="Fee" value={optionalPercent(evaluation.fee_per_contract)} />
+                <SideEvaluationMetric label="Raw gap" value={optionalPercent(evaluation.raw_gap)} />
+                <SideEvaluationMetric label="Edge" value={optionalPercent(evaluation.edge)} />
+                <SideEvaluationMetric label="Gap" value={sideEvaluationGapText(evaluation)} />
+              </div>
+              <div
+                className="mt-2 truncate font-mono text-[11px] text-muted-foreground"
+                title={text(evaluation.reason)}
+              >
+                {text(evaluation.comparison_reason || evaluation.reason)}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 text-xs text-muted-foreground">No side evaluation evidence recorded.</div>
+      )}
+    </NestedSurface>
+  )
+}
+
+function SideEvaluationMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="truncate font-mono text-xs text-foreground">{value}</div>
     </div>
   )
 }

--- a/apps/dashboard/components/live/strategy-operator-ledger.tsx
+++ b/apps/dashboard/components/live/strategy-operator-ledger.tsx
@@ -41,6 +41,7 @@ interface StrategyLedgerRow {
   latest_run_id: string | null
   latest_run_generated_at: string | null
   latest_decision: LatestDecision
+  latest_live_edge_attribution: LiveEdgeAttribution | null
   recent_runs: StrategyRecentRun[]
   risk_summary: RiskSummary
   context_summary: ContextSummary
@@ -68,6 +69,39 @@ interface LatestDecision {
   market_ticker: string | null
   run_id: string | null
   generated_at: string | null
+}
+
+interface LiveEdgeAttribution {
+  side?: string | null
+  fair_value?: number | null
+  price?: number | null
+  fee_per_contract?: number | null
+  raw_gap?: number | null
+  edge?: number | null
+  min_edge?: number | null
+  edge_shortfall?: number | null
+  edge_margin?: number | null
+  edge_cleared?: boolean | null
+  side_evaluations?: LiveSideEvaluation[] | null
+}
+
+interface LiveSideEvaluation {
+  side?: string | null
+  selected?: boolean | null
+  valid?: boolean | null
+  status?: string | null
+  reason?: string | null
+  comparison_reason?: string | null
+  probability?: number | null
+  fair_value?: number | null
+  price?: number | null
+  fee_per_contract?: number | null
+  raw_gap?: number | null
+  edge?: number | null
+  min_edge?: number | null
+  edge_shortfall?: number | null
+  edge_margin?: number | null
+  edge_cleared?: boolean | null
 }
 
 interface StrategyRecentRun {
@@ -358,6 +392,8 @@ function StrategyDetailRail({ row }: { row: StrategyLedgerRow | null }) {
             <KeyValue label="Reason" value={value(row.latest_attempt_reason)} />
           </div>
         </NestedSurface>
+
+        <EdgeAttributionRail attribution={row.latest_live_edge_attribution} />
 
         <NestedSurface className="p-3">
           <div className="text-xs font-medium text-muted-foreground">Risk</div>
@@ -659,6 +695,130 @@ function RecentRunList({ runs }: { runs: StrategyRecentRun[] }) {
       ))}
     </div>
   )
+}
+
+function EdgeAttributionRail({ attribution }: { attribution: LiveEdgeAttribution | null }) {
+  const evaluations = sideEvaluations(attribution)
+  return (
+    <NestedSurface className="p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs font-medium text-muted-foreground">YES / NO edge comparison</div>
+        <div className="font-mono text-xs text-muted-foreground">
+          {evaluations.length ? `${evaluations.length} side${evaluations.length === 1 ? "" : "s"}` : "--"}
+        </div>
+      </div>
+      {evaluations.length ? (
+        <div className="mt-2 grid gap-2">
+          {evaluations.map((evaluation, index) => (
+            <div
+              className={cn(
+                "rounded-md border px-2 py-2",
+                evaluation.selected
+                  ? "border-cockpit-accent-border bg-cockpit-accent-soft"
+                  : "border-border/80 bg-surface-panel",
+              )}
+              key={`${value(evaluation.side, "side")}-${index}`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-mono text-xs font-medium uppercase text-foreground">
+                  {value(evaluation.side)}
+                </span>
+                <span className="rounded-sm border border-field-border/70 px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                  {evaluation.selected ? "selected" : value(evaluation.status, "available")}
+                </span>
+              </div>
+              <div className="mt-2 grid grid-cols-3 gap-x-2 gap-y-1">
+                <SideMetric label="Fair" value={optionalPercent(evaluation.fair_value ?? evaluation.probability)} />
+                <SideMetric label="Ask" value={optionalPercent(evaluation.price)} />
+                <SideMetric label="Edge" value={optionalPercent(evaluation.edge)} />
+                <SideMetric label="Raw" value={optionalPercent(evaluation.raw_gap)} />
+                <SideMetric label="Fee" value={optionalPercent(evaluation.fee_per_contract)} />
+                <SideMetric label="Gap" value={edgeGapText(evaluation)} />
+              </div>
+              <div className="mt-2 truncate font-mono text-[11px] text-muted-foreground">
+                {value(evaluation.comparison_reason || evaluation.reason)}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 text-sm text-muted-foreground">No live edge attribution recorded.</div>
+      )}
+    </NestedSurface>
+  )
+}
+
+function SideMetric({ label, value: metricValue }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="truncate font-mono text-xs text-foreground">{metricValue}</div>
+    </div>
+  )
+}
+
+function sideEvaluations(attribution: LiveEdgeAttribution | null): LiveSideEvaluation[] {
+  if (!attribution) return []
+  if (Array.isArray(attribution.side_evaluations) && attribution.side_evaluations.length) {
+    return attribution.side_evaluations.filter(isLiveSideEvaluation)
+  }
+  if (!hasLegacyAttribution(attribution)) return []
+  return [{
+    side: attribution.side,
+    selected: Boolean(attribution.side),
+    valid: attribution.price !== null && attribution.price !== undefined,
+    status: attribution.edge_cleared ? "cleared" : "legacy_selected_side",
+    reason: "legacy_selected_side_attribution",
+    comparison_reason: "legacy_selected_side_attribution",
+    probability: attribution.fair_value,
+    fair_value: attribution.fair_value,
+    price: attribution.price,
+    fee_per_contract: attribution.fee_per_contract,
+    raw_gap: attribution.raw_gap,
+    edge: attribution.edge,
+    min_edge: attribution.min_edge,
+    edge_shortfall: attribution.edge_shortfall,
+    edge_margin: attribution.edge_margin,
+    edge_cleared: attribution.edge_cleared,
+  }]
+}
+
+function isLiveSideEvaluation(value: unknown): value is LiveSideEvaluation {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+function hasLegacyAttribution(attribution: LiveEdgeAttribution) {
+  return Boolean(
+    attribution.side ||
+    (attribution.edge !== null && attribution.edge !== undefined) ||
+    (attribution.price !== null && attribution.price !== undefined),
+  )
+}
+
+function optionalPercent(input: unknown) {
+  if (input === null || input === undefined || input === "") return "--"
+  const number = Number(input)
+  if (!Number.isFinite(number)) return "--"
+  return `${(number * 100).toFixed(2)}%`
+}
+
+function edgeGapText(evaluation: LiveSideEvaluation) {
+  const shortfall = Number(evaluation.edge_shortfall)
+  if (Number.isFinite(shortfall) && shortfall > 0) {
+    return `short ${optionalPercent(shortfall)}`
+  }
+  const margin = Number(evaluation.edge_margin)
+  if (Number.isFinite(margin)) {
+    return `${margin >= 0 ? "+" : ""}${optionalPercent(margin)}`
+  }
+  const edge = Number(evaluation.edge)
+  const minEdge = Number(evaluation.min_edge)
+  if (Number.isFinite(edge) && Number.isFinite(minEdge)) {
+    const derivedMargin = edge - minEdge
+    if (derivedMargin < 0) return `short ${optionalPercent(-derivedMargin)}`
+    return `+${optionalPercent(derivedMargin)}`
+  }
+  return "--"
 }
 
 function fleetHealth(

--- a/src/alphadb/dashboard/app.py
+++ b/src/alphadb/dashboard/app.py
@@ -571,6 +571,9 @@ def _strategy_operator_ledger_row(
         if latest_status.generated_at
         else None,
         "latest_decision": _strategy_operator_latest_decision(latest_status),
+        "latest_live_edge_attribution": _strategy_operator_latest_edge_attribution(
+            latest_status
+        ),
         "recent_runs": recent_runs,
         "risk_summary": _strategy_operator_risk_summary(
             latest_status,
@@ -661,6 +664,13 @@ def _strategy_operator_latest_decision(status: LiveRunStatus) -> dict[str, Any]:
         "run_id": status.run_id,
         "generated_at": status.generated_at.isoformat() if status.generated_at else None,
     }
+
+
+def _strategy_operator_latest_edge_attribution(
+    status: LiveRunStatus,
+) -> dict[str, Any] | None:
+    attribution = _mapping_or_empty(status.summary.get("live_edge_attribution"))
+    return dict(attribution) if attribution else None
 
 
 def _strategy_operator_risk_summary(

--- a/src/alphadb/live_edge_attribution.py
+++ b/src/alphadb/live_edge_attribution.py
@@ -10,6 +10,7 @@ SCHEMA_VERSION = "alphadb_live_edge_attribution.v1"
 MARKET_CONTEXT_COINBASE_PRIMARY = "coinbase_primary"
 MARKET_CONTEXT_BRTI_PRIMARY = "brti_primary"
 MARKET_CONTEXT_FIXTURE = "fixture"
+DEFAULT_TAKER_FEE_MULTIPLIER = 0.07
 
 
 def build_live_edge_attribution(
@@ -48,6 +49,19 @@ def build_live_edge_attribution(
     if edge is None and raw_gap is not None and fee is not None:
         edge = round(raw_gap - fee, 6)
 
+    fee_multiplier = _first_float(
+        runtime_controls_map,
+        ("taker_fee_multiplier",),
+        default=_first_float(
+            snapshot,
+            ("taker_fee_multiplier",),
+            default=_first_float(
+                config_map,
+                ("taker_fee_multiplier",),
+                default=DEFAULT_TAKER_FEE_MULTIPLIER,
+            ),
+        ),
+    )
     min_edge = _first_float(
         runtime_controls_map,
         ("min_edge",),
@@ -93,6 +107,18 @@ def build_live_edge_attribution(
         source_row=source_map,
         config=config_map,
     )
+    side_evaluations = build_live_side_evaluations(
+        decision=decision_map,
+        source_row=source_map,
+        selected_side=side,
+        min_edge=min_edge,
+        min_contract_price=min_contract_price,
+        taker_fee_multiplier=(
+            fee_multiplier
+            if fee_multiplier is not None
+            else DEFAULT_TAKER_FEE_MULTIPLIER
+        ),
+    )
     missing_fields = _missing_fields(
         {
             "side": side,
@@ -126,6 +152,11 @@ def build_live_edge_attribution(
         "edge_margin": _round(edge_margin),
         "min_contract_price": _round(min_contract_price),
         "edge_cleared": edge is not None and min_edge is not None and edge >= min_edge,
+        "side_evaluations": side_evaluations,
+        "side_evaluation_summary": side_evaluation_summary(
+            side_evaluations=side_evaluations,
+            selected_side=side,
+        ),
         "attribution_class": classify_live_edge_attribution(
             decision_reason=_text(decision_map.get("reason")),
             raw_gap=raw_gap,
@@ -168,6 +199,220 @@ def build_live_edge_attribution(
         ),
         "missing_fields": missing_fields,
     }
+
+
+def build_live_side_evaluations(
+    *,
+    decision: Mapping[str, Any],
+    source_row: Mapping[str, Any],
+    selected_side: str | None,
+    min_edge: float | None,
+    min_contract_price: float | None,
+    taker_fee_multiplier: float,
+) -> list[dict[str, Any]]:
+    probability_yes = _probability_yes(decision=decision, source_row=source_row)
+    evaluations = [
+        build_live_side_evaluation(
+            side="yes",
+            probability_yes=probability_yes,
+            decision=decision,
+            source_row=source_row,
+            selected_side=selected_side,
+            min_edge=min_edge,
+            min_contract_price=min_contract_price,
+            taker_fee_multiplier=taker_fee_multiplier,
+        ),
+        build_live_side_evaluation(
+            side="no",
+            probability_yes=probability_yes,
+            decision=decision,
+            source_row=source_row,
+            selected_side=selected_side,
+            min_edge=min_edge,
+            min_contract_price=min_contract_price,
+            taker_fee_multiplier=taker_fee_multiplier,
+        ),
+    ]
+    return side_evaluations_with_selection_context(
+        side_evaluations=evaluations,
+        selected_side=selected_side,
+    )
+
+
+def build_live_side_evaluation(
+    *,
+    side: str,
+    probability_yes: float | None,
+    decision: Mapping[str, Any],
+    source_row: Mapping[str, Any],
+    selected_side: str | None,
+    min_edge: float | None,
+    min_contract_price: float | None,
+    taker_fee_multiplier: float,
+) -> dict[str, Any]:
+    selected = selected_side == side
+    probability = _side_probability(side, probability_yes)
+    price = _side_price(side=side, decision=decision, source_row=source_row, selected=selected)
+    explicit_fee = _side_fee(side=side, decision=decision, source_row=source_row, selected=selected)
+    fee = explicit_fee if explicit_fee is not None else _taker_fee(price, taker_fee_multiplier)
+    raw_gap = (
+        round(probability - price, 6)
+        if probability is not None and price is not None
+        else None
+    )
+    edge = (
+        round(raw_gap - fee, 6)
+        if raw_gap is not None and fee is not None
+        else None
+    )
+    edge_shortfall = (
+        round(max(0.0, min_edge - edge), 6)
+        if min_edge is not None and edge is not None
+        else None
+    )
+    edge_margin = (
+        round(edge - min_edge, 6)
+        if min_edge is not None and edge is not None
+        else None
+    )
+    valid, invalid_reason = _side_validity(probability=probability, price=price)
+    status, reason = side_evaluation_status(
+        valid=valid,
+        invalid_reason=invalid_reason,
+        price=price,
+        min_contract_price=min_contract_price,
+        edge=edge,
+        min_edge=min_edge,
+    )
+    return {
+        "side": side,
+        "selected": selected,
+        "valid": valid,
+        "status": status,
+        "reason": reason,
+        "comparison_reason": None,
+        "probability": _round(probability),
+        "fair_value": _round(probability),
+        "price": _round(price),
+        "fee_per_contract": _round(fee),
+        "raw_gap": _round(raw_gap),
+        "edge": _round(edge),
+        "min_edge": _round(min_edge),
+        "edge_shortfall": _round(edge_shortfall),
+        "edge_margin": _round(edge_margin),
+        "edge_cleared": edge is not None and min_edge is not None and edge >= min_edge,
+        "min_contract_price": _round(min_contract_price),
+    }
+
+
+def side_evaluations_with_selection_context(
+    *,
+    side_evaluations: Sequence[dict[str, Any]],
+    selected_side: str | None,
+) -> list[dict[str, Any]]:
+    selected = next(
+        (
+            evaluation
+            for evaluation in side_evaluations
+            if _text(evaluation.get("side")) == selected_side
+        ),
+        None,
+    )
+    selected_edge = _float(selected.get("edge")) if selected else None
+    annotated: list[dict[str, Any]] = []
+    for evaluation in side_evaluations:
+        reason = side_comparison_reason(
+            evaluation=evaluation,
+            selected_side=selected_side,
+            selected_edge=selected_edge,
+        )
+        annotated.append({**evaluation, "comparison_reason": reason})
+    return annotated
+
+
+def side_comparison_reason(
+    *,
+    evaluation: Mapping[str, Any],
+    selected_side: str | None,
+    selected_edge: float | None,
+) -> str | None:
+    side = _text(evaluation.get("side"))
+    if selected_side is not None and side == selected_side:
+        return "selected"
+    status = _text(evaluation.get("status"))
+    reason = _text(evaluation.get("reason"))
+    if status == "unavailable":
+        return f"not_selected_{reason or 'unavailable'}"
+    if reason == "price_below_min_contract":
+        return "not_selected_price_below_min_contract"
+    edge = _float(evaluation.get("edge"))
+    if edge is not None and selected_edge is not None:
+        if edge < selected_edge:
+            return "not_selected_worse_edge"
+        if edge == selected_edge:
+            return "not_selected_tie_break"
+        return "not_selected_despite_higher_edge"
+    if reason:
+        return f"not_selected_{reason}"
+    return "not_selected"
+
+
+def side_evaluation_summary(
+    *,
+    side_evaluations: Sequence[Mapping[str, Any]],
+    selected_side: str | None,
+) -> dict[str, Any]:
+    valid = [
+        evaluation
+        for evaluation in side_evaluations
+        if evaluation.get("valid") is True and _float(evaluation.get("edge")) is not None
+    ]
+    best = max(
+        valid,
+        key=lambda evaluation: (
+            _float(evaluation.get("edge")) or float("-inf"),
+            _text(evaluation.get("side")) or "",
+        ),
+        default=None,
+    )
+    selected = next(
+        (
+            evaluation
+            for evaluation in side_evaluations
+            if _text(evaluation.get("side")) == selected_side
+        ),
+        None,
+    )
+    return {
+        "selected_side": selected_side,
+        "best_side": _text(best.get("side")) if best else None,
+        "selected_reason": _text(selected.get("reason")) if selected else None,
+        "selected_status": _text(selected.get("status")) if selected else None,
+    }
+
+
+def side_evaluation_status(
+    *,
+    valid: bool,
+    invalid_reason: str | None,
+    price: float | None,
+    min_contract_price: float | None,
+    edge: float | None,
+    min_edge: float | None,
+) -> tuple[str, str | None]:
+    if not valid:
+        return "unavailable", invalid_reason
+    if (
+        price is not None
+        and min_contract_price is not None
+        and price < min_contract_price
+    ):
+        return "blocked", "price_below_min_contract"
+    if edge is not None and min_edge is not None and edge < min_edge:
+        return "below_min_edge", "edge_below_min"
+    if edge is not None and min_edge is not None and edge >= min_edge:
+        return "cleared", "edge_met"
+    return "available", None
 
 
 def classify_live_edge_attribution(
@@ -428,6 +673,94 @@ def _first_float(
         if value is not None:
             return value
     return default
+
+
+def _probability_yes(
+    *,
+    decision: Mapping[str, Any],
+    source_row: Mapping[str, Any],
+) -> float | None:
+    probability_yes = _first_float(
+        source_row,
+        ("p_yes", "probability_yes"),
+        default=_float(decision.get("probability_yes")),
+    )
+    if probability_yes is not None:
+        return probability_yes
+    selected_probability = _first_float(decision, ("fair_value", "probability"))
+    selected_side = _text(decision.get("side"))
+    if selected_probability is None or selected_side not in {"yes", "no"}:
+        return None
+    if selected_side == "yes":
+        return selected_probability
+    return 1.0 - selected_probability
+
+
+def _side_probability(side: str, probability_yes: float | None) -> float | None:
+    if probability_yes is None:
+        return None
+    return probability_yes if side == "yes" else 1.0 - probability_yes
+
+
+def _side_price(
+    *,
+    side: str,
+    decision: Mapping[str, Any],
+    source_row: Mapping[str, Any],
+    selected: bool,
+) -> float | None:
+    side_keys = (
+        ("yes_ask", "yes_ask_dollars", "executable_yes_price")
+        if side == "yes"
+        else ("no_ask", "no_ask_dollars", "executable_no_price")
+    )
+    price = _first_float(source_row, side_keys)
+    if price is not None:
+        return price
+    if selected:
+        return _first_float(decision, ("price", *side_keys))
+    return None
+
+
+def _side_fee(
+    *,
+    side: str,
+    decision: Mapping[str, Any],
+    source_row: Mapping[str, Any],
+    selected: bool,
+) -> float | None:
+    side_keys = ("yes_fee", "yes_fee_per_contract") if side == "yes" else (
+        "no_fee",
+        "no_fee_per_contract",
+    )
+    fee = _first_float(source_row, side_keys)
+    if fee is not None:
+        return fee
+    if selected:
+        return _first_float(decision, ("fee_per_contract", "fee", *side_keys))
+    return None
+
+
+def _side_validity(
+    *,
+    probability: float | None,
+    price: float | None,
+) -> tuple[bool, str | None]:
+    if probability is None:
+        return False, "missing_probability"
+    if price is None:
+        return False, "missing_executable_price"
+    if probability < 0.0 or probability > 1.0:
+        return False, "invalid_probability"
+    if price <= 0.0 or price >= 1.0:
+        return False, "invalid_executable_price"
+    return True, None
+
+
+def _taker_fee(price: float | None, taker_fee_multiplier: float) -> float | None:
+    if price is None or price <= 0.0 or price >= 1.0:
+        return None
+    return round(taker_fee_multiplier * price * (1.0 - price), 6)
 
 
 def _float(value: Any) -> float | None:

--- a/tests/test_dashboard_live_console.py
+++ b/tests/test_dashboard_live_console.py
@@ -266,6 +266,28 @@ def test_strategy_operator_ledger_payload_returns_ordered_sparse_rows() -> None:
         skip_reason="edge_below_min",
         latest_attempt_status="skipped",
         latest_attempt_reason="edge_below_min",
+        summary={
+            "live_edge_attribution": {
+                "side": "yes",
+                "edge": -0.01,
+                "min_edge": 0.0,
+                "side_evaluations": [
+                    {
+                        "side": "yes",
+                        "selected": True,
+                        "edge": -0.01,
+                        "reason": "edge_below_min",
+                    },
+                    {
+                        "side": "no",
+                        "selected": False,
+                        "edge": -0.03,
+                        "reason": "edge_below_min",
+                        "comparison_reason": "not_selected_worse_edge",
+                    },
+                ],
+            }
+        },
     )
     dashboard = service(repository, status=status)
 
@@ -285,6 +307,7 @@ def test_strategy_operator_ledger_payload_returns_ordered_sparse_rows() -> None:
     assert rows[0]["latest_run_id"] == "fv_live_20260604T150000Z"
     assert rows[0]["latest_decision"]["outcome"] == "skipped"
     assert rows[0]["latest_decision"]["reason"] == "edge_below_min"
+    assert rows[0]["latest_live_edge_attribution"]["side_evaluations"][1]["side"] == "no"
     assert rows[0]["risk_summary"]["state"] == "available"
     assert rows[0]["context_summary"]["active_source"] == "coinbase_primary"
     assert rows[0]["active_config"]["strategy"] == FAIR_VALUE_LIVE_STRATEGY
@@ -480,6 +503,32 @@ def test_cockpit_recent_attempts_table_renders_edge_diagnostics() -> None:
     assert "Hide ${definition.label}" in source
     assert "hidden: hiddenPanelIds" in source
     assert "window.localStorage" in source
+
+
+def test_cockpit_attempt_details_renders_bidirectional_edge_diagnostics() -> None:
+    source = Path("apps/dashboard/components/live/live-operations.tsx").read_text()
+
+    assert "interface LiveSideEvaluation" in source
+    assert "side_evaluations" in source
+    assert "SideEvaluationComparison" in source
+    assert "YES / NO edge comparison" in source
+    assert "optionalPercent(evaluation.fair_value ?? evaluation.probability)" in source
+    assert "optionalPercent(evaluation.price)" in source
+    assert "optionalPercent(evaluation.raw_gap)" in source
+    assert "sideEvaluationGapText(evaluation)" in source
+    assert "evaluation.comparison_reason || evaluation.reason" in source
+    assert "legacy_selected_side_attribution" in source
+
+
+def test_cockpit_strategy_ledger_renders_bidirectional_edge_diagnostics() -> None:
+    source = Path("apps/dashboard/components/live/strategy-operator-ledger.tsx").read_text()
+
+    assert "latest_live_edge_attribution" in source
+    assert "EdgeAttributionRail" in source
+    assert "YES / NO edge comparison" in source
+    assert "side_evaluations" in source
+    assert "evaluation.comparison_reason || evaluation.reason" in source
+    assert "legacy_selected_side_attribution" in source
 
 
 def test_cockpit_runtime_config_exposes_daily_limit_reset_action() -> None:

--- a/tests/test_live_edge_attribution.py
+++ b/tests/test_live_edge_attribution.py
@@ -31,6 +31,8 @@ def test_live_edge_attribution_decomposes_edge_below_min() -> None:
     assert attribution["edge"] == 0.03
     assert attribution["edge_shortfall"] == 0.02
     assert attribution["attribution_class"] == "threshold_drag"
+    assert side_evaluation(attribution, "yes")["selected"] is True
+    assert side_evaluation(attribution, "yes")["reason"] == "edge_below_min"
     assert attribution["freshness"]["quote_age_seconds"] == 2.0
     assert attribution["freshness"]["active_context"]["status"] == "fresh"
     assert attribution["fresh_quote_counterfactual"]["status"] == "unavailable"
@@ -166,3 +168,167 @@ def test_live_edge_attribution_bucket_summary_counts_classes() -> None:
         {"attribution_class": "fee_drag", "count": 1},
         {"attribution_class": "unknown", "count": 1},
     ]
+
+
+def test_live_edge_attribution_exposes_yes_and_no_evaluations_for_negative_yes_gap() -> None:
+    attribution = build_live_edge_attribution(
+        decision={
+            "decision": "skip",
+            "reason": "edge_below_min",
+            "ticker": "KXBTC15M-NEGATIVE-YES",
+            "side": "yes",
+            "fair_value": 0.6147,
+            "price": 0.999,
+            "fee_per_contract": 0.00007,
+            "edge": -0.38437,
+        },
+        source_row={
+            "ticker": "KXBTC15M-NEGATIVE-YES",
+            "p_yes": 0.6147,
+            "yes_ask": 0.999,
+            "no_ask": 0.99,
+        },
+        runtime_controls={"min_edge": 0.0, "min_contract_price": 0.25},
+    )
+
+    yes = side_evaluation(attribution, "yes")
+    no = side_evaluation(attribution, "no")
+
+    assert attribution["side_evaluation_summary"] == {
+        "selected_side": "yes",
+        "best_side": "yes",
+        "selected_reason": "edge_below_min",
+        "selected_status": "below_min_edge",
+    }
+    assert yes["selected"] is True
+    assert yes["raw_gap"] == -0.3843
+    assert yes["edge"] == -0.38437
+    assert yes["edge_cleared"] is False
+    assert no["selected"] is False
+    assert no["probability"] == 0.3853
+    assert no["raw_gap"] == -0.6047
+    assert no["reason"] == "edge_below_min"
+    assert no["comparison_reason"] == "not_selected_worse_edge"
+
+
+def test_live_edge_attribution_exposes_no_selected_side_evaluation() -> None:
+    attribution = build_live_edge_attribution(
+        decision={
+            "decision": "trade",
+            "reason": "edge_met",
+            "ticker": "KXBTC15M-NO",
+            "side": "no",
+            "fair_value": 0.7,
+            "price": 0.5,
+            "fee_per_contract": 0.0175,
+            "edge": 0.1825,
+        },
+        source_row={
+            "ticker": "KXBTC15M-NO",
+            "p_yes": 0.3,
+            "yes_ask": 0.8,
+            "no_ask": 0.5,
+        },
+        runtime_controls={"min_edge": 0.05, "min_contract_price": 0.25},
+    )
+
+    yes = side_evaluation(attribution, "yes")
+    no = side_evaluation(attribution, "no")
+
+    assert attribution["side"] == "no"
+    assert attribution["side_evaluation_summary"]["best_side"] == "no"
+    assert yes["selected"] is False
+    assert yes["status"] == "below_min_edge"
+    assert yes["edge"] == -0.5112
+    assert no["selected"] is True
+    assert no["status"] == "cleared"
+    assert no["edge_cleared"] is True
+    assert no["edge"] == 0.1825
+
+
+def test_live_edge_attribution_marks_missing_or_invalid_opposite_side() -> None:
+    missing_no = build_live_edge_attribution(
+        decision={
+            "decision": "skip",
+            "reason": "edge_below_min",
+            "ticker": "KXBTC15M-MISSING-NO",
+            "side": "yes",
+            "fair_value": 0.6,
+            "price": 0.55,
+            "fee": 0.017325,
+            "edge": 0.032675,
+        },
+        source_row={
+            "ticker": "KXBTC15M-MISSING-NO",
+            "p_yes": 0.6,
+            "yes_ask": 0.55,
+        },
+        runtime_controls={"min_edge": 0.05, "min_contract_price": 0.25},
+    )
+    invalid_no = build_live_edge_attribution(
+        decision={
+            "decision": "skip",
+            "reason": "edge_below_min",
+            "ticker": "KXBTC15M-INVALID-NO",
+            "side": "yes",
+            "fair_value": 0.6,
+            "price": 0.55,
+            "fee": 0.017325,
+            "edge": 0.032675,
+        },
+        source_row={
+            "ticker": "KXBTC15M-INVALID-NO",
+            "p_yes": 0.6,
+            "yes_ask": 0.55,
+            "no_ask": 1.0,
+        },
+        runtime_controls={"min_edge": 0.05, "min_contract_price": 0.25},
+    )
+
+    assert side_evaluation(missing_no, "no")["status"] == "unavailable"
+    assert side_evaluation(missing_no, "no")["reason"] == "missing_executable_price"
+    assert (
+        side_evaluation(missing_no, "no")["comparison_reason"]
+        == "not_selected_missing_executable_price"
+    )
+    assert side_evaluation(invalid_no, "no")["status"] == "unavailable"
+    assert side_evaluation(invalid_no, "no")["reason"] == "invalid_executable_price"
+    assert (
+        side_evaluation(invalid_no, "no")["comparison_reason"]
+        == "not_selected_invalid_executable_price"
+    )
+
+
+def test_live_edge_attribution_marks_both_sides_below_minimum() -> None:
+    attribution = build_live_edge_attribution(
+        decision={
+            "decision": "skip",
+            "reason": "edge_below_min",
+            "ticker": "KXBTC15M-BOTH-BELOW",
+            "side": "yes",
+            "fair_value": 0.51,
+            "price": 0.5,
+            "fee": 0.0175,
+            "edge": -0.0075,
+        },
+        source_row={
+            "ticker": "KXBTC15M-BOTH-BELOW",
+            "p_yes": 0.51,
+            "yes_ask": 0.5,
+            "no_ask": 0.5,
+        },
+        runtime_controls={"min_edge": 0.05, "min_contract_price": 0.25},
+    )
+
+    assert side_evaluation(attribution, "yes")["status"] == "below_min_edge"
+    assert side_evaluation(attribution, "no")["status"] == "below_min_edge"
+    assert side_evaluation(attribution, "yes")["edge_cleared"] is False
+    assert side_evaluation(attribution, "no")["edge_cleared"] is False
+
+
+def side_evaluation(attribution: dict[str, object], side: str) -> dict[str, object]:
+    return next(
+        item
+        for item in attribution["side_evaluations"]  # type: ignore[index]
+        if item["side"] == side
+    )


### PR DESCRIPTION
## Summary
- Emit live YES and NO side evaluations with selected-side context, validity, fee, gap, edge, shortfall, and comparison reason metadata.
- Surface the latest attribution in the strategy operator ledger payload and render YES/NO comparison panels in Cockpit diagnostics.
- Add focused backend and dashboard coverage for selected YES, selected NO, missing/invalid prices, and both-sides-below-minimum cases.

## Linear
- ADB-324
- ADB-325

## Validation
- `/Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest -q` -> 380 passed, 22 warnings
- `pnpm exec tsc --noEmit` from `apps/dashboard` -> passed
- `pnpm lint` from `apps/dashboard` -> passed with two existing exhaustive-deps warnings
- `PYTHONPATH=src /Users/sid/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m alphadb.repo_hygiene` -> passed for tracked public state; local ignored/untracked warnings remain
- `git diff --check` -> passed
- `pre-commit run --all-files` -> not available because `.pre-commit-config.yaml` is absent
- Browser smoke of the Next Cockpit shell at `http://localhost:3000` -> rendered; local AlphaDB API was not running, so live API calls returned 500 as expected in this isolated smoke