### PR TITLE
[codex] Restore Cockpit runtime config workspace

### DIFF
--- a/apps/dashboard/app/live/config/page.tsx
+++ b/apps/dashboard/app/live/config/page.tsx
@@ -1,0 +1,10 @@
+import { AppShell } from "@/components/app-shell"
+import { LiveOperations } from "@/components/live/live-operations"
+
+export default function LiveConfigPage() {
+  return (
+    <AppShell>
+      <LiveOperations />
+    </AppShell>
+  )
+}

--- a/apps/dashboard/components/live/strategy-operator-ledger.tsx
+++ b/apps/dashboard/components/live/strategy-operator-ledger.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   AlertTriangle,
@@ -8,12 +9,14 @@ import {
   Eye,
   PauseCircle,
   RefreshCw,
+  SlidersHorizontal,
   ShieldCheck,
   WifiOff,
 } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
+import { useSelectedStrategy } from "@/components/strategy/strategy-context"
 import { NestedSurface, PanelBody, PanelHeader, PanelSurface } from "@/components/ui/surface"
 import { apiGet } from "@/lib/alphadb-api"
 import { cn } from "@/lib/utils"
@@ -343,6 +346,8 @@ export function StrategyOperatorLedger() {
 }
 
 function StrategyDetailRail({ row }: { row: StrategyLedgerRow | null }) {
+  const { setSelectedStrategy, strategies } = useSelectedStrategy()
+
   if (!row) {
     return (
       <PanelSurface className="h-auto min-h-[520px]">
@@ -357,6 +362,8 @@ function StrategyDetailRail({ row }: { row: StrategyLedgerRow | null }) {
     )
   }
 
+  const liveStrategy = strategies.find((strategy) => strategy.id === row.strategy_id)
+
   return (
     <PanelSurface className="h-auto min-h-[520px]">
       <PanelHeader>
@@ -369,6 +376,17 @@ function StrategyDetailRail({ row }: { row: StrategyLedgerRow | null }) {
         </div>
       </PanelHeader>
       <PanelBody className="space-y-3">
+        {liveStrategy && (
+          <Link
+            className={buttonVariants({ variant: "outline", size: "sm", className: "w-full" })}
+            href="/live/config"
+            onClick={() => setSelectedStrategy(liveStrategy.id)}
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            Runtime config
+          </Link>
+        )}
+
         <div className="grid grid-cols-2 gap-2">
           <MiniValue label="Live state" value={stateLabel(row.live_state)} />
           <MiniValue label="Data" value={dataStateLabel(row.data_state)} />

--- a/apps/dashboard/components/nav/side-nav.tsx
+++ b/apps/dashboard/components/nav/side-nav.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
-import { Activity, Database, FlaskConical, Layers, TrendingUp, Zap } from "lucide-react"
+import { Activity, Database, FlaskConical, Layers, SlidersHorizontal, TrendingUp, Zap } from "lucide-react"
 
 const navItems = [
   { href: "/", label: "Live", icon: Activity },
+  { href: "/live/config", label: "Config", icon: SlidersHorizontal },
   { href: "/performance", label: "Performance", icon: TrendingUp },
   { href: "/strategies", label: "Strategies", icon: Layers },
   { href: "/data", label: "Data", icon: Database },


### PR DESCRIPTION
## Summary

Restores a reachable Cockpit workspace for strategy runtime config after the Live home moved to the Strategy Operator Ledger.

## What changed

- Adds `/live/config` as a Next.js route that mounts the existing `LiveOperations` workspace.
- Adds a `Config` side-nav item for direct access.
- Adds a `Runtime config` action in the strategy detail rail that preserves the selected live strategy before navigating.

## Root cause

The runtime config editor still existed in `LiveOperations`, and the AlphaDB API still exposed `/api/live/config`, but the current Cockpit home route only mounted the read-only strategy ledger. That left the editor unreachable in the deployed UI.

## Validation

- `pnpm lint` (passes with two pre-existing hook dependency warnings)
- `pnpm build`
- `.venv/bin/python -m pytest tests/test_dashboard_live_console.py tests/test_live_runtime.py`
- `.venv/bin/alphadb-repo-hygiene`

`pre-commit run --all-files` is not runnable because the repository does not currently have `.pre-commit-config.yaml`.
